### PR TITLE
remove include dir for eigen and replace it with target link libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,11 +18,6 @@ endif()
 
 option(ALGEBRA_PLUGIN_BUILD_VC "Download and build local Vc" Off)
 
-if (NOT EIGEN3_INCLUDE_DIRS)
-    find_package(Eigen3 REQUIRED)
-    include_directories(SYSTEM ${EIGEN3_INCLUDE_DIRS})
-endif()
-
 if(ALGEBRA_PLUGIN_BUILD_VC)
      add_subdirectory(extern/Vc)
 endif()

--- a/core/include/eigen/CMakeLists.txt
+++ b/core/include/eigen/CMakeLists.txt
@@ -18,4 +18,7 @@ if(ALGEBRA_PLUGIN_CUSTOM_SCALARTYPE)
     INTERFACE -DALGEBRA_PLUGIN_CUSTOM_SCALARTYPE=${ALGEBRA_PLUGIN_CUSTOM_SCALARTYPE})
 endif()
 
+find_package(Eigen3 REQUIRED)
+target_link_libraries(algebra_eigen INTERFACE Eigen3::Eigen)
+
 add_library(algebra::eigen ALIAS algebra_eigen)


### PR DESCRIPTION
I removed the include directory since it didn't work for me (Eigen3_include_dir keeps referring ridiculous directory which doesn't have eigen 3.3.7 source). I don't know if it happens to other people.
Anyway I replace it with target_llink_libraries, which should be better.

@asalzburger @paulgessinger 