### PR TITLE
More MSVC Fixes, main branch (2022.02.04.)

### DIFF
--- a/math/cmath/include/algebra/math/impl/cmath_getter.hpp
+++ b/math/cmath/include/algebra/math/impl/cmath_getter.hpp
@@ -134,7 +134,7 @@ struct vector_getter {
   ALGEBRA_HOST_DEVICE inline result_type operator()(
       const matrix_type<ROWS, COLS> &m, std::size_t row, std::size_t col) {
 
-    result_type subvector;
+    result_type subvector{};
     for (std::size_t irow = row; irow < row + SIZE; ++irow) {
       subvector[irow - row] = m[col][irow];
     }

--- a/tests/common/test_host_basics.hpp
+++ b/tests/common/test_host_basics.hpp
@@ -171,6 +171,11 @@ TYPED_TEST_P(test_host_basics, transform3) {
   auto m44 = trf2.matrix();
   typename TypeParam::transform3 trfm(m44);
 
+  // Make sure that algebra::getter:vector can be called.
+  (void)algebra::getter::vector<3>(m44, 0, 0);
+  (void)algebra::getter::vector<3>(m44, 0, 1);
+  (void)algebra::getter::vector<3>(m44, 0, 2);
+
   // Re-evaluate rot and trn
   auto rotm = trfm.rotation();
   ASSERT_NEAR(element_getter(rotm, 0, 0), x[0], this->m_epsilon);


### PR DESCRIPTION
Fixed a warning coming from MSVC in `algebra::cmath::vector_getter`. It showed up while trying to build [detray](https://github.com/acts-project/detray) with MSVC. (Oh yeah, that is coming! MSVC complains about a lot of funky business in that project, for pretty good reasons...)

Added code for triggering the issue, so that this project would check that function explicitly as well. Even if the return value of that function is not checked. Because that return value is not independent of the plugin type being used...

Keeping it as a draft for now, as I'll only finalise it once detray builds successfully on Windows. :wink: