### PR TITLE
Improved SYCL Math Support, main branch (2022.01.18.)

### DIFF
--- a/.github/ci_setup.sh
+++ b/.github/ci_setup.sh
@@ -1,0 +1,22 @@
+# Algebra plugins library, part of the ACTS project (R&D line)
+#
+# (c) 2021-2022 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
+#
+# This script is meant to configure the build/runtime environment of the
+# Docker contaners that are used in the project's CI configuration.
+#
+# Usage: source .github/ci_setup.sh <platform name>
+#
+
+# The platform name.
+PLATFORM_NAME=$1
+
+# Set up the correct environment for the SYCL tests.
+if [ "${PLATFORM_NAME}" = "SYCL" ]; then
+   source /opt/intel/oneapi/setvars.sh
+   export CXX=`which clang++`
+   export SYCLCXX=`which dpcpp`
+   export SYCL_DEVICE_FILTER=host
+fi

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -1,6 +1,6 @@
 # Algebra plugins library, part of the ACTS project (R&D line)
 #
-# (c) 2021 CERN for the benefit of the ACTS project
+# (c) 2021-2022 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -87,6 +87,9 @@ jobs:
           - NAME: "CUDA"
             CONTAINER: "ghcr.io/acts-project/ubuntu2004_cuda:v13"
             OPTIONS: -DALGEBRA_PLUGINS_TEST_CUDA=TRUE -DALGEBRA_PLUGINS_INCLUDE_EIGEN=TRUE -DALGEBRA_PLUGINS_SETUP_EIGEN3=TRUE -DALGEBRA_PLUGINS_USE_SYSTEM_EIGEN3=FALSE -DALGEBRA_PLUGINS_INCLUDE_VECMEM=TRUE -DALGEBRA_PLUGINS_SETUP_VECMEM=TRUE -DALGEBRA_PLUGINS_USE_SYSTEM_VECMEM=FALSE
+          - NAME: "SYCL"
+            CONTAINER: "ghcr.io/acts-project/ubuntu2004_oneapi:v13"
+            OPTIONS: -DALGEBRA_PLUGINS_TEST_SYCL=TRUE -DALGEBRA_PLUGINS_INCLUDE_VECMEM=TRUE -DALGEBRA_PLUGINS_SETUP_VECMEM=TRUE -DALGEBRA_PLUGINS_USE_SYSTEM_VECMEM=FALSE
 
     # The system to run on.
     runs-on: ubuntu-latest
@@ -103,15 +106,18 @@ jobs:
     - uses: actions/checkout@v2
     # Run the CMake configuration.
     - name: Configure
-      run: cmake -DCMAKE_BUILD_TYPE=${{ matrix.BUILD_TYPE }}
-                 ${{ matrix.PLATFORM.OPTIONS }}
-                 -S ${GITHUB_WORKSPACE} -B build
+      run: |
+        source ${GITHUB_WORKSPACE}/.github/ci_setup.sh ${{ matrix.PLATFORM.NAME }}
+        cmake -DCMAKE_BUILD_TYPE=${{ matrix.BUILD_TYPE }} ${{ matrix.PLATFORM.OPTIONS }} -S ${GITHUB_WORKSPACE} -B build
     # Perform the build.
     - name: Build
-      run: cmake --build build
+      run: |
+        source ${GITHUB_WORKSPACE}/.github/ci_setup.sh ${{ matrix.PLATFORM.NAME }}
+        cmake --build build
     # Run the unit test(s).
     - name: Test
-      if: "matrix.PLATFORM.NAME == 'HOST'"
+      if: "matrix.PLATFORM.NAME != 'CUDA'"
       run: |
         cd build
+        source ${GITHUB_WORKSPACE}/.github/ci_setup.sh ${{ matrix.PLATFORM.NAME }}
         ctest --output-on-failure

--- a/math/CMakeLists.txt
+++ b/math/CMakeLists.txt
@@ -1,10 +1,11 @@
 # Algebra plugins library, part of the ACTS project (R&D line)
 #
-# (c) 2021 CERN for the benefit of the ACTS project
+# (c) 2021-2022 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
 # Set up all enabled libraries.
+add_subdirectory( common )
 add_subdirectory( cmath )
 if( ALGEBRA_PLUGINS_INCLUDE_EIGEN )
    add_subdirectory( eigen )

--- a/math/cmath/CMakeLists.txt
+++ b/math/cmath/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Algebra plugins library, part of the ACTS project (R&D line)
 #
-# (c) 2021 CERN for the benefit of the ACTS project
+# (c) 2021-2022 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -15,4 +15,4 @@ algebra_add_library( algebra_cmath_math cmath_math
    "include/algebra/math/impl/cmath_transform3.hpp"
    "include/algebra/math/impl/cmath_vector.hpp" )
 target_link_libraries( algebra_cmath_math
-   INTERFACE algebra::common )
+   INTERFACE algebra::common algebra::common_math )

--- a/math/cmath/include/algebra/math/impl/cmath_getter.hpp
+++ b/math/cmath/include/algebra/math/impl/cmath_getter.hpp
@@ -1,6 +1,6 @@
 /** Algebra plugins library, part of the ACTS project
  *
- * (c) 2020-2021 CERN for the benefit of the ACTS project
+ * (c) 2020-2022 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -8,10 +8,10 @@
 #pragma once
 
 // Project include(s).
+#include "algebra/math/common.hpp"
 #include "algebra/qualifiers.hpp"
 
 // System include(s).
-#include <cmath>
 #include <cstddef>
 #include <type_traits>
 
@@ -26,7 +26,7 @@ template <typename size_type, template <typename, size_type> class array_t,
 ALGEBRA_HOST_DEVICE inline scalar_t phi(
     const array_t<scalar_t, N> &v) noexcept {
 
-  return std::atan2(v[1], v[0]);
+  return algebra::math::atan2(v[1], v[0]);
 }
 
 /** This method retrieves theta from a vector, vector base with rows >= 3
@@ -38,7 +38,8 @@ template <typename size_type, template <typename, size_type> class array_t,
 ALGEBRA_HOST_DEVICE inline scalar_t theta(
     const array_t<scalar_t, N> &v) noexcept {
 
-  return std::atan2(std::sqrt(v[0] * v[0] + v[1] * v[1]), v[2]);
+  return algebra::math::atan2(algebra::math::sqrt(v[0] * v[0] + v[1] * v[1]),
+                              v[2]);
 }
 
 /** This method retrieves the perpenticular magnitude of a vector with rows >= 2
@@ -50,7 +51,7 @@ template <typename size_type, template <typename, size_type> class array_t,
 ALGEBRA_HOST_DEVICE inline scalar_t perp(
     const array_t<scalar_t, N> &v) noexcept {
 
-  return std::sqrt(v[0] * v[0] + v[1] * v[1]);
+  return algebra::math::sqrt(v[0] * v[0] + v[1] * v[1]);
 }
 
 /** This method retrieves the norm of a vector, no dimension restriction
@@ -72,7 +73,7 @@ template <typename size_type, template <typename, size_type> class array_t,
           typename scalar_t, size_type N, std::enable_if_t<N >= 3, bool> = true>
 ALGEBRA_HOST_DEVICE inline scalar_t norm(const array_t<scalar_t, N> &v) {
 
-  return std::sqrt(v[0] * v[0] + v[1] * v[1] + v[2] * v[2]);
+  return algebra::math::sqrt(v[0] * v[0] + v[1] * v[1] + v[2] * v[2]);
 }
 
 /** This method retrieves the pseudo-rapidity from a vector or vector base with
@@ -85,7 +86,7 @@ template <typename size_type, template <typename, size_type> class array_t,
 ALGEBRA_HOST_DEVICE inline scalar_t eta(
     const array_t<scalar_t, N> &v) noexcept {
 
-  return std::atanh(v[2] / norm(v));
+  return algebra::math::atanh(v[2] / norm(v));
 }
 
 /// "Element getter", assuming a simple 2D array access

--- a/math/cmath/include/algebra/math/impl/cmath_vector.hpp
+++ b/math/cmath/include/algebra/math/impl/cmath_vector.hpp
@@ -1,6 +1,6 @@
 /** Algebra plugins library, part of the ACTS project
  *
- * (c) 2020-2021 CERN for the benefit of the ACTS project
+ * (c) 2020-2022 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -8,10 +8,8 @@
 #pragma once
 
 // Project include(s).
+#include "algebra/math/common.hpp"
 #include "algebra/qualifiers.hpp"
-
-// System include(s).
-#include <cmath>
 
 namespace algebra::cmath {
 
@@ -58,7 +56,7 @@ template <typename size_type, template <typename, size_type> class array_t,
 ALGEBRA_HOST_DEVICE inline array_t<scalar_t, N> normalize(
     const array_t<scalar_t, N> &v) {
 
-  scalar_t oon = 1. / std::sqrt(dot(v, v));
+  const scalar_t oon = 1. / algebra::math::sqrt(dot(v, v));
   return {v[0] * oon, v[1] * oon};
 }
 
@@ -88,7 +86,7 @@ template <typename size_type, template <typename, size_type> class array_t,
 ALGEBRA_HOST_DEVICE inline array_t<scalar_t, 3> normalize(
     const array_t<scalar_t, N> &v) {
 
-  scalar_t oon = 1. / std::sqrt(dot(v, v));
+  const scalar_t oon = 1. / algebra::math::sqrt(dot(v, v));
   return {v[0] * oon, v[1] * oon, v[2] * oon};
 }
 

--- a/math/common/CMakeLists.txt
+++ b/math/common/CMakeLists.txt
@@ -1,0 +1,11 @@
+# Algebra plugins library, part of the ACTS project (R&D line)
+#
+# (c) 2022 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
+
+# Set up the library.
+algebra_add_library( algebra_common_math common_math
+   "include/algebra/math/common.hpp" )
+target_link_libraries( algebra_common_math
+   INTERFACE algebra::common )

--- a/math/common/include/algebra/math/common.hpp
+++ b/math/common/include/algebra/math/common.hpp
@@ -1,0 +1,48 @@
+/** Algebra plugins library, part of the ACTS project
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s).
+#include "algebra/qualifiers.hpp"
+
+// SYCL include(s).
+#if defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION)
+#include <CL/sycl.hpp>
+#endif
+
+// System include(s).
+#include <cmath>
+
+namespace algebra::math {
+
+/// Namespace to pick up math functions from
+#if defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION)
+namespace math_ns = cl::sycl;
+#else
+namespace math_ns = std;
+#endif  // SYCL
+
+/// Arc tangent of y/x
+template <typename scalar_t>
+ALGEBRA_HOST_DEVICE inline scalar_t atan2(scalar_t y, scalar_t x) {
+  return math_ns::atan2(y, x);
+}
+
+/// Square root of arg
+template <typename scalar_t>
+ALGEBRA_HOST_DEVICE inline scalar_t sqrt(scalar_t arg) {
+  return math_ns::sqrt(arg);
+}
+
+/// Inverse hyperbolic tangent of arg
+template <typename scalar_t>
+ALGEBRA_HOST_DEVICE inline scalar_t atanh(scalar_t arg) {
+  return math_ns::atanh(arg);
+}
+
+}  // namespace algebra::math

--- a/math/eigen/CMakeLists.txt
+++ b/math/eigen/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Algebra plugins library, part of the ACTS project (R&D line)
 #
-# (c) 2021 CERN for the benefit of the ACTS project
+# (c) 2021-2022 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -14,4 +14,4 @@ algebra_add_library( algebra_eigen_math eigen_math
    "include/algebra/math/impl/eigen_transform3.hpp"
    "include/algebra/math/impl/eigen_vector.hpp" )
 target_link_libraries( algebra_eigen_math
-   INTERFACE algebra::common Eigen3::Eigen )
+   INTERFACE algebra::common algebra::common_math Eigen3::Eigen )

--- a/math/eigen/include/algebra/math/impl/eigen_getter.hpp
+++ b/math/eigen/include/algebra/math/impl/eigen_getter.hpp
@@ -1,6 +1,6 @@
 /** Algebra plugins, part of the ACTS project
  *
- * (c) 2020 CERN for the benefit of the ACTS project
+ * (c) 2020-2022 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -8,13 +8,13 @@
 #pragma once
 
 // Project include(s).
+#include "algebra/math/common.hpp"
 #include "algebra/qualifiers.hpp"
 
 // Eigen include(s).
 #include <Eigen/Core>
 
 // System include(s).
-#include <cmath>
 #include <type_traits>
 
 namespace algebra::eigen::math {
@@ -30,7 +30,7 @@ template <
 ALGEBRA_HOST_DEVICE inline auto phi(
     const Eigen::MatrixBase<derived_type> &v) noexcept {
 
-  return std::atan2(v[1], v[0]);
+  return algebra::math::atan2(v[1], v[0]);
 }
 
 /** This method retrieves theta from a vector, vector base with rows >= 3
@@ -44,7 +44,8 @@ template <
 ALGEBRA_HOST_DEVICE inline auto theta(
     const Eigen::MatrixBase<derived_type> &v) noexcept {
 
-  return std::atan2(std::sqrt(v[0] * v[0] + v[1] * v[1]), v[2]);
+  return algebra::math::atan2(algebra::math::sqrt(v[0] * v[0] + v[1] * v[1]),
+                              v[2]);
 }
 
 /** This method retrieves the perpenticular magnitude of a vector with rows >= 2
@@ -58,7 +59,7 @@ template <
 ALGEBRA_HOST_DEVICE inline auto perp(
     const Eigen::MatrixBase<derived_type> &v) noexcept {
 
-  return std::sqrt(v[0] * v[0] + v[1] * v[1]);
+  return algebra::math::sqrt(v[0] * v[0] + v[1] * v[1]);
 }
 
 /** This method retrieves the norm of a vector, no dimension restriction
@@ -83,7 +84,7 @@ template <
 ALGEBRA_HOST_DEVICE inline auto eta(
     const Eigen::MatrixBase<derived_type> &v) noexcept {
 
-  return std::atanh(v[2] / v.norm());
+  return algebra::math::atanh(v[2] / v.norm());
 }
 
 }  // namespace algebra::eigen::math

--- a/math/vc/CMakeLists.txt
+++ b/math/vc/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Algebra plugins library, part of the ACTS project (R&D line)
 #
-# (c) 2021 CERN for the benefit of the ACTS project
+# (c) 2021-2022 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -11,4 +11,4 @@ algebra_add_library( algebra_vc_math vc_math
    "include/algebra/math/impl/vc_transform3.hpp"
    "include/algebra/math/impl/vc_vector.hpp" )
 target_link_libraries( algebra_vc_math
-   INTERFACE algebra::common Vc::Vc )
+   INTERFACE algebra::common algebra::common_math Vc::Vc )

--- a/math/vc/include/algebra/math/impl/vc_getter.hpp
+++ b/math/vc/include/algebra/math/impl/vc_getter.hpp
@@ -1,6 +1,6 @@
 /** Algebra plugins library, part of the ACTS project
  *
- * (c) 2020-2021 CERN for the benefit of the ACTS project
+ * (c) 2020-2022 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -8,11 +8,9 @@
 #pragma once
 
 // Project include(s).
+#include "algebra/math/common.hpp"
 #include "algebra/math/impl/vc_vector.hpp"
 #include "algebra/qualifiers.hpp"
-
-// System include(s).
-#include <cmath>
 
 namespace algebra::vc::math {
 
@@ -23,7 +21,7 @@ namespace algebra::vc::math {
 template <typename vector_type>
 ALGEBRA_HOST_DEVICE inline auto phi(const vector_type &v) noexcept {
 
-  return std::atan2(v[1], v[0]);
+  return algebra::math::atan2(v[1], v[0]);
 }
 
 /** This method retrieves theta from a vector, vector base with rows >= 3
@@ -33,7 +31,8 @@ ALGEBRA_HOST_DEVICE inline auto phi(const vector_type &v) noexcept {
 template <typename vector_type>
 ALGEBRA_HOST_DEVICE inline auto theta(const vector_type &v) noexcept {
 
-  return std::atan2(std::sqrt(v[0] * v[0] + v[1] * v[1]), v[2]);
+  return algebra::math::atan2(algebra::math::sqrt(v[0] * v[0] + v[1] * v[1]),
+                              v[2]);
 }
 
 /** This method retrieves the perpenticular magnitude of a vector with rows >= 2
@@ -43,7 +42,7 @@ ALGEBRA_HOST_DEVICE inline auto theta(const vector_type &v) noexcept {
 template <typename vector_type>
 ALGEBRA_HOST_DEVICE inline auto perp(const vector_type &v) noexcept {
 
-  return std::sqrt(v[0] * v[0] + v[1] * v[1]);
+  return algebra::math::sqrt(v[0] * v[0] + v[1] * v[1]);
 }
 
 /** This method retrieves the norm of a vector, no dimension restriction
@@ -53,7 +52,7 @@ ALGEBRA_HOST_DEVICE inline auto perp(const vector_type &v) noexcept {
 template <typename vector_type>
 ALGEBRA_HOST_DEVICE inline auto norm(const vector_type &v) {
 
-  return std::sqrt(dot(v, v));
+  return algebra::math::sqrt(dot(v, v));
 }
 
 /** This method retrieves the pseudo-rapidity from a vector or vector base with
@@ -64,7 +63,7 @@ ALGEBRA_HOST_DEVICE inline auto norm(const vector_type &v) {
 template <typename vector_type>
 ALGEBRA_HOST_DEVICE inline auto eta(const vector_type &v) noexcept {
 
-  return std::atanh(v[2] / norm(v));
+  return algebra::math::atanh(v[2] / norm(v));
 }
 
 }  // namespace algebra::vc::math

--- a/math/vc/include/algebra/math/impl/vc_vector.hpp
+++ b/math/vc/include/algebra/math/impl/vc_vector.hpp
@@ -1,6 +1,6 @@
 /** Algebra plugins library, part of the ACTS project
  *
- * (c) 2020-2021 CERN for the benefit of the ACTS project
+ * (c) 2020-2022 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -8,10 +8,10 @@
 #pragma once
 
 // Project include(s).
+#include "algebra/math/common.hpp"
 #include "algebra/qualifiers.hpp"
 
 // System include(s).
-#include <cmath>
 #include <type_traits>
 #include <utility>
 
@@ -46,7 +46,7 @@ ALGEBRA_HOST_DEVICE inline auto dot(const vector_type1 &a,
 template <typename vector_type>
 ALGEBRA_HOST_DEVICE inline auto normalize(const vector_type &v) {
 
-  return v / std::sqrt(dot(v, v));
+  return v / algebra::math::sqrt(dot(v, v));
 }
 
 /** Cross product between two input vectors - 3 Dim

--- a/storage/smatrix/include/algebra/storage/smatrix.hpp
+++ b/storage/smatrix/include/algebra/storage/smatrix.hpp
@@ -1,6 +1,6 @@
 /** Algebra plugins library, part of the ACTS project
  *
- * (c) 2020-2021 CERN for the benefit of the ACTS project
+ * (c) 2020-2022 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -16,7 +16,7 @@
 namespace algebra::smatrix {
 
 /// Array type used in the Smatrix storage model
-template <typename T, std::size_t N>
+template <typename T, unsigned int N>
 using storage_type = ROOT::Math::SVector<T, N>;
 
 /// 3-element "vector" type, using @c ROOT::Math::SVector

--- a/tests/accelerator/CMakeLists.txt
+++ b/tests/accelerator/CMakeLists.txt
@@ -1,8 +1,16 @@
 # Algebra plugins library, part of the ACTS project (R&D line)
 #
-# (c) 2021 CERN for the benefit of the ACTS project
+# (c) 2021-2022 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
+
+# Set up a "common library" for the device tests.
+add_library( algebra_tests_accel_common INTERFACE )
+target_include_directories( algebra_tests_accel_common INTERFACE
+   "${CMAKE_CURRENT_SOURCE_DIR}/common" )
+target_link_libraries( algebra_tests_accel_common
+   INTERFACE GTest::gtest vecmem::core algebra::common algebra::tests_common )
+add_library( algebra::tests_accel_common ALIAS algebra_tests_accel_common )
 
 # Run the CUDA test(s) by default, if CUDA is available.
 vecmem_check_language( CUDA )
@@ -16,4 +24,18 @@ unset( _cudaEnabledDefault )
 
 if( ALGEBRA_PLUGINS_TEST_CUDA )
    add_subdirectory( cuda )
+endif()
+
+# Run the SYCL test(s) by default, if SYCL is available.
+vecmem_check_language( SYCL )
+set( _syclEnabledDefault FALSE )
+if( CMAKE_SYCL_COMPILER )
+   set( _syclEnabledDefault TRUE )
+endif()
+option( ALGEBRA_PLUGINS_TEST_SYCL "Test the code in SYCL device code"
+   ${_syclEnabledDefault} )
+unset( _syclEnabledDefault )
+
+if( ALGEBRA_PLUGINS_TEST_SYCL )
+   add_subdirectory( sycl )
 endif()

--- a/tests/accelerator/common/test_basics_base.hpp
+++ b/tests/accelerator/common/test_basics_base.hpp
@@ -1,0 +1,136 @@
+/** Algebra plugins library, part of the ACTS project
+ *
+ * (c) 2020-2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Local include(s).
+#include "test_base.hpp"
+
+// VecMem include(s).
+#include <vecmem/containers/vector.hpp>
+#include <vecmem/memory/memory_resource.hpp>
+
+// GoogleTest include(s).
+#include <gtest/gtest.h>
+
+// System include(s).
+#include <cmath>
+#include <memory>
+
+/// Test case class, to be specialised for the different plugins and languages
+template <typename T>
+class test_basics_base : public testing::Test, public test_base<T> {
+
+ public:
+  /// Constructor, setting up the inputs for all of the tests
+  test_basics_base(vecmem::memory_resource& mr) : m_resource(mr) {}
+
+ protected:
+  /// Function setting things up for a test
+  virtual void SetUp() override {
+
+    // Create the vectors.
+    m_t1 = std::make_unique<vecmem::vector<typename T::vector3> >(s_arraySize,
+                                                                  &m_resource);
+    m_t2 = std::make_unique<vecmem::vector<typename T::vector3> >(s_arraySize,
+                                                                  &m_resource);
+    m_t3 = std::make_unique<vecmem::vector<typename T::vector3> >(s_arraySize,
+                                                                  &m_resource);
+
+    m_p1 = std::make_unique<vecmem::vector<typename T::point2> >(s_arraySize,
+                                                                 &m_resource);
+    m_p2 = std::make_unique<vecmem::vector<typename T::point2> >(s_arraySize,
+                                                                 &m_resource);
+
+    m_v1 = std::make_unique<vecmem::vector<typename T::vector3> >(s_arraySize,
+                                                                  &m_resource);
+    m_v2 = std::make_unique<vecmem::vector<typename T::vector3> >(s_arraySize,
+                                                                  &m_resource);
+
+    m_output_host = std::make_unique<vecmem::vector<typename T::scalar> >(
+        s_arraySize, &m_resource);
+    m_output_device = std::make_unique<vecmem::vector<typename T::scalar> >(
+        s_arraySize, &m_resource);
+
+    // Initialise the input and output vectors.
+    for (std::size_t i = 0; i < s_arraySize; ++i) {
+
+      m_t1->at(i) = {static_cast<typename T::scalar>(1.1),
+                     static_cast<typename T::scalar>(2.2),
+                     static_cast<typename T::scalar>(3.3)};
+      m_t2->at(i) = {static_cast<typename T::scalar>(4.4),
+                     static_cast<typename T::scalar>(5.5),
+                     static_cast<typename T::scalar>(6.6)};
+      m_t3->at(i) = {static_cast<typename T::scalar>(7.7),
+                     static_cast<typename T::scalar>(8.8),
+                     static_cast<typename T::scalar>(9.9)};
+
+      m_p1->at(i) = {static_cast<typename T::scalar>(i * 0.5),
+                     static_cast<typename T::scalar>((i + 1) * 1.0)};
+      m_p2->at(i) = {static_cast<typename T::scalar>((i + 2) * 1.2),
+                     static_cast<typename T::scalar>(i * 0.6)};
+
+      m_v1->at(i) = {static_cast<typename T::scalar>(i * 0.6),
+                     static_cast<typename T::scalar>((i + 1) * 1.2),
+                     static_cast<typename T::scalar>((i + 2) * 1.3)};
+      m_v2->at(i) = {static_cast<typename T::scalar>((i + 1) * 1.8),
+                     static_cast<typename T::scalar>(i * 2.3),
+                     static_cast<typename T::scalar>((i + 2) * 3.4)};
+
+      m_output_host->at(i) = 0;
+      m_output_device->at(i) = 0;
+    }
+  }
+
+  /// Function tearing things down after the test
+  virtual void TearDown() override {
+
+    // Delete the vectors.
+    m_t1.reset();
+    m_t2.reset();
+    m_t3.reset();
+    m_p1.reset();
+    m_p2.reset();
+    m_v1.reset();
+    m_v2.reset();
+
+    m_output_host.reset();
+    m_output_device.reset();
+  }
+
+  /// Compare the outputs, after the data processing is finished.
+  void compareOutputs() const {
+    for (std::size_t i = 0; i < this->s_arraySize; ++i) {
+      EXPECT_NEAR(m_output_host->at(i), m_output_device->at(i),
+                  std::abs(0.001 * m_output_host->at(i)));
+    }
+  }
+
+  /// Memory resource provided by the derived class
+  vecmem::memory_resource& m_resource;
+
+  /// Size for the tested arrays.
+  static constexpr std::size_t s_arraySize = 5000;
+
+  /// @name Inputs for the tests
+  /// @{
+
+  std::unique_ptr<vecmem::vector<typename T::vector3> > m_t1, m_t2, m_t3;
+  std::unique_ptr<vecmem::vector<typename T::point2> > m_p1, m_p2;
+  std::unique_ptr<vecmem::vector<typename T::vector3> > m_v1, m_v2;
+
+  /// @}
+
+  /// @name Outputs for the tests
+  /// @{
+
+  std::unique_ptr<vecmem::vector<typename T::scalar> > m_output_host,
+      m_output_device;
+
+  /// @}
+
+};  // class test_basics_base

--- a/tests/accelerator/common/test_basics_functors.hpp
+++ b/tests/accelerator/common/test_basics_functors.hpp
@@ -1,6 +1,6 @@
 /** Algebra plugins library, part of the ACTS project
  *
- * (c) 2020-2021 CERN for the benefit of the ACTS project
+ * (c) 2020-2022 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -16,8 +16,6 @@
 // VecMem include(s).
 #include <vecmem/containers/data/vector_view.hpp>
 #include <vecmem/containers/device_vector.hpp>
-
-namespace cuda {
 
 /// Base class for all of the functors
 template <typename T>
@@ -36,7 +34,7 @@ class vector_2d_ops_functor : public functor_base<T> {
   ALGEBRA_HOST_DEVICE void operator()(
       std::size_t i, vecmem::data::vector_view<const typename T::point2> a,
       vecmem::data::vector_view<const typename T::point2> b,
-      vecmem::data::vector_view<typename T::scalar>& output) {
+      vecmem::data::vector_view<typename T::scalar> output) const {
 
     // Create the VecMem vector(s).
     vecmem::device_vector<const typename T::point2> vec_a(a), vec_b(b);
@@ -56,7 +54,7 @@ class vector_3d_ops_functor : public functor_base<T> {
   ALGEBRA_HOST_DEVICE void operator()(
       std::size_t i, vecmem::data::vector_view<const typename T::vector3> a,
       vecmem::data::vector_view<const typename T::vector3> b,
-      vecmem::data::vector_view<typename T::scalar>& output) {
+      vecmem::data::vector_view<typename T::scalar> output) const {
 
     // Create the VecMem vector(s).
     vecmem::device_vector<const typename T::vector3> vec_a(a), vec_b(b);
@@ -79,7 +77,7 @@ class transform3_ops_functor : public functor_base<T> {
       vecmem::data::vector_view<const typename T::vector3> t3,
       vecmem::data::vector_view<const typename T::vector3> a,
       vecmem::data::vector_view<const typename T::vector3> b,
-      vecmem::data::vector_view<typename T::scalar>& output) {
+      vecmem::data::vector_view<typename T::scalar> output) const {
 
     // Create the VecMem vector(s).
     vecmem::device_vector<const typename T::vector3> vec_t1(t1), vec_t2(t2),
@@ -104,7 +102,7 @@ class cartesian2_ops_functor : public functor_base<T> {
       vecmem::data::vector_view<const typename T::vector3> t3,
       vecmem::data::vector_view<const typename T::vector3> a,
       vecmem::data::vector_view<const typename T::vector3> b,
-      vecmem::data::vector_view<typename T::scalar>& output) {
+      vecmem::data::vector_view<typename T::scalar> output) const {
 
     // Create the VecMem vector(s).
     vecmem::device_vector<const typename T::vector3> vec_t1(t1), vec_t2(t2),
@@ -129,7 +127,7 @@ class cylindrical2_ops_functor : public functor_base<T> {
       vecmem::data::vector_view<const typename T::vector3> t3,
       vecmem::data::vector_view<const typename T::vector3> a,
       vecmem::data::vector_view<const typename T::vector3> b,
-      vecmem::data::vector_view<typename T::scalar>& output) {
+      vecmem::data::vector_view<typename T::scalar> output) const {
 
     // Create the VecMem vector(s).
     vecmem::device_vector<const typename T::vector3> vec_t1(t1), vec_t2(t2),
@@ -154,7 +152,7 @@ class polar2_ops_functor : public functor_base<T> {
       vecmem::data::vector_view<const typename T::vector3> t3,
       vecmem::data::vector_view<const typename T::vector3> a,
       vecmem::data::vector_view<const typename T::vector3> b,
-      vecmem::data::vector_view<typename T::scalar>& output) {
+      vecmem::data::vector_view<typename T::scalar> output) const {
 
     // Create the VecMem vector(s).
     vecmem::device_vector<const typename T::vector3> vec_t1(t1), vec_t2(t2),
@@ -167,5 +165,3 @@ class polar2_ops_functor : public functor_base<T> {
         vec_t1[ii], vec_t2[ii], vec_t3[ii], vec_a[ii], vec_b[ii]);
   }
 };
-
-}  // namespace cuda

--- a/tests/accelerator/cuda/CMakeLists.txt
+++ b/tests/accelerator/cuda/CMakeLists.txt
@@ -14,14 +14,13 @@ find_package( CUDAToolkit REQUIRED )
 # Helper library for the CUDA tests.
 add_library( algebra_tests_cuda_common STATIC
    "common/cuda_error_check.hpp" "common/cuda_error_check.cpp"
-   "common/execute_cuda_test.cuh" "common/test_cuda_basics.cuh"
-   "common/test_cuda_basics_functors.hpp" )
+   "common/execute_cuda_test.cuh" "common/test_cuda_basics.cuh" )
 target_include_directories( algebra_tests_cuda_common PUBLIC
    "${CMAKE_CURRENT_SOURCE_DIR}/common" )
 target_link_libraries( algebra_tests_cuda_common
    PUBLIC    CUDA::cudart
    INTERFACE GTest::gtest algebra::common algebra::tests_common
-             vecmem::core vecmem::cuda )
+             algebra::tests_accel_common vecmem::core vecmem::cuda )
 target_compile_options( algebra_tests_cuda_common INTERFACE
    $<$<COMPILE_LANGUAGE:CUDA>:-Xcudafe --diag_suppress=177>
    $<$<COMPILE_LANGUAGE:CUDA>:--ftz=false --prec-div=true>

--- a/tests/accelerator/sycl/CMakeLists.txt
+++ b/tests/accelerator/sycl/CMakeLists.txt
@@ -1,0 +1,28 @@
+# Algebra plugins library, part of the ACTS project (R&D line)
+#
+# (c) 2021-2022 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
+
+# Enable SYCL as a language.
+enable_language( SYCL )
+
+# Helper library for the SYCL tests.
+add_library( algebra_tests_sycl_common INTERFACE )
+target_include_directories( algebra_tests_sycl_common INTERFACE
+   "${CMAKE_CURRENT_SOURCE_DIR}/common" )
+target_link_libraries( algebra_tests_sycl_common
+   INTERFACE GTest::gtest algebra::tests_common algebra::tests_accel_common
+             vecmem::core vecmem::sycl )
+add_library( algebra::tests_sycl_common ALIAS algebra_tests_sycl_common )
+
+# Set up all of the (available) CUDA tests.
+algebra_add_test( array_sycl "array_cmath.sycl"
+   LINK_LIBRARIES algebra::array_cmath algebra::tests_sycl_common
+                  GTest::gtest_main )
+
+if( ALGEBRA_PLUGINS_INCLUDE_VECMEM )
+   algebra_add_test( vecmem_sycl "vecmem_cmath.sycl"
+      LINK_LIBRARIES algebra::vecmem_cmath algebra::tests_sycl_common
+                     GTest::gtest_main )
+endif()

--- a/tests/accelerator/sycl/array_cmath.sycl
+++ b/tests/accelerator/sycl/array_cmath.sycl
@@ -1,0 +1,49 @@
+/** Algebra plugins library, part of the ACTS project
+ *
+ * (c) 2020-2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Project include(s).
+#include "algebra/array_cmath.hpp"
+
+// Local include(s).
+#include "test_sycl_basics.hpp"
+
+// GoogleTest include(s).
+#include <gtest/gtest.h>
+
+// System include(s).
+#include <string>
+
+/// Struct providing a readable name for the test
+struct test_specialisation_name {
+  template <typename T>
+  static std::string GetName(int i) {
+    switch (i) {
+      case 0:
+        return "sycl_array_cmath<float>";
+      case 1:
+        return "sycl_array_cmath<double>";
+      default:
+        return "unknown";
+    }
+  }
+};
+
+// Instantiate the test(s).
+typedef testing::Types<
+    test_types<
+        float, algebra::array::point2<float>, algebra::array::point3<float>,
+        algebra::array::vector2<float>, algebra::array::vector3<float>,
+        algebra::array::transform3<float>, algebra::array::cartesian2<float>,
+        algebra::array::polar2<float>, algebra::array::cylindrical2<float> >,
+    test_types<
+        double, algebra::array::point2<double>, algebra::array::point3<double>,
+        algebra::array::vector2<double>, algebra::array::vector3<double>,
+        algebra::array::transform3<double>, algebra::array::cartesian2<double>,
+        algebra::array::polar2<double>, algebra::array::cylindrical2<double> > >
+    array_cmath_types;
+INSTANTIATE_TYPED_TEST_SUITE_P(algebra_plugins, test_sycl_basics,
+                               array_cmath_types, test_specialisation_name);

--- a/tests/accelerator/sycl/common/execute_sycl_test.hpp
+++ b/tests/accelerator/sycl/common/execute_sycl_test.hpp
@@ -1,0 +1,41 @@
+/** Algebra plugins library, part of the ACTS project
+ *
+ * (c) 2020-2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// SYCL include(s).
+#include <CL/sycl.hpp>
+
+// System include(s).
+#include <cstddef>
+
+/// Execute a test functor using SYCL, on @c arraySizes threads
+template <class FUNCTOR, class... ARGS>
+void execute_sycl_test(cl::sycl::queue& queue, std::size_t arraySizes,
+                       ARGS... args) {
+
+  // Submit a kernel that would run the specified functor.
+  queue
+      .submit([&](::sycl::handler& h) {
+        // Use parallel_for without specifying a "kernel class" explicitly.
+        // Unfortunately the FUNCTOR class is too complicated, and DPC++ dies
+        // on it. While providing a unique simple class for every template
+        // specialisation is also pretty impossible. :-(
+        h.parallel_for(cl::sycl::range<1>(arraySizes),
+                       [=](cl::sycl::item<1> id) {
+                         // Find the current index that we need to
+                         // process.
+                         const std::size_t i = id[0];
+                         if (i >= arraySizes) {
+                           return;
+                         }
+                         // Execute the test functor for this index.
+                         FUNCTOR()(i, args...);
+                       });
+      })
+      .wait_and_throw();
+}

--- a/tests/accelerator/sycl/vecmem_cmath.sycl
+++ b/tests/accelerator/sycl/vecmem_cmath.sycl
@@ -1,0 +1,50 @@
+/** Algebra plugins library, part of the ACTS project
+ *
+ * (c) 2020-2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Project include(s).
+#include "algebra/vecmem_cmath.hpp"
+
+// Local include(s).
+#include "test_sycl_basics.hpp"
+
+// GoogleTest include(s).
+#include <gtest/gtest.h>
+
+// System include(s).
+#include <string>
+
+/// Struct providing a readable name for the test
+struct test_specialisation_name {
+  template <typename T>
+  static std::string GetName(int i) {
+    switch (i) {
+      case 0:
+        return "sycl_vecmem_cmath<float>";
+      case 1:
+        return "sycl_vecmem_cmath<double>";
+      default:
+        return "unknown";
+    }
+  }
+};
+
+// Instantiate the test(s).
+typedef testing::Types<
+    test_types<
+        float, algebra::vecmem::point2<float>, algebra::vecmem::point3<float>,
+        algebra::vecmem::vector2<float>, algebra::vecmem::vector3<float>,
+        algebra::vecmem::transform3<float>, algebra::vecmem::cartesian2<float>,
+        algebra::vecmem::polar2<float>, algebra::vecmem::cylindrical2<float> >,
+    test_types<
+        double, algebra::vecmem::point2<double>,
+        algebra::vecmem::point3<double>, algebra::vecmem::vector2<double>,
+        algebra::vecmem::vector3<double>, algebra::vecmem::transform3<double>,
+        algebra::vecmem::cartesian2<double>, algebra::vecmem::polar2<double>,
+        algebra::vecmem::cylindrical2<double> > >
+    vecmem_cmath_types;
+INSTANTIATE_TYPED_TEST_SUITE_P(algebra_plugins, test_sycl_basics,
+                               vecmem_cmath_types, test_specialisation_name);


### PR DESCRIPTION
This -- in the end -- fairly substantial update was triggered by the errors seen in @konradkusiak97's developments in [traccc](https://github.com/acts-project/traccc). Which lead to the opening of the following ticket: https://github.com/intel/llvm/issues/5326

What we came across is that it would be impossible to use [std::atan2](https://en.cppreference.com/w/cpp/numeric/math/atan2) (and some other math functions) in SYCL device code on non-Intel backends. For the CUDA and HIP backends we must use `cl::sycl::atan2` instead.

For this I ended up introducing `algebra/math/common.hpp`, which would declare all of the "standard" math functions that we use in a couple of places in the code. This part was relatively simple.

But then I decided that we really also need to have explicit SYCL tests in place as well. Even if that test for now would only try to build the code for Intel backends. (For which the code was working as it was...) However once we introduce different SYCL backends for the [vecmem](https://github.com/acts-project/vecmem) CI, it should be relatively easy to introduce such tests here as well with this PR in place.

Pinging @beomki-yeo, @niermann999 and @HadrienG2. :wink: