### PR TITLE
External Updates, main branch (2021.11.08.)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,15 +52,17 @@ endif()
 
 # Set up VecMem.
 option( ALGEBRA_PLUGINS_SETUP_VECMEM
-   "Set up the VecMem target(s) explicitly" FALSE )
+   "Set up the VecMem target(s) explicitly" TRUE )
 option( ALGEBRA_PLUGINS_USE_SYSTEM_VECMEM
    "Pick up an existing installation of VecMem from the build environment"
-   TRUE )
+   FALSE )
 if( ALGEBRA_PLUGINS_SETUP_VECMEM )
    if( ALGEBRA_PLUGINS_USE_SYSTEM_VECMEM )
-      find_package( vecmem REQUIRED )
+      find_package( vecmem 0.7.0 REQUIRED COMPONENTS LANGUAGE )
    else()
       add_subdirectory( extern/vecmem )
+      # Make the "VecMem language code" available for the whole project.
+      include( "${VECMEM_LANGUAGE_DIR}/vecmem-check-language.cmake" )
    endif()
 endif()
 

--- a/extern/vc/CMakeLists.txt
+++ b/extern/vc/CMakeLists.txt
@@ -13,7 +13,7 @@ message( STATUS "Building Vc as part of the Algebra Plugins project" )
 
 # Declare where to get Vc from.
 set( ALGEBRA_PLUGINS_VC_SOURCE
-   "GIT_REPOSITORY;https://github.com/VcDevel/Vc.git;GIT_TAG;b84dcd0"
+   "URL;https://github.com/VcDevel/Vc/archive/b84dcd0a65d8dc5de6a2bd4d367882b3748f812c.tar.gz;URL_MD5;ae1e8317352df53113ee28ba3f0d490a"
    CACHE STRING "Source for Vc, when built as part of this project" )
 mark_as_advanced( ALGEBRA_PLUGINS_VC_SOURCE )
 FetchContent_Declare( Vc ${ALGEBRA_PLUGINS_VC_SOURCE} )

--- a/extern/vecmem/CMakeLists.txt
+++ b/extern/vecmem/CMakeLists.txt
@@ -13,7 +13,7 @@ message( STATUS "Building VecMem as part of the Algebra Plugins project" )
 
 # Declare where to get VecMem from.
 set( ALGEBRA_PLUGINS_VECMEM_SOURCE
-   "URL;https://github.com/acts-project/vecmem/archive/refs/tags/v0.6.0.tar.gz;URL_MD5;d741067ff148d2df3c4e6d4587d65fdc"
+   "URL;https://github.com/acts-project/vecmem/archive/refs/tags/v0.7.0.tar.gz;URL_MD5;24e9bbb0b6b82406e01770d39b6a6ec0"
    CACHE STRING "Source for VecMem, when built as part of this project" )
 mark_as_advanced( ALGEBRA_PLUGINS_VECMEM_SOURCE )
 FetchContent_Declare( VecMem ${ALGEBRA_PLUGINS_VECMEM_SOURCE} )


### PR DESCRIPTION
Updated the VecMem and Vc builds.
  - [Vc](https://github.com/VcDevel/Vc) is now downloaded as a TGZ file, instead of downloading the entire Git repository.
    * This was bothering me quite a bit in recent weeks. That it currently takes a long time to download Vc for the build.
  - [VecMem](https://github.com/acts-project/vecmem) is updated to version [v0.7.0](https://github.com/acts-project/vecmem/releases/tag/v0.7.0), and the "language code" from it is activated for this project.
    * In case we ever want to add any CUDA/HIP/SYCL tests to this project.
    * This is done in the same way as in https://github.com/acts-project/traccc/pull/106.

I also enabled the setup of VecMem by default for the project. Every other "traccc project" depends on VecMem by now. We may want to make that mandatory here as well. Though maybe not... I could possibly be convinced of the contrary... :thinking: