### PR TITLE
add rotate function to eigen

### DIFF
--- a/core/include/eigen/include/algebra/definitions/eigen.hpp
+++ b/core/include/eigen/include/algebra/definitions/eigen.hpp
@@ -199,6 +199,18 @@ namespace algebra
                 return (_data.isApprox(rhs._data));
             }
 
+            /** Rotate a vector into / from a frame 
+             * 
+             * @param m is the rotation matrix
+             * @param v is the vector to be rotated
+             */
+	    
+            static vector3 rotate(const Eigen::Transform<scalar, 3, Eigen::Affine> &m, const vector3 &v)
+            {
+
+                return m.matrix().block<3,3>(0,0)*v;
+            }
+	    
             /** This method retrieves the rotation of a transform  **/
             auto rotation() const
             {

--- a/core/include/eigen/include/algebra/definitions/eigen.hpp
+++ b/core/include/eigen/include/algebra/definitions/eigen.hpp
@@ -204,10 +204,12 @@ namespace algebra
              * @param m is the rotation matrix
              * @param v is the vector to be rotated
              */
-	    
-            static vector3 rotate(const Eigen::Transform<scalar, 3, Eigen::Affine> &m, const vector3 &v)
+            template <typename derived_type>	    
+            static auto rotate(const Eigen::Transform<scalar, 3, Eigen::Affine> &m, const Eigen::MatrixBase<derived_type> &v)
             {
-
+                constexpr int rows = Eigen::MatrixBase<derived_type>::RowsAtCompileTime;
+                constexpr int cols = Eigen::MatrixBase<derived_type>::ColsAtCompileTime;
+                static_assert(rows == 3 and cols == 1, "transform::rotate(m,v) requires a (3,1) matrix");
                 return m.matrix().block<3,3>(0,0)*v;
             }
 	    


### PR DESCRIPTION
Rotate function of eigen plugin is missing so I added it 
The input type (`Eigen::Transform<scalar, 3, Eigen::Affine>`) of eigen rotate function follows the type of `_data`
as the input type (`matrix44`) of array rotate function does. So we still keep the same usage for those plugins

@niermann999 @asalzburger would you review quickly as it is tiny PR?