### PR TITLE
Remove "auto" from algebra::cmath_math, main branch (2021.11.02.)

### DIFF
--- a/frontend/array_cmath/include/algebra/array_cmath.hpp
+++ b/frontend/array_cmath/include/algebra/array_cmath.hpp
@@ -28,7 +28,7 @@ namespace array {
 /// @name cmath based transforms on @c algebra::array::storage_type
 /// @{
 
-using transform3 = cmath::transform3<array::storage_type, scalar>;
+using transform3 = cmath::transform3<std::size_t, array::storage_type, scalar>;
 using cartesian2 = cmath::cartesian2<transform3>;
 using polar2 = cmath::polar2<transform3>;
 using cylindrical2 = cmath::cylindrical2<transform3>;

--- a/frontend/eigen_cmath/include/algebra/eigen_cmath.hpp
+++ b/frontend/eigen_cmath/include/algebra/eigen_cmath.hpp
@@ -59,7 +59,7 @@ struct block_getter {
 /// @{
 
 using transform3 =
-    cmath::transform3<eigen::storage_type, scalar,
+    cmath::transform3<std::size_t, eigen::storage_type, scalar,
                       Eigen::Transform<scalar, 3, Eigen::Affine>::MatrixType,
                       algebra::eigen::element_getter,
                       algebra::eigen::block_getter>;

--- a/frontend/smatrix_cmath/include/algebra/smatrix_cmath.hpp
+++ b/frontend/smatrix_cmath/include/algebra/smatrix_cmath.hpp
@@ -59,8 +59,8 @@ struct block_getter {
 /// @name cmath based transforms on @c algebra::smatrix::storage_type
 /// @{
 
-using transform3 = cmath::transform3<smatrix::storage_type, scalar,
-                                     ROOT::Math::SMatrix<scalar, 4, 4>,
+using transform3 = cmath::transform3<unsigned int, smatrix::storage_type,
+                                     scalar, ROOT::Math::SMatrix<scalar, 4, 4>,
                                      element_getter, block_getter>;
 using cartesian2 = cmath::cartesian2<transform3>;
 using polar2 = cmath::polar2<transform3>;

--- a/frontend/vc_cmath/include/algebra/vc_cmath.hpp
+++ b/frontend/vc_cmath/include/algebra/vc_cmath.hpp
@@ -78,7 +78,7 @@ using math::perp;
 using math::phi;
 
 using transform3 =
-    cmath::transform3<vc::storage_type, scalar,
+    cmath::transform3<std::size_t, vc::storage_type, scalar,
                       Vc::array<Vc::array<scalar, 4>, 4>, element_getter,
                       block_getter, vc::vector3, vc::point2>;
 using cartesian2 = cmath::cartesian2<transform3>;

--- a/frontend/vecmem_cmath/include/algebra/vecmem_cmath.hpp
+++ b/frontend/vecmem_cmath/include/algebra/vecmem_cmath.hpp
@@ -28,7 +28,7 @@ namespace vecmem {
 /// @name cmath based transforms on @c algebra::vecmem::storage_type
 /// @{
 
-using transform3 = cmath::transform3<vecmem::storage_type, scalar>;
+using transform3 = cmath::transform3<std::size_t, vecmem::storage_type, scalar>;
 using cartesian2 = cmath::cartesian2<transform3>;
 using polar2 = cmath::polar2<transform3>;
 using cylindrical2 = cmath::cylindrical2<transform3>;

--- a/math/cmath/include/algebra/math/impl/cmath_getter.hpp
+++ b/math/cmath/include/algebra/math/impl/cmath_getter.hpp
@@ -21,8 +21,8 @@ namespace algebra::cmath {
  *
  * @param v the input vector
  **/
-template <template <typename, auto> class array_t, typename scalar_t, auto N,
-          std::enable_if_t<N >= 2, bool> = true>
+template <typename size_type, template <typename, size_type> class array_t,
+          typename scalar_t, size_type N, std::enable_if_t<N >= 2, bool> = true>
 ALGEBRA_HOST_DEVICE inline scalar_t phi(
     const array_t<scalar_t, N> &v) noexcept {
 
@@ -33,8 +33,8 @@ ALGEBRA_HOST_DEVICE inline scalar_t phi(
  *
  * @param v the input vector
  **/
-template <template <typename, auto> class array_t, typename scalar_t, auto N,
-          std::enable_if_t<N >= 3, bool> = true>
+template <typename size_type, template <typename, size_type> class array_t,
+          typename scalar_t, size_type N, std::enable_if_t<N >= 3, bool> = true>
 ALGEBRA_HOST_DEVICE inline scalar_t theta(
     const array_t<scalar_t, N> &v) noexcept {
 
@@ -45,8 +45,8 @@ ALGEBRA_HOST_DEVICE inline scalar_t theta(
  *
  * @param v the input vector
  **/
-template <template <typename, auto> class array_t, typename scalar_t, auto N,
-          std::enable_if_t<N >= 2, bool> = true>
+template <typename size_type, template <typename, size_type> class array_t,
+          typename scalar_t, size_type N, std::enable_if_t<N >= 2, bool> = true>
 ALGEBRA_HOST_DEVICE inline scalar_t perp(
     const array_t<scalar_t, N> &v) noexcept {
 
@@ -57,18 +57,19 @@ ALGEBRA_HOST_DEVICE inline scalar_t perp(
  *
  * @param v the input vector
  **/
-template <template <typename, auto> class array_t, typename scalar_t>
-ALGEBRA_HOST_DEVICE inline scalar_t norm(const array_t<scalar_t, 2> &v) {
+template <typename size_type, template <typename, size_type> class array_t,
+          typename scalar_t, size_type N, std::enable_if_t<N == 2, bool> = true>
+ALGEBRA_HOST_DEVICE inline scalar_t norm(const array_t<scalar_t, N> &v) {
 
-  return perp<array_t>(v);
+  return perp(v);
 }
 
 /** This method retrieves the norm of a vector, no dimension restriction
  *
  * @param v the input vector
  **/
-template <template <typename, auto> class array_t, typename scalar_t, auto N,
-          std::enable_if_t<N >= 3, bool> = true>
+template <typename size_type, template <typename, size_type> class array_t,
+          typename scalar_t, size_type N, std::enable_if_t<N >= 3, bool> = true>
 ALGEBRA_HOST_DEVICE inline scalar_t norm(const array_t<scalar_t, N> &v) {
 
   return std::sqrt(v[0] * v[0] + v[1] * v[1] + v[2] * v[2]);
@@ -79,12 +80,12 @@ ALGEBRA_HOST_DEVICE inline scalar_t norm(const array_t<scalar_t, N> &v) {
  *
  * @param v the input vector
  **/
-template <template <typename, auto> class array_t, typename scalar_t, auto N,
-          std::enable_if_t<N >= 3, bool> = true>
+template <typename size_type, template <typename, size_type> class array_t,
+          typename scalar_t, size_type N, std::enable_if_t<N >= 3, bool> = true>
 ALGEBRA_HOST_DEVICE inline scalar_t eta(
     const array_t<scalar_t, N> &v) noexcept {
 
-  return std::atanh(v[2] / norm<array_t>(v));
+  return std::atanh(v[2] / norm(v));
 }
 
 /// "Element getter", assuming a simple 2D array access

--- a/math/cmath/include/algebra/math/impl/cmath_operator.hpp
+++ b/math/cmath/include/algebra/math/impl/cmath_operator.hpp
@@ -10,47 +10,50 @@
 // Project include(s).
 #include "algebra/common/algebra_qualifiers.hpp"
 
+// System include(s).
+#include <cstddef>
+
 namespace algebra::cmath {
 
 /// @name Operators on 2-element arrays
 /// @{
 
-template <template <typename, auto> class array_t, typename scalar_t>
+template <template <typename, std::size_t> class array_t, typename scalar_t>
 ALGEBRA_HOST_DEVICE inline array_t<scalar_t, 2> operator*(
     const array_t<scalar_t, 2> &a, float s) {
 
   return {a[0] * static_cast<scalar_t>(s), a[1] * static_cast<scalar_t>(s)};
 }
 
-template <template <typename, auto> class array_t, typename scalar_t>
+template <template <typename, std::size_t> class array_t, typename scalar_t>
 ALGEBRA_HOST_DEVICE inline array_t<scalar_t, 2> operator*(
     const array_t<scalar_t, 2> &a, double s) {
 
   return {a[0] * static_cast<scalar_t>(s), a[1] * static_cast<scalar_t>(s)};
 }
 
-template <template <typename, auto> class array_t, typename scalar_t>
+template <template <typename, std::size_t> class array_t, typename scalar_t>
 ALGEBRA_HOST_DEVICE inline array_t<scalar_t, 2> operator*(
     float s, const array_t<scalar_t, 2> &a) {
 
   return {static_cast<scalar_t>(s) * a[0], static_cast<scalar_t>(s) * a[1]};
 }
 
-template <template <typename, auto> class array_t, typename scalar_t>
+template <template <typename, std::size_t> class array_t, typename scalar_t>
 ALGEBRA_HOST_DEVICE inline array_t<scalar_t, 2> operator*(
     double s, const array_t<scalar_t, 2> &a) {
 
   return {static_cast<scalar_t>(s) * a[0], static_cast<scalar_t>(s) * a[1]};
 }
 
-template <template <typename, auto> class array_t, typename scalar_t>
+template <template <typename, std::size_t> class array_t, typename scalar_t>
 ALGEBRA_HOST_DEVICE inline array_t<scalar_t, 2> operator-(
     const array_t<scalar_t, 2> &a, const array_t<scalar_t, 2> &b) {
 
   return {a[0] - b[0], a[1] - b[1]};
 }
 
-template <template <typename, auto> class array_t, typename scalar_t>
+template <template <typename, std::size_t> class array_t, typename scalar_t>
 ALGEBRA_HOST_DEVICE inline array_t<scalar_t, 2> operator+(
     const array_t<scalar_t, 2> &a, const array_t<scalar_t, 2> &b) {
 
@@ -62,7 +65,7 @@ ALGEBRA_HOST_DEVICE inline array_t<scalar_t, 2> operator+(
 /// @name Operators on 3-element arrays
 /// @{
 
-template <template <typename, auto> class array_t, typename scalar_t>
+template <template <typename, std::size_t> class array_t, typename scalar_t>
 ALGEBRA_HOST_DEVICE inline array_t<scalar_t, 3> operator*(
     const array_t<scalar_t, 3> &a, float s) {
 
@@ -70,7 +73,7 @@ ALGEBRA_HOST_DEVICE inline array_t<scalar_t, 3> operator*(
           a[2] * static_cast<scalar_t>(s)};
 }
 
-template <template <typename, auto> class array_t, typename scalar_t>
+template <template <typename, std::size_t> class array_t, typename scalar_t>
 ALGEBRA_HOST_DEVICE inline array_t<scalar_t, 3> operator*(
     const array_t<scalar_t, 3> &a, double s) {
 
@@ -78,7 +81,7 @@ ALGEBRA_HOST_DEVICE inline array_t<scalar_t, 3> operator*(
           a[2] * static_cast<scalar_t>(s)};
 }
 
-template <template <typename, auto> class array_t, typename scalar_t>
+template <template <typename, std::size_t> class array_t, typename scalar_t>
 ALGEBRA_HOST_DEVICE inline array_t<scalar_t, 3> operator*(
     float s, const array_t<scalar_t, 3> &a) {
 
@@ -86,7 +89,7 @@ ALGEBRA_HOST_DEVICE inline array_t<scalar_t, 3> operator*(
           static_cast<scalar_t>(s) * a[2]};
 }
 
-template <template <typename, auto> class array_t, typename scalar_t>
+template <template <typename, std::size_t> class array_t, typename scalar_t>
 ALGEBRA_HOST_DEVICE inline array_t<scalar_t, 3> operator*(
     double s, const array_t<scalar_t, 3> &a) {
 
@@ -94,14 +97,14 @@ ALGEBRA_HOST_DEVICE inline array_t<scalar_t, 3> operator*(
           static_cast<scalar_t>(s) * a[2]};
 }
 
-template <template <typename, auto> class array_t, typename scalar_t>
+template <template <typename, std::size_t> class array_t, typename scalar_t>
 ALGEBRA_HOST_DEVICE inline array_t<scalar_t, 3> operator-(
     const array_t<scalar_t, 3> &a, const array_t<scalar_t, 3> &b) {
 
   return {a[0] - b[0], a[1] - b[1], a[2] - b[2]};
 }
 
-template <template <typename, auto> class array_t, typename scalar_t>
+template <template <typename, std::size_t> class array_t, typename scalar_t>
 ALGEBRA_HOST_DEVICE inline array_t<scalar_t, 3> operator+(
     const array_t<scalar_t, 3> &a, const array_t<scalar_t, 3> &b) {
 

--- a/math/cmath/include/algebra/math/impl/cmath_transform3.hpp
+++ b/math/cmath/include/algebra/math/impl/cmath_transform3.hpp
@@ -16,7 +16,8 @@ namespace algebra::cmath {
 
 /** Transform wrapper class to ensure standard API within differnt plugins
  **/
-template <template <typename, auto> class array_t, typename scalar_t,
+template <typename size_type, template <typename, size_type> class array_t,
+          typename scalar_t,
           typename matrix44_t = array_t<array_t<scalar_t, 4>, 4>,
           class element_getter_t = element_getter<array_t, scalar_t>,
           class block_getter_t = block_getter<array_t, scalar_t>,
@@ -28,7 +29,7 @@ struct transform3 {
   /// @{
 
   /// Array type used by the transform
-  template <typename T, auto N>
+  template <typename T, size_type N>
   using array_type = array_t<T, N>;
   /// Scalar type used by the transform
   using scalar_type = scalar_t;

--- a/math/cmath/include/algebra/math/impl/cmath_vector.hpp
+++ b/math/cmath/include/algebra/math/impl/cmath_vector.hpp
@@ -25,8 +25,8 @@ namespace algebra::cmath {
  *
  * @return a vector (expression) representing the cross product
  **/
-template <template <typename, auto> class array_t, typename scalar_t, auto N,
-          std::enable_if_t<N >= 3, bool> = true>
+template <typename size_type, template <typename, size_type> class array_t,
+          typename scalar_t, size_type N, std::enable_if_t<N >= 3, bool> = true>
 ALGEBRA_HOST_DEVICE inline array_t<scalar_t, N> cross(
     const array_t<scalar_t, N> &a, const array_t<scalar_t, N> &b) {
 
@@ -41,9 +41,10 @@ ALGEBRA_HOST_DEVICE inline array_t<scalar_t, N> cross(
  *
  * @return the scalar dot product value
  **/
-template <template <typename, auto> class array_t, typename scalar_t>
-ALGEBRA_HOST_DEVICE inline scalar_t dot(const array_t<scalar_t, 2> &a,
-                                        const array_t<scalar_t, 2> &b) {
+template <typename size_type, template <typename, size_type> class array_t,
+          typename scalar_t, size_type N, std::enable_if_t<N == 2, bool> = true>
+ALGEBRA_HOST_DEVICE inline scalar_t dot(const array_t<scalar_t, N> &a,
+                                        const array_t<scalar_t, N> &b) {
 
   return a[0] * b[0] + a[1] * b[1];
 }
@@ -52,9 +53,10 @@ ALGEBRA_HOST_DEVICE inline scalar_t dot(const array_t<scalar_t, 2> &a,
  *
  * @param v the input vector
  **/
-template <template <typename, auto> class array_t, typename scalar_t>
-ALGEBRA_HOST_DEVICE inline array_t<scalar_t, 2> normalize(
-    const array_t<scalar_t, 2> &v) {
+template <typename size_type, template <typename, size_type> class array_t,
+          typename scalar_t, size_type N, std::enable_if_t<N == 2, bool> = true>
+ALGEBRA_HOST_DEVICE inline array_t<scalar_t, N> normalize(
+    const array_t<scalar_t, N> &v) {
 
   scalar_t oon = 1. / std::sqrt(dot(v, v));
   return {v[0] * oon, v[1] * oon};
@@ -67,8 +69,9 @@ ALGEBRA_HOST_DEVICE inline array_t<scalar_t, 2> normalize(
  *
  * @return the scalar dot product value
  **/
-template <template <typename, auto> class array_t, typename scalar_t, auto N1,
-          auto N2, std::enable_if_t<N1 >= 3, bool> = true,
+template <typename size_type, template <typename, size_type> class array_t,
+          typename scalar_t, size_type N1, size_type N2,
+          std::enable_if_t<N1 >= 3, bool> = true,
           std::enable_if_t<N2 >= 3, bool> = true>
 ALGEBRA_HOST_DEVICE inline scalar_t dot(const array_t<scalar_t, N1> &a,
                                         const array_t<scalar_t, N2> &b) {
@@ -80,8 +83,8 @@ ALGEBRA_HOST_DEVICE inline scalar_t dot(const array_t<scalar_t, N1> &a,
  *
  * @param v the input vector
  **/
-template <template <typename, auto> class array_t, typename scalar_t, auto N,
-          std::enable_if_t<N >= 3, bool> = true>
+template <typename size_type, template <typename, size_type> class array_t,
+          typename scalar_t, size_type N, std::enable_if_t<N >= 3, bool> = true>
 ALGEBRA_HOST_DEVICE inline array_t<scalar_t, 3> normalize(
     const array_t<scalar_t, N> &v) {
 


### PR DESCRIPTION
Removed the `auto` size type specifications from the `algebra::cmath_math` code. As it was discovered by @beomki-yeo in https://github.com/acts-project/detray/pull/134, CUDA does not understand the formalism that the code used so far. :frowning:

All of the "free-standing" functions were updated to receive yet another template parameter, with the "size type". For this to work I had to make all of those functions make explicit use of the size type parameter. For instance turning:

```c++
template <template <typename, auto> class array_t, typename scalar_t>
ALGEBRA_HOST_DEVICE inline scalar_t dot(const array_t<scalar_t, 2> &a,
                                        const array_t<scalar_t, 2> &b) {
  return a[0] * b[0] + a[1] * b[1];
}
```

into:

```c++
template <typename size_type, template <typename, size_type> class array_t,
          typename scalar_t, size_type N, std::enable_if_t<N == 2, bool> = true>
ALGEBRA_HOST_DEVICE inline scalar_t dot(const array_t<scalar_t, N> &a,
                                        const array_t<scalar_t, N> &b) {
  return a[0] * b[0] + a[1] * b[1];
}
```

Otherwise the compiler would not be able to deduce the type of `size_type` automatically. Yeah, it's a bit weird, but it works. :stuck_out_tongue:

With these changes included I was able to build https://github.com/acts-project/detray/pull/134. While also keeping the SMatrix code functional. :wink: So if you're happy with it @beomki-yeo, this should replace #33...