### PR TITLE
Update to Eigen 3.4.0

### DIFF
--- a/extern/eigen3/CMakeLists.txt
+++ b/extern/eigen3/CMakeLists.txt
@@ -13,8 +13,8 @@ message( STATUS "Building Eigen3 as part of the Algebra Plugins project" )
 
 # Declare where to get Eigen3 from.
 FetchContent_Declare( Eigen3
-   URL "https://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-3.4.0.tar.bz2"
-   URL_MD5 "2d5a8dac126c4937fd94d5d10fcd7dd1" )
+  URL "https://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-3.4.0.tar.bz2"
+  URL_MD5 "80a43aa9b64030639d1b1bd0c01fae801ab722f537ed" )
 
 # Turn off the unit tests for Eigen3.
 if( DEFINED CACHE{BUILD_TESTING} )

--- a/extern/eigen3/CMakeLists.txt
+++ b/extern/eigen3/CMakeLists.txt
@@ -14,7 +14,7 @@ message( STATUS "Building Eigen3 as part of the Algebra Plugins project" )
 # Declare where to get Eigen3 from.
 FetchContent_Declare( Eigen3
   URL "https://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-3.4.0.tar.bz2"
-  URL_MD5 "80a43aa9b64030639d1b1bd0c01fae801ab722f537ed" )
+  URL_MD5 "132dde48fe2b563211675626d29f1707" )
 
 # Turn off the unit tests for Eigen3.
 if( DEFINED CACHE{BUILD_TESTING} )

--- a/extern/eigen3/CMakeLists.txt
+++ b/extern/eigen3/CMakeLists.txt
@@ -13,7 +13,7 @@ message( STATUS "Building Eigen3 as part of the Algebra Plugins project" )
 
 # Declare where to get Eigen3 from.
 FetchContent_Declare( Eigen3
-   URL "https://gitlab.com/libeigen/eigen/-/archive/3.3.9/eigen-3.3.9.tar.bz2"
+   URL "https://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-3.4.0.tar.bz2"
    URL_MD5 "2d5a8dac126c4937fd94d5d10fcd7dd1" )
 
 # Turn off the unit tests for Eigen3.


### PR DESCRIPTION
cuda eigen unit test file of acts-project/detray#133 does NOT work with eigen 3.3.9. (Compilation was OK but zero output from `point_to_global`)
eigen 3.4.0 solves the issue.

