### PR TITLE
Windows Compatibility, main branch (2021.11.18.)

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -32,6 +32,8 @@ jobs:
             GENERATOR: "Unix Makefiles"
           - OS: "macos-latest"
             GENERATOR: "Xcode"
+          - OS: "windows-latest"
+            GENERATOR: "Visual Studio 16 2019"
 
     # The system to run on.
     runs-on: ${{ matrix.PLATFORM.OS }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,12 +106,14 @@ if( ALGEBRA_PLUGINS_SETUP_VC )
    else()
       add_subdirectory( extern/vc )
    endif()
-   # Use the preferred compiler flags from Vc for the entire project. Do not
-   # set them on the libraries individually, as the clients of the libraries
-   # may want to use a different optimisation.
-   vc_set_preferred_compiler_flags()
-   add_compile_definitions( ${Vc_DEFINITIONS} )
-   add_compile_options( ${Vc_COMPILE_FLAGS} ${Vc_ARCHITECTURE_FLAGS} )
+   if( NOT "${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC" )
+      # Use the preferred compiler flags from Vc for the entire project. Do not
+      # set them on the libraries individually, as the clients of the libraries
+      # may want to use a different optimisation.
+      vc_set_preferred_compiler_flags()
+      add_compile_definitions( ${Vc_DEFINITIONS} )
+      add_compile_options( ${Vc_COMPILE_FLAGS} ${Vc_ARCHITECTURE_FLAGS} )
+   endif()
 endif()
 
 # Undo the developer flag suppression.

--- a/cmake/algebra-plugins-compiler-options.cmake
+++ b/cmake/algebra-plugins-compiler-options.cmake
@@ -4,6 +4,15 @@
 #
 # Mozilla Public License Version 2.0
 
+# Include the helper function(s).
+include( algebra-plugins-functions )
+
 # Set up the used C++ standard.
 set( CMAKE_CXX_STANDARD 17 CACHE STRING "The (host) C++ standard to use" )
 set( CMAKE_CUDA_STANDARD 17 CACHE STRING "The (CUDA) C++ standard to use" )
+
+# Turn on the correct setting for the __cplusplus macro with MSVC.
+if( "${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC" )
+   algebra_add_flag( CMAKE_CXX_FLAGS "/Zc:__cplusplus" )
+   algebra_add_flag( CMAKE_CUDA_FLAGS "-Xcompiler /Zc:__cplusplus" )
+endif()

--- a/cmake/algebra-plugins-functions.cmake
+++ b/cmake/algebra-plugins-functions.cmake
@@ -4,6 +4,12 @@
 #
 # Mozilla Public License Version 2.0
 
+# Guard against multiple includes.
+include_guard( GLOBAL )
+
+# CMake include(s).
+include( CMakeParseArguments )
+
 # Helper function for setting up the algebra plugins libraries.
 #
 # Usage: algebra_add_library( algebra_array array "header1.hpp"... )
@@ -56,3 +62,25 @@ function( algebra_add_test name )
       COMMAND $<TARGET_FILE:${test_exe_name}> )
 
 endfunction( algebra_add_test )
+
+# Helper function for adding individual flags to "flag variables".
+#
+# Usage: algebra_add_flag( CMAKE_CXX_FLAGS "-Wall" )
+#
+function( algebra_add_flag name value )
+
+   # Escape special characters in the value:
+   set( matchedValue "${value}" )
+   foreach( c "*" "." "^" "$" "+" "?" )
+      string( REPLACE "${c}" "\\${c}" matchedValue "${matchedValue}" )
+   endforeach()
+
+   # Check if the variable already has this value in it:
+   if( "${${name}}" MATCHES "${matchedValue}" )
+      return()
+   endif()
+
+   # If not, then let's add it now:
+   set( ${name} "${${name}} ${value}" PARENT_SCOPE )
+
+endfunction( algebra_add_flag )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,6 +8,10 @@
 add_library( algebra_tests_common INTERFACE )
 target_include_directories( algebra_tests_common INTERFACE
    "${CMAKE_CURRENT_SOURCE_DIR}/common" )
+if( "${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC" )
+   target_compile_definitions( algebra_tests_common INTERFACE
+      -D_USE_MATH_DEFINES )
+endif()
 add_library( algebra::tests_common ALIAS algebra_tests_common )
 
 # Set up all of the (available) "host" tests.

--- a/tests/accelerator/cuda/CMakeLists.txt
+++ b/tests/accelerator/cuda/CMakeLists.txt
@@ -4,6 +4,9 @@
 #
 # Mozilla Public License Version 2.0
 
+# CMake version requirement.
+cmake_minimum_required( VERSION 3.17 )
+
 # Enable CUDA as a language.
 enable_language( CUDA )
 find_package( CUDAToolkit REQUIRED )
@@ -21,6 +24,13 @@ target_link_libraries( algebra_tests_cuda_common
              vecmem::core vecmem::cuda )
 target_compile_options( algebra_tests_cuda_common INTERFACE
    $<$<COMPILE_LANGUAGE:CUDA>:-Xcudafe --diag_suppress=177> )
+if( "${CUDAToolkit_VERSION}" VERSION_GREATER_EQUAL "11.5" )
+   # Replace all "#pragma diag_suppress" calls in the Eigen code with
+   # "#pragma nv_diag_suppress" calls. To be removed once the Eigen
+   # code starts behaving better.
+   target_compile_definitions( algebra_tests_cuda_common
+      INTERFACE diag_suppress=nv_diag_suppress )
+endif()
 add_library( algebra::tests_cuda_common ALIAS algebra_tests_cuda_common )
 
 # Set up all of the (available) CUDA tests.

--- a/tests/accelerator/cuda/common/execute_cuda_test.cuh
+++ b/tests/accelerator/cuda/common/execute_cuda_test.cuh
@@ -42,11 +42,12 @@ void execute_cuda_test(std::size_t arraySizes, ARGS... args) {
   // If the arrays are not even this large, then reduce the value to the
   // size of the arrays.
   if (arraySizes < nThreadsPerBlock) {
-    nThreadsPerBlock = arraySizes;
+    nThreadsPerBlock = static_cast<int>(arraySizes);
   }
 
   // Launch the test on the device.
-  const int nBlocks = ((arraySizes + nThreadsPerBlock - 1) / nThreadsPerBlock);
+  const int nBlocks =
+      static_cast<int>((arraySizes + nThreadsPerBlock - 1) / nThreadsPerBlock);
   cudaTestKernel<FUNCTOR><<<nBlocks, nThreadsPerBlock>>>(arraySizes, args...);
 
   // Check whether it succeeded to run.

--- a/tests/accelerator/cuda/common/test_cuda_basics.cuh
+++ b/tests/accelerator/cuda/common/test_cuda_basics.cuh
@@ -72,6 +72,14 @@ class test_cuda_basics : public testing::Test, public test_base<T> {
     }
   }
 
+  /// Compare the outputs, after the data processing is finished.
+  void compareOutputs() const {
+    for (std::size_t i = 0; i < this->s_arraySize; ++i) {
+      EXPECT_FLOAT_EQ(static_cast<float>(m_output_host[i]),
+                      static_cast<float>(m_output_device[i]));
+    }
+  }
+
   /// Memory resource for all of the tests.
   vecmem::cuda::managed_memory_resource m_resource;
 
@@ -115,9 +123,7 @@ TYPED_TEST_P(test_cuda_basics, vector_2d_ops) {
       vecmem::get_data(this->m_p2), vecmem::get_data(this->m_output_device));
 
   // Compare the outputs.
-  for (std::size_t i = 0; i < this->s_arraySize; ++i) {
-    EXPECT_FLOAT_EQ(this->m_output_host[i], this->m_output_device[i]);
-  }
+  this->compareOutputs();
 }
 
 /// Test for some basic 3D "vector operations"
@@ -132,9 +138,7 @@ TYPED_TEST_P(test_cuda_basics, vector_3d_ops) {
       vecmem::get_data(this->m_v2), vecmem::get_data(this->m_output_device));
 
   // Compare the outputs.
-  for (std::size_t i = 0; i < this->s_arraySize; ++i) {
-    EXPECT_FLOAT_EQ(this->m_output_host[i], this->m_output_device[i]);
-  }
+  this->compareOutputs();
 }
 
 /// Test for some operations with @c transform3
@@ -153,9 +157,7 @@ TYPED_TEST_P(test_cuda_basics, transform3) {
       vecmem::get_data(this->m_output_device));
 
   // Compare the outputs.
-  for (std::size_t i = 0; i < this->s_arraySize; ++i) {
-    EXPECT_FLOAT_EQ(this->m_output_host[i], this->m_output_device[i]);
-  }
+  this->compareOutputs();
 }
 
 /// Test for some operations with @c cartesian2
@@ -174,9 +176,7 @@ TYPED_TEST_P(test_cuda_basics, cartesian2) {
       vecmem::get_data(this->m_output_device));
 
   // Compare the outputs.
-  for (std::size_t i = 0; i < this->s_arraySize; ++i) {
-    EXPECT_FLOAT_EQ(this->m_output_host[i], this->m_output_device[i]);
-  }
+  this->compareOutputs();
 }
 
 /// Test for some operations with @c cylindrical2
@@ -195,9 +195,7 @@ TYPED_TEST_P(test_cuda_basics, cylindrical2) {
       vecmem::get_data(this->m_output_device));
 
   // Compare the outputs.
-  for (std::size_t i = 0; i < this->s_arraySize; ++i) {
-    EXPECT_FLOAT_EQ(this->m_output_host[i], this->m_output_device[i]);
-  }
+  this->compareOutputs();
 }
 
 /// Test for some operations with @c polar2
@@ -216,9 +214,7 @@ TYPED_TEST_P(test_cuda_basics, polar2) {
       vecmem::get_data(this->m_output_device));
 
   // Compare the outputs.
-  for (std::size_t i = 0; i < this->s_arraySize; ++i) {
-    EXPECT_FLOAT_EQ(this->m_output_host[i], this->m_output_device[i]);
-  }
+  this->compareOutputs();
 }
 
 REGISTER_TYPED_TEST_SUITE_P(test_cuda_basics, vector_2d_ops, vector_3d_ops,

--- a/tests/accelerator/cuda/common/test_cuda_basics_functors.hpp
+++ b/tests/accelerator/cuda/common/test_cuda_basics_functors.hpp
@@ -43,7 +43,8 @@ class vector_2d_ops_functor : public functor_base<T> {
     vecmem::device_vector<typename T::scalar> vec_output(output);
 
     // Perform the operation.
-    vec_output[i] = this->m_tester.vector_2d_ops(vec_a[i], vec_b[i]);
+    auto ii = static_cast<typename decltype(vec_output)::size_type>(i);
+    vec_output[ii] = this->m_tester.vector_2d_ops(vec_a[ii], vec_b[ii]);
   }
 };
 
@@ -62,7 +63,8 @@ class vector_3d_ops_functor : public functor_base<T> {
     vecmem::device_vector<typename T::scalar> vec_output(output);
 
     // Perform the operation.
-    vec_output[i] = this->m_tester.vector_3d_ops(vec_a[i], vec_b[i]);
+    auto ii = static_cast<typename decltype(vec_output)::size_type>(i);
+    vec_output[ii] = this->m_tester.vector_3d_ops(vec_a[ii], vec_b[ii]);
   }
 };
 
@@ -85,8 +87,9 @@ class transform3_ops_functor : public functor_base<T> {
     vecmem::device_vector<typename T::scalar> vec_output(output);
 
     // Perform the operation.
-    vec_output[i] = this->m_tester.transform3_ops(
-        vec_t1[i], vec_t2[i], vec_t3[i], vec_a[i], vec_b[i]);
+    auto ii = static_cast<typename decltype(vec_output)::size_type>(i);
+    vec_output[ii] = this->m_tester.transform3_ops(
+        vec_t1[ii], vec_t2[ii], vec_t3[ii], vec_a[ii], vec_b[ii]);
   }
 };
 
@@ -109,8 +112,9 @@ class cartesian2_ops_functor : public functor_base<T> {
     vecmem::device_vector<typename T::scalar> vec_output(output);
 
     // Perform the operation.
-    vec_output[i] = this->m_tester.cartesian2_ops(
-        vec_t1[i], vec_t2[i], vec_t3[i], vec_a[i], vec_b[i]);
+    auto ii = static_cast<typename decltype(vec_output)::size_type>(i);
+    vec_output[ii] = this->m_tester.cartesian2_ops(
+        vec_t1[ii], vec_t2[ii], vec_t3[ii], vec_a[ii], vec_b[ii]);
   }
 };
 
@@ -133,8 +137,9 @@ class cylindrical2_ops_functor : public functor_base<T> {
     vecmem::device_vector<typename T::scalar> vec_output(output);
 
     // Perform the operation.
-    vec_output[i] = this->m_tester.cylindrical2_ops(
-        vec_t1[i], vec_t2[i], vec_t3[i], vec_a[i], vec_b[i]);
+    auto ii = static_cast<typename decltype(vec_output)::size_type>(i);
+    vec_output[ii] = this->m_tester.cylindrical2_ops(
+        vec_t1[ii], vec_t2[ii], vec_t3[ii], vec_a[ii], vec_b[ii]);
   }
 };
 
@@ -157,8 +162,9 @@ class polar2_ops_functor : public functor_base<T> {
     vecmem::device_vector<typename T::scalar> vec_output(output);
 
     // Perform the operation.
-    vec_output[i] = this->m_tester.polar2_ops(vec_t1[i], vec_t2[i], vec_t3[i],
-                                              vec_a[i], vec_b[i]);
+    auto ii = static_cast<typename decltype(vec_output)::size_type>(i);
+    vec_output[ii] = this->m_tester.polar2_ops(
+        vec_t1[ii], vec_t2[ii], vec_t3[ii], vec_a[ii], vec_b[ii]);
   }
 };
 

--- a/tests/common/test_host_basics.hpp
+++ b/tests/common/test_host_basics.hpp
@@ -14,6 +14,7 @@
 #include <gtest/gtest.h>
 
 // System include(s).
+#include <array>
 #include <climits>
 #include <cmath>
 


### PR DESCRIPTION
These changes are set up on top of #41. So I'll keep it in a draft stage until that PR is sorted out.

I hope you all saw this coming. :stuck_out_tongue: I just really wanted to see if I could build this project on Windows as well. :smile: Turns out, we can. It only required a couple of changes. All of them in the test code, and not in the main headers / libraries of the project.

Note that unfortunately with CUDA enabled, I see a large number of warnings. Most of them coming from Eigen. But there are also some coming when `nvcc` is making use of [vecmem/memory/details/memory_resource_base.hpp](https://github.com/acts-project/vecmem/blob/main/core/include/vecmem/memory/details/memory_resource_base.hpp). It seems that we'll need to find the equivalent of

```c++
#ifdef _MSC_VER
#pragma warning(push)
#pragma warning(disable : 4275)
#endif  // MSVC
```

for `nvcc`. :thinking: (Pinging @stephenswat and @paulgessinger.)

Still, the build succeeds, and all of the tests can run successfully on Windows. :smile:

One final thing that I didn't really understand is that the "recommended compile options" coming from Vc make the compilation (actually, the linking) fail. For non-Vc-using executables as well. :confused: (The linker fails to find standard library symbols for some reason with those flags enabled.) But I didn't want to start debugging that, so I just removed the global setup of the Vc flags with MSVC.