### PR TITLE
Fix identity error in CUDA debug builds with Eigen

### DIFF
--- a/math/eigen/include/algebra/math/impl/eigen_transform3.hpp
+++ b/math/eigen/include/algebra/math/impl/eigen_transform3.hpp
@@ -87,11 +87,9 @@ struct transform3 {
   /// @name Data objects
   /// @{
 
-  Eigen::Transform<scalar_type, 3, Eigen::Affine> _data =
-      Eigen::Transform<scalar_type, 3, Eigen::Affine>::Identity();
+  Eigen::Transform<scalar_type, 3, Eigen::Affine> _data;
 
-  Eigen::Transform<scalar_type, 3, Eigen::Affine> _data_inv =
-      Eigen::Transform<scalar_type, 3, Eigen::Affine>::Identity();
+  Eigen::Transform<scalar_type, 3, Eigen::Affine> _data_inv;
 
   /// @}
 
@@ -122,6 +120,8 @@ struct transform3 {
    **/
   ALGEBRA_HOST_DEVICE
   transform3(const vector3 &t) {
+    _data.setIdentity();
+
     auto &matrix = _data.matrix();
     matrix.template block<3, 1>(0, 3) = t;
 
@@ -153,8 +153,14 @@ struct transform3 {
     _data_inv = _data.inverse();
   }
 
+  /** Default constructor: set contents to identity matrices */
+  ALGEBRA_HOST_DEVICE
+  transform3() {
+    _data.setIdentity();
+    _data_inv.setIdentity();
+  }
+
   /** Default contructors */
-  transform3() = default;
   transform3(const transform3 &rhs) = default;
   ~transform3() = default;
 


### PR DESCRIPTION
This is a fix to a bug that @krasznaa alerted me of yesterday, where under some very strict set of circumstances, the Eigen tests would fail to run, giving an invalid memory access error. For this to happen, the code must be compiled in `Debug` build mode.

Anyway, the error results from the fact that the matrices in our Eigen `transform3` class are all defaulted to the `Identity()` transformation. While this should be fine, it apparently does not work well with CUDA. Thus, the solution is to remove these defaults and explicitly set the matrices to identity matrices using `setIdentity()`.

Without going deep into the Eigen3 code, I can only speculate _why_ this bug happens. One semi-likely explanation might be that the identity matrices are stored in the `.data` or `.bss` sections of the executable in order to allow direct copies, and that this memory is not available on the GPU. However, I am not sure whether this is the case.