### PR TITLE
use std::array for array_s 

### DIFF
--- a/core/common/include/algebra/common/types.hpp
+++ b/core/common/include/algebra/common/types.hpp
@@ -24,19 +24,16 @@
 
 namespace algebra
 {
+    template <typename value_type, unsigned int kDIM>
+    using array_s = std::array<value_type, kDIM>;
+    
     // General algebra container types to be used with plugin
     #ifdef ALGEBRA_PLUGIN_USE_VECMEM
-
-    template <typename value_type, unsigned int kDIM>
-    using array_s = vecmem::static_array<value_type, kDIM>;
 
     template <typename value_type>
     using vector_s = vecmem::vector<value_type>;
 
     #else
-
-    template <typename value_type, unsigned int kDIM>
-    using array_s = std::array<value_type, kDIM>;
 
     template <typename value_type>
     using vector_s = std::vector<value_type>;

--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -24,7 +24,7 @@ if(ALGEBRA_PLUGIN_BUILD_VECMEM)
      FetchContent_Declare( 
           Vecmem
           GIT_REPOSITORY "https://github.com/acts-project/vecmem.git"
-          GIT_TAG "v0.3.0"
+          GIT_TAG "v0.2.0"
      )
 
      # Do not build google test in vecmem again

--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -24,7 +24,7 @@ if(ALGEBRA_PLUGIN_BUILD_VECMEM)
      FetchContent_Declare( 
           Vecmem
           GIT_REPOSITORY "https://github.com/acts-project/vecmem.git"
-          GIT_TAG "v0.2.0"
+          GIT_TAG "v0.3.0"
      )
 
      # Do not build google test in vecmem again


### PR DESCRIPTION
Currently `array_s` is an alias of `vecmem::static_array` when vecmem algebra is turned on. Unfortunately this doesn't work with detray because it cannot be called with `constexpr`: see [here](https://github.com/acts-project/detray/blob/8391a722efb2bc0e387f91ada2c4fff0b1f56a53/core/include/masks/cylinder3.hpp#L62) for example.

So let's roll it back to `std::array`