### PR TITLE
CI Update, main branch (2021.11.18.)

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -13,79 +13,113 @@ on:
       - main
       - 'release/**'
 
+# All the different build/test jobs.
 jobs:
-  ubuntu:
+
+  # Native build jobs.
+  native:
+
+    # The different build modes to test.
+    strategy:
+      matrix:
+        BUILD:
+          - TYPE: "Release"
+            SCALAR: "double"
+          - TYPE: "Debug"
+            SCALAR: "float"
+        PLATFORM:
+          - OS: "ubuntu-latest"
+            GENERATOR: "Unix Makefiles"
+          - OS: "macos-latest"
+            GENERATOR: "Xcode"
+
+    # The system to run on.
+    runs-on: ${{ matrix.PLATFORM.OS }}
+
+    # The build/test steps to execute.
+    steps:
+    # Use a standard checkout of the code.
+    - uses: actions/checkout@v2
+    # Run the CMake configuration.
+    - name: Configure
+      run: cmake -DCMAKE_BUILD_TYPE=${{ matrix.BUILD.TYPE }}
+                 -DALGEBRA_PLUGINS_CUSTOM_SCALARTYPE=${{ matrix.BUILD.SCALAR }}
+                 -DALGEBRA_PLUGINS_INCLUDE_EIGEN=TRUE
+                 -DALGEBRA_PLUGINS_SETUP_EIGEN3=TRUE
+                 -DALGEBRA_PLUGINS_USE_SYSTEM_EIGEN3=FALSE
+                 -DALGEBRA_PLUGINS_INCLUDE_VC=TRUE
+                 -DALGEBRA_PLUGINS_SETUP_VC=TRUE
+                 -DALGEBRA_PLUGINS_USE_SYSTEM_VC=FALSE
+                 -DALGEBRA_PLUGINS_INCLUDE_VECMEM=TRUE
+                 -DALGEBRA_PLUGINS_SETUP_VECMEM=TRUE
+                 -DALGEBRA_PLUGINS_USE_SYSTEM_VECMEM=FALSE
+                 -S ${{ github.workspace }} -B build
+                 -G "${{ matrix.PLATFORM.GENERATOR }}"
+    # Perform the build.
+    - name: Build
+      run: cmake --build build --config ${{ matrix.BUILD.TYPE }}
+    # Run the unit test(s).
+    - name: Test
+      run: |
+        cd build
+        ctest --output-on-failure -C ${{ matrix.BUILD.TYPE }}
+
+  # Containerised build jobs.
+  container:
+
+    # The different build modes to test.
+    strategy:
+      matrix:
+        BUILD:
+          - TYPE: "Release"
+            SCALAR: "float"
+          - TYPE: "Debug"
+            SCALAR: "double"
+        PLATFORM:
+          - NAME: "HOST"
+            CONTAINER: "ghcr.io/acts-project/ubuntu2004:v13"
+            OPTIONS: -DALGEBRA_PLUGINS_INCLUDE_EIGEN=TRUE -DALGEBRA_PLUGINS_SETUP_EIGEN3=TRUE -DALGEBRA_PLUGINS_USE_SYSTEM_EIGEN3=TRUE
+          - NAME: "HOST"
+            CONTAINER: "ghcr.io/acts-project/ubuntu2004:v13"
+            OPTIONS: -DALGEBRA_PLUGINS_INCLUDE_EIGEN=TRUE -DALGEBRA_PLUGINS_SETUP_EIGEN3=TRUE -DALGEBRA_PLUGINS_USE_SYSTEM_EIGEN3=FALSE
+          - NAME: "HOST"
+            CONTAINER: "ghcr.io/acts-project/ubuntu2004:v13"
+            OPTIONS: -DALGEBRA_PLUGINS_INCLUDE_SMATRIX=TRUE
+          - NAME: "HOST"
+            CONTAINER: "ghcr.io/acts-project/ubuntu2004:v13"
+            OPTIONS: -DALGEBRA_PLUGINS_INCLUDE_VC=TRUE -DALGEBRA_PLUGINS_SETUP_VC=TRUE -DALGEBRA_PLUGINS_USE_SYSTEM_VC=FALSE
+          - NAME: "HOST"
+            CONTAINER: "ghcr.io/acts-project/ubuntu2004:v13"
+            OPTIONS: -DALGEBRA_PLUGINS_INCLUDE_VECMEM=TRUE -DALGEBRA_PLUGINS_SETUP_VECMEM=TRUE -DALGEBRA_PLUGINS_USE_SYSTEM_VECMEM=FALSE
+          - NAME: "CUDA"
+            CONTAINER: "ghcr.io/acts-project/ubuntu2004_cuda:v13"
+            OPTIONS: -DALGEBRA_PLUGINS_TEST_CUDA=TRUE -DALGEBRA_PLUGINS_INCLUDE_EIGEN=TRUE -DALGEBRA_PLUGINS_SETUP_EIGEN3=TRUE -DALGEBRA_PLUGINS_USE_SYSTEM_EIGEN3=FALSE -DALGEBRA_PLUGINS_INCLUDE_VECMEM=TRUE -DALGEBRA_PLUGINS_SETUP_VECMEM=TRUE -DALGEBRA_PLUGINS_USE_SYSTEM_VECMEM=FALSE
+
+    # The system to run on.
     runs-on: ubuntu-latest
+    container: ${{ matrix.PLATFORM.CONTAINER }}
 
-    # The different build modes to test.
-    strategy:
-      matrix:
-        BUILD_TYPE: [ "Release", "Debug" ]
-        SCALAR_TYPE: [ "double", "float" ]
-        CMAKE_OPTIONS:
-          - -DALGEBRA_PLUGINS_INCLUDE_EIGEN=TRUE -DALGEBRA_PLUGINS_SETUP_EIGEN3=TRUE -DALGEBRA_PLUGINS_USE_SYSTEM_EIGEN3=TRUE
-          - -DALGEBRA_PLUGINS_INCLUDE_EIGEN=TRUE -DALGEBRA_PLUGINS_SETUP_EIGEN3=TRUE -DALGEBRA_PLUGINS_USE_SYSTEM_EIGEN3=FALSE
-          - -DALGEBRA_PLUGINS_INCLUDE_VC=TRUE -DALGEBRA_PLUGINS_SETUP_VC=TRUE -DALGEBRA_PLUGINS_USE_SYSTEM_VC=FALSE
-          - -DALGEBRA_PLUGINS_INCLUDE_VECMEM=TRUE -DALGEBRA_PLUGINS_SETUP_VECMEM=TRUE -DALGEBRA_PLUGINS_USE_SYSTEM_VECMEM=FALSE
-          - -DALGEBRA_PLUGINS_INCLUDE_EIGEN=TRUE -DALGEBRA_PLUGINS_SETUP_EIGEN3=TRUE -DALGEBRA_PLUGINS_USE_SYSTEM_EIGEN3=TRUE -DALGEBRA_PLUGINS_INCLUDE_VC=TRUE -DALGEBRA_PLUGINS_SETUP_VC=TRUE -DALGEBRA_PLUGINS_USE_SYSTEM_VC=FALSE -DALGEBRA_PLUGINS_INCLUDE_VECMEM=TRUE -DALGEBRA_PLUGINS_SETUP_VECMEM=TRUE -DALGEBRA_PLUGINS_USE_SYSTEM_VECMEM=FALSE
+    # Use BASH as the shell from the image.
+    defaults:
+      run:
+        shell: bash
 
+    # The build/test steps to execute.
     steps:
+    # Use a standard checkout of the code.
     - uses: actions/checkout@v2
-
-    - name: Install Dependencies
-      run: sudo apt-get install libeigen3-dev
-
-    - name: Configure CMake
-      shell: bash
-      run: cmake -S ${{ github.workspace }} -B ${{runner.workspace}}/build
-             -DCMAKE_BUILD_TYPE=${{ matrix.BUILD_TYPE }}
-             -DALGEBRA_PLUGINS_CUSTOM_SCALARTYPE=${{ matrix.SCALAR_TYPE }}
-             ${{ matrix.CMAKE_OPTIONS }}
-
+    # Run the CMake configuration.
+    - name: Configure
+      run: cmake -DCMAKE_BUILD_TYPE=${{ matrix.BUILD.TYPE }}
+                 -DALGEBRA_PLUGINS_CUSTOM_SCALARTYPE=${{ matrix.BUILD.SCALAR }}
+                 ${{ matrix.PLATFORM.OPTIONS }}
+                 -S ${GITHUB_WORKSPACE} -B build
+    # Perform the build.
     - name: Build
-      shell: bash
-      run: cmake --build ${{runner.workspace}}/build
-                 --config ${{ matrix.BUILD_TYPE }}
-
-    - name: Unit Tests
-      working-directory: ${{runner.workspace}}/build
-      shell: bash
-      run: ctest -C ${{ matrix.BUILD_TYPE }}
-
-  macos:
-    runs-on: macos-latest
-
-    # The different build modes to test.
-    strategy:
-      matrix:
-        BUILD_TYPE: [ "Release", "Debug" ]
-        SCALAR_TYPE: [ "double", "float" ]
-        CMAKE_OPTIONS:
-          - -DALGEBRA_PLUGINS_INCLUDE_EIGEN=TRUE -DALGEBRA_PLUGINS_SETUP_EIGEN3=TRUE -DALGEBRA_PLUGINS_USE_SYSTEM_EIGEN3=TRUE
-          - -DALGEBRA_PLUGINS_INCLUDE_EIGEN=TRUE -DALGEBRA_PLUGINS_SETUP_EIGEN3=TRUE -DALGEBRA_PLUGINS_USE_SYSTEM_EIGEN3=FALSE
-          - -DALGEBRA_PLUGINS_INCLUDE_VC=TRUE -DALGEBRA_PLUGINS_SETUP_VC=TRUE -DALGEBRA_PLUGINS_USE_SYSTEM_VC=FALSE
-          - -DALGEBRA_PLUGINS_INCLUDE_VECMEM=TRUE -DALGEBRA_PLUGINS_SETUP_VECMEM=TRUE -DALGEBRA_PLUGINS_USE_SYSTEM_VECMEM=FALSE
-          - -DALGEBRA_PLUGINS_INCLUDE_EIGEN=TRUE -DALGEBRA_PLUGINS_SETUP_EIGEN3=TRUE -DALGEBRA_PLUGINS_USE_SYSTEM_EIGEN3=TRUE -DALGEBRA_PLUGINS_INCLUDE_VC=TRUE -DALGEBRA_PLUGINS_SETUP_VC=TRUE -DALGEBRA_PLUGINS_USE_SYSTEM_VC=FALSE -DALGEBRA_PLUGINS_INCLUDE_VECMEM=TRUE -DALGEBRA_PLUGINS_SETUP_VECMEM=TRUE -DALGEBRA_PLUGINS_USE_SYSTEM_VECMEM=FALSE
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Install Dependencies
-      run: brew install cmake eigen ninja
-
-    - name: Configure CMake
-      shell: bash
-      run: cmake -S ${{ github.workspace }} -B ${{runner.workspace}}/build
-             -DCMAKE_BUILD_TYPE=${{ matrix.BUILD_TYPE }}
-             -DALGEBRA_PLUGINS_CUSTOM_SCALARTYPE=${{ matrix.SCALAR_TYPE }}
-             ${{ matrix.CMAKE_OPTIONS }}
-
-    - name: Build
-      shell: bash
-      run: cmake --build ${{runner.workspace}}/build
-                 --config ${{ matrix.BUILD_TYPE }}
-
-    - name: Unit Tests
-      working-directory: ${{runner.workspace}}/build
-      shell: bash
-      run: ctest -C ${{ matrix.BUILD_TYPE }}
+      run: cmake --build build
+    # Run the unit test(s).
+    - name: Test
+      if: "matrix.PLATFORM.NAME == 'HOST'"
+      run: |
+        cd build
+        ctest --output-on-failure

--- a/tests/accelerator/CMakeLists.txt
+++ b/tests/accelerator/CMakeLists.txt
@@ -4,8 +4,16 @@
 #
 # Mozilla Public License Version 2.0
 
-# Run the CUDA test(s), if CUDA is available.
+# Run the CUDA test(s) by default, if CUDA is available.
 vecmem_check_language( CUDA )
+set( _cudaEnabledDefault FALSE )
 if( CMAKE_CUDA_COMPILER )
+   set( _cudaEnabledDefault TRUE )
+endif()
+option( ALGEBRA_PLUGINS_TEST_CUDA "Test the code in CUDA device code"
+   ${_cudaEnabledDefault} )
+unset( _cudaEnabledDefault )
+
+if( ALGEBRA_PLUGINS_TEST_CUDA )
    add_subdirectory( cuda )
 endif()

--- a/tests/accelerator/cuda/common/test_cuda_basics.cuh
+++ b/tests/accelerator/cuda/common/test_cuda_basics.cuh
@@ -37,15 +37,27 @@ class test_cuda_basics : public testing::Test, public test_base<T> {
     // Initialise the input vectors with some dummy values.
     for (std::size_t i = 0; i < s_arraySize; ++i) {
 
-      m_t1[i] = {1., 2., 3.};
-      m_t2[i] = {4., 5., 6.};
-      m_t3[i] = {7., 8., 9.};
+      m_t1[i] = {static_cast<typename T::scalar>(1.),
+                 static_cast<typename T::scalar>(2.),
+                 static_cast<typename T::scalar>(3.)};
+      m_t2[i] = {static_cast<typename T::scalar>(4.),
+                 static_cast<typename T::scalar>(5.),
+                 static_cast<typename T::scalar>(6.)};
+      m_t3[i] = {static_cast<typename T::scalar>(7.),
+                 static_cast<typename T::scalar>(8.),
+                 static_cast<typename T::scalar>(9.)};
 
-      m_p1[i] = {i * 0.5, (i + 1) * 1.0};
-      m_p2[i] = {(i - 1) * 1.2, i * 0.6};
+      m_p1[i] = {static_cast<typename T::scalar>(i * 0.5),
+                 static_cast<typename T::scalar>((i + 1) * 1.0)};
+      m_p2[i] = {static_cast<typename T::scalar>((i - 1) * 1.2),
+                 static_cast<typename T::scalar>(i * 0.6)};
 
-      m_v1[i] = {i * 0.6, (i + 1) * 1.2, (i + 2) * 1.3};
-      m_v2[i] = {(i - 1) * 1.8, i * 2.3, (i - 2) * 3.4};
+      m_v1[i] = {static_cast<typename T::scalar>(i * 0.6),
+                 static_cast<typename T::scalar>((i + 1) * 1.2),
+                 static_cast<typename T::scalar>((i + 2) * 1.3)};
+      m_v2[i] = {static_cast<typename T::scalar>((i - 1) * 1.8),
+                 static_cast<typename T::scalar>(i * 2.3),
+                 static_cast<typename T::scalar>((i - 2) * 3.4)};
     }
   }
 


### PR DESCRIPTION
As I mentioned in #39, we don't yet perform the CUDA tests in the CI.

I re-organised the CI configuration in the style that we use in [vecmem](https://github.com/acts-project/vecmem) these days.
  - I separately set up "native" and "containerized" tests;
  - The native tests turn on every feature that they can, and only test such a fully loaded configuration;
  - For the containerized tests, the "host tests" turn on features one-by-one, to test that those can function individually. And not just when everything else is also turned on.
  - The "cuda test", similar to the "native tests", only runs on one configurations, with everything possible turned on at once.

Note that I decided not to use every combination of build mode and scalar type in the tests individually. Since I intend to get rid of the `ALGEBRA_PLUGINS_CUSTOM_SCALARTYPE` setting completely soon, I didn't want to bloat the CI too much temporarily.

Also note, that I'm not actually super happy with how I set up the tests with the `ghcr.io/acts-project/ubuntu2004:v13` image. :frowning: I was hoping that I could make this type of formalism work:

```yaml
          - NAME: "HOST"
            CONTAINER: "ghcr.io/acts-project/ubuntu2004:v13"
            OPTIONS:
              - -DALGEBRA_PLUGINS_INCLUDE_EIGEN=TRUE -DALGEBRA_PLUGINS_SETUP_EIGEN3=TRUE -DALGEBRA_PLUGINS_USE_SYSTEM_EIGEN3=TRUE
              - -DALGEBRA_PLUGINS_INCLUDE_EIGEN=TRUE -DALGEBRA_PLUGINS_SETUP_EIGEN3=TRUE -DALGEBRA_PLUGINS_USE_SYSTEM_EIGEN3=FALSE
              ...
```

But GitHub did not want to play ball. :confused: So the configuration that I ended up with, does have some unnecessary-looking repetitions in it...