### PR TITLE
general matrix operations

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -29,7 +29,7 @@ jobs:
           - OS: "macos-latest"
             GENERATOR: "Xcode"
           - OS: "windows-latest"
-            GENERATOR: "Visual Studio 16 2019"
+            GENERATOR: "Visual Studio 17 2022"
 
     # The system to run on.
     runs-on: ${{ matrix.PLATFORM.OS }}

--- a/frontend/array_cmath/include/algebra/array_cmath.hpp
+++ b/frontend/array_cmath/include/algebra/array_cmath.hpp
@@ -29,11 +29,11 @@ namespace array {
 template <typename T>
 using transform3 = cmath::transform3<std::size_t, array::storage_type, T>;
 template <typename T>
-using cartesian2 = cmath::cartesian2<transform3<T> >;
+using cartesian2 = cmath::cartesian2<transform3<T>>;
 template <typename T>
-using polar2 = cmath::polar2<transform3<T> >;
+using polar2 = cmath::polar2<transform3<T>>;
 template <typename T>
-using cylindrical2 = cmath::cylindrical2<transform3<T> >;
+using cylindrical2 = cmath::cylindrical2<transform3<T>>;
 
 /// @}
 
@@ -84,4 +84,77 @@ using cmath::normalize;
 /// @}
 
 }  // namespace vector
+
+namespace matrix {
+
+template <typename T, std::size_t ROWS, std::size_t COLS>
+using matrix_type = array::matrix_type<T, ROWS, COLS>;
+
+template <typename size_type, typename scalar_t>
+using element_getter_type =
+    cmath::element_getter<size_type, array::storage_type, scalar_t>;
+
+// matrix actor
+template <typename size_type, typename scalar_t, typename determinant_actor_t,
+          typename inverse_actor_t>
+using actor = cmath::matrix::actor<size_type, matrix_type, scalar_t,
+                                   determinant_actor_t, inverse_actor_t,
+                                   element_getter_type<size_type, scalar_t>>;
+
+namespace determinant {
+
+// determinant aggregation
+template <typename size_type, typename scalar_t, class... As>
+using actor =
+    cmath::matrix::determinant::actor<size_type, matrix_type, scalar_t, As...>;
+
+// determinant::cofactor
+template <typename size_type, typename scalar_t, size_type... Ds>
+using cofactor = cmath::matrix::determinant::cofactor<
+    size_type, matrix_type, scalar_t, element_getter_type<size_type, scalar_t>,
+    Ds...>;
+
+// determinant::hard_coded
+template <typename size_type, typename scalar_t, size_type... Ds>
+using hard_coded = cmath::matrix::determinant::hard_coded<
+    size_type, matrix_type, scalar_t, element_getter_type<size_type, scalar_t>,
+    Ds...>;
+
+// preset0
+template <typename size_type, typename scalar_t>
+using preset0 = actor<size_type, scalar_t, cofactor<size_type, scalar_t>,
+                      hard_coded<size_type, scalar_t, 2>>;
+
+}  // namespace determinant
+
+namespace inverse {
+
+// inverion aggregation
+template <typename size_type, typename scalar_t, class... As>
+using actor =
+    cmath::matrix::inverse::actor<size_type, matrix_type, scalar_t, As...>;
+
+// inverse::cofactor
+template <typename size_type, typename scalar_t, size_type... Ds>
+using cofactor =
+    cmath::matrix::inverse::cofactor<size_type, matrix_type, scalar_t,
+                                     element_getter_type<size_type, scalar_t>,
+                                     Ds...>;
+
+// inverse::hard_coded
+template <typename size_type, typename scalar_t, size_type... Ds>
+using hard_coded =
+    cmath::matrix::inverse::hard_coded<size_type, matrix_type, scalar_t,
+                                       element_getter_type<size_type, scalar_t>,
+                                       Ds...>;
+
+// preset0
+template <typename size_type, typename scalar_t>
+using preset0 = actor<size_type, scalar_t, cofactor<size_type, scalar_t>,
+                      hard_coded<size_type, scalar_t, 2>>;
+
+}  // namespace inverse
+
+}  // namespace matrix
+
 }  // namespace algebra

--- a/frontend/array_cmath/include/algebra/array_cmath.hpp
+++ b/frontend/array_cmath/include/algebra/array_cmath.hpp
@@ -120,7 +120,7 @@ using hard_coded = cmath::matrix::determinant::hard_coded<
     size_type, matrix_type, scalar_t, element_getter_type<size_type, scalar_t>,
     Ds...>;
 
-// preset0
+// preset(s) as standard option(s) for user's convenience
 template <typename size_type, typename scalar_t>
 using preset0 = actor<size_type, scalar_t, cofactor<size_type, scalar_t>,
                       hard_coded<size_type, scalar_t, 2>>;
@@ -148,7 +148,7 @@ using hard_coded =
                                        element_getter_type<size_type, scalar_t>,
                                        Ds...>;
 
-// preset0
+// preset(s) as standard option(s) for user's convenience
 template <typename size_type, typename scalar_t>
 using preset0 = actor<size_type, scalar_t, cofactor<size_type, scalar_t>,
                       hard_coded<size_type, scalar_t, 2>>;

--- a/frontend/eigen_cmath/include/algebra/eigen_cmath.hpp
+++ b/frontend/eigen_cmath/include/algebra/eigen_cmath.hpp
@@ -120,7 +120,7 @@ using hard_coded =
     cmath::matrix::determinant::hard_coded<size_type, matrix_type, scalar_t,
                                            element_getter_type, Ds...>;
 
-// preset0
+// preset(s) as standard option(s) for user's convenience
 template <typename size_type, typename scalar_t>
 using preset0 = actor<size_type, scalar_t, cofactor<size_type, scalar_t>,
                       hard_coded<size_type, scalar_t, 2>>;
@@ -146,7 +146,7 @@ using hard_coded =
     cmath::matrix::inverse::hard_coded<size_type, matrix_type, scalar_t,
                                        element_getter_type, Ds...>;
 
-// preset0
+// preset(s) as standard option(s) for user's convenience
 template <typename size_type, typename scalar_t>
 using preset0 = actor<size_type, scalar_t, cofactor<size_type, scalar_t>,
                       hard_coded<size_type, scalar_t, 2>>;

--- a/frontend/eigen_cmath/include/algebra/eigen_cmath.hpp
+++ b/frontend/eigen_cmath/include/algebra/eigen_cmath.hpp
@@ -30,15 +30,15 @@ namespace eigen {
 
 template <typename T>
 using transform3 = cmath::transform3<
-    std::size_t, eigen::storage_type, T,
+    int, eigen::storage_type, T,
     typename Eigen::Transform<T, 3, Eigen::Affine>::MatrixType,
     math::element_getter, math::block_getter>;
 template <typename T>
-using cartesian2 = cmath::cartesian2<transform3<T> >;
+using cartesian2 = cmath::cartesian2<transform3<T>>;
 template <typename T>
-using polar2 = cmath::polar2<transform3<T> >;
+using polar2 = cmath::polar2<transform3<T>>;
 template <typename T>
-using cylindrical2 = cmath::cylindrical2<transform3<T> >;
+using cylindrical2 = cmath::cylindrical2<transform3<T>>;
 
 /// @}
 
@@ -87,4 +87,72 @@ using eigen::math::normalize;
 /// @}
 
 }  // namespace vector
+
+namespace matrix {
+
+template <typename T, int ROWS, int COLS>
+using matrix_type = eigen::matrix_type<T, ROWS, COLS>;
+using element_getter_type = eigen::math::element_getter;
+
+// matrix actor
+template <typename size_type, typename scalar_t, typename determinant_actor_t,
+          typename inverse_actor_t>
+using actor =
+    cmath::matrix::actor<size_type, matrix_type, scalar_t, determinant_actor_t,
+                         inverse_actor_t, element_getter_type>;
+
+namespace determinant {
+
+// determinant aggregation
+template <typename size_type, typename scalar_t, class... As>
+using actor =
+    cmath::matrix::determinant::actor<size_type, matrix_type, scalar_t, As...>;
+
+// determinant::cofactor
+template <typename size_type, typename scalar_t, size_type... Ds>
+using cofactor =
+    cmath::matrix::determinant::cofactor<size_type, matrix_type, scalar_t,
+                                         element_getter_type, Ds...>;
+
+// determinant::hard_coded
+template <typename size_type, typename scalar_t, size_type... Ds>
+using hard_coded =
+    cmath::matrix::determinant::hard_coded<size_type, matrix_type, scalar_t,
+                                           element_getter_type, Ds...>;
+
+// preset0
+template <typename size_type, typename scalar_t>
+using preset0 = actor<size_type, scalar_t, cofactor<size_type, scalar_t>,
+                      hard_coded<size_type, scalar_t, 2>>;
+
+}  // namespace determinant
+
+namespace inverse {
+
+// inverion aggregation
+template <typename size_type, typename scalar_t, class... As>
+using actor =
+    cmath::matrix::inverse::actor<size_type, matrix_type, scalar_t, As...>;
+
+// inverse::cofactor
+template <typename size_type, typename scalar_t, size_type... Ds>
+using cofactor =
+    cmath::matrix::inverse::cofactor<size_type, matrix_type, scalar_t,
+                                     element_getter_type, Ds...>;
+
+// inverse::hard_coded
+template <typename size_type, typename scalar_t, size_type... Ds>
+using hard_coded =
+    cmath::matrix::inverse::hard_coded<size_type, matrix_type, scalar_t,
+                                       element_getter_type, Ds...>;
+
+// preset0
+template <typename size_type, typename scalar_t>
+using preset0 = actor<size_type, scalar_t, cofactor<size_type, scalar_t>,
+                      hard_coded<size_type, scalar_t, 2>>;
+
+}  // namespace inverse
+
+}  // namespace matrix
+
 }  // namespace algebra

--- a/frontend/eigen_eigen/include/algebra/eigen_eigen.hpp
+++ b/frontend/eigen_eigen/include/algebra/eigen_eigen.hpp
@@ -81,4 +81,12 @@ using eigen::math::normalize;
 /// @}
 
 }  // namespace vector
+
+namespace matrix {
+
+template <typename scalar_t>
+using actor = eigen::matrix::actor<scalar_t>;
+
+}  // namespace matrix
+
 }  // namespace algebra

--- a/frontend/smatrix_cmath/include/algebra/smatrix_cmath.hpp
+++ b/frontend/smatrix_cmath/include/algebra/smatrix_cmath.hpp
@@ -115,7 +115,7 @@ template <typename size_type, typename scalar_t, size_type... Ds>
 using hard_coded = cmath::matrix::determinant::hard_coded<
     size_type, matrix_type, scalar_t, element_getter_type<scalar_t>, Ds...>;
 
-// preset0
+// preset(s) as standard option(s) for user's convenience
 template <typename size_type, typename scalar_t>
 using preset0 = actor<size_type, scalar_t, cofactor<size_type, scalar_t>,
                       hard_coded<size_type, scalar_t, 2>>;
@@ -141,7 +141,7 @@ using hard_coded =
     cmath::matrix::inverse::hard_coded<size_type, matrix_type, scalar_t,
                                        element_getter_type<scalar_t>, Ds...>;
 
-// preset0
+// preset(s) as standard option(s) for user's convenience
 template <typename size_type, typename scalar_t>
 using preset0 = actor<size_type, scalar_t, cofactor<size_type, scalar_t>,
                       hard_coded<size_type, scalar_t, 2>>;

--- a/frontend/smatrix_cmath/include/algebra/smatrix_cmath.hpp
+++ b/frontend/smatrix_cmath/include/algebra/smatrix_cmath.hpp
@@ -25,13 +25,13 @@ template <typename T>
 using transform3 =
     cmath::transform3<unsigned int, smatrix::storage_type, T,
                       ROOT::Math::SMatrix<T, 4, 4>, math::element_getter<T>,
-                      math::block_getter<T> >;
+                      math::block_getter<T>>;
 template <typename T>
-using cartesian2 = cmath::cartesian2<transform3<T> >;
+using cartesian2 = cmath::cartesian2<transform3<T>>;
 template <typename T>
-using polar2 = cmath::polar2<transform3<T> >;
+using polar2 = cmath::polar2<transform3<T>>;
 template <typename T>
-using cylindrical2 = cmath::cylindrical2<transform3<T> >;
+using cylindrical2 = cmath::cylindrical2<transform3<T>>;
 
 /// @}
 
@@ -58,7 +58,7 @@ ALGEBRA_HOST_DEVICE inline auto vector(
     const ROOT::Math::SMatrix<scalar_t, ROWS, COLS>& m, unsigned int row,
     unsigned int col) {
 
-  return m.template SubCol<smatrix::storage_type<scalar_t, SIZE> >(col, row);
+  return m.template SubCol<smatrix::storage_type<scalar_t, SIZE>>(col, row);
 }
 
 /// @name Getter functions on @c algebra::smatrix::matrix_type
@@ -82,4 +82,72 @@ using smatrix::math::normalize;
 /// @}
 
 }  // namespace vector
+
+namespace matrix {
+
+template <typename T, unsigned int ROWS, unsigned int COLS>
+using matrix_type = smatrix::matrix_type<T, ROWS, COLS>;
+template <typename scalar_t>
+using element_getter_type = smatrix::math::element_getter<scalar_t>;
+
+// matrix actor
+template <typename size_type, typename scalar_t, typename determinant_actor_t,
+          typename inverse_actor_t>
+using actor =
+    cmath::matrix::actor<size_type, matrix_type, scalar_t, determinant_actor_t,
+                         inverse_actor_t, element_getter_type<scalar_t>>;
+
+namespace determinant {
+
+// determinant aggregation
+template <typename size_type, typename scalar_t, class... As>
+using actor =
+    cmath::matrix::determinant::actor<size_type, matrix_type, scalar_t, As...>;
+
+// determinant::cofactor
+template <typename size_type, typename scalar_t, size_type... Ds>
+using cofactor =
+    cmath::matrix::determinant::cofactor<size_type, matrix_type, scalar_t,
+                                         element_getter_type<scalar_t>, Ds...>;
+
+// determinant::hard_coded
+template <typename size_type, typename scalar_t, size_type... Ds>
+using hard_coded = cmath::matrix::determinant::hard_coded<
+    size_type, matrix_type, scalar_t, element_getter_type<scalar_t>, Ds...>;
+
+// preset0
+template <typename size_type, typename scalar_t>
+using preset0 = actor<size_type, scalar_t, cofactor<size_type, scalar_t>,
+                      hard_coded<size_type, scalar_t, 2>>;
+
+}  // namespace determinant
+
+namespace inverse {
+
+// inverion aggregation
+template <typename size_type, typename scalar_t, class... As>
+using actor =
+    cmath::matrix::inverse::actor<size_type, matrix_type, scalar_t, As...>;
+
+// inverse::cofactor
+template <typename size_type, typename scalar_t, size_type... Ds>
+using cofactor =
+    cmath::matrix::inverse::cofactor<size_type, matrix_type, scalar_t,
+                                     element_getter_type<scalar_t>, Ds...>;
+
+// inverse::hard_coded
+template <typename size_type, typename scalar_t, size_type... Ds>
+using hard_coded =
+    cmath::matrix::inverse::hard_coded<size_type, matrix_type, scalar_t,
+                                       element_getter_type<scalar_t>, Ds...>;
+
+// preset0
+template <typename size_type, typename scalar_t>
+using preset0 = actor<size_type, scalar_t, cofactor<size_type, scalar_t>,
+                      hard_coded<size_type, scalar_t, 2>>;
+
+}  // namespace inverse
+
+}  // namespace matrix
+
 }  // namespace algebra

--- a/frontend/smatrix_smatrix/include/algebra/smatrix_smatrix.hpp
+++ b/frontend/smatrix_smatrix/include/algebra/smatrix_smatrix.hpp
@@ -75,4 +75,12 @@ using smatrix::math::normalize;
 /// @}
 
 }  // namespace vector
+
+namespace matrix {
+
+template <typename scalar_t>
+using actor = smatrix::matrix::actor<scalar_t>;
+
+}  // namespace matrix
+
 }  // namespace algebra

--- a/frontend/vc_cmath/include/algebra/vc_cmath.hpp
+++ b/frontend/vc_cmath/include/algebra/vc_cmath.hpp
@@ -38,13 +38,13 @@ using transform3 =
                       Vc::array<Vc::array<T, 4>, 4>,
                       cmath::element_getter<std::size_t, Vc::array, T>,
                       cmath::block_getter<std::size_t, Vc::array, T>,
-                      vc::vector3<T>, vc::point2<T> >;
+                      vc::vector3<T>, vc::point2<T>>;
 template <typename T>
-using cartesian2 = cmath::cartesian2<transform3<T> >;
+using cartesian2 = cmath::cartesian2<transform3<T>>;
 template <typename T>
-using polar2 = cmath::polar2<transform3<T> >;
+using polar2 = cmath::polar2<transform3<T>>;
 template <typename T>
-using cylindrical2 = cmath::cylindrical2<transform3<T> >;
+using cylindrical2 = cmath::cylindrical2<transform3<T>>;
 
 /// @}
 
@@ -78,7 +78,7 @@ ALGEBRA_HOST_DEVICE inline vc::storage_type<scalar_t, SIZE> vector(
     std::size_t col) {
 
   return cmath::vector_getter<std::size_t, Vc::array, scalar_t, SIZE,
-                              vc::storage_type<scalar_t, SIZE> >()(m, row, col);
+                              vc::storage_type<scalar_t, SIZE>>()(m, row, col);
 }
 
 /// @name Getter functions on @c algebra::vc::matrix_type
@@ -106,4 +106,77 @@ using vc::math::normalize;
 /// @}
 
 }  // namespace vector
+
+namespace matrix {
+
+template <typename T, std::size_t ROWS, std::size_t COLS>
+using matrix_type = vc::matrix_type<T, ROWS, COLS>;
+
+template <typename size_type, typename scalar_t>
+using element_getter_type =
+    cmath::element_getter<size_type, Vc::array, scalar_t>;
+
+// matrix actor
+template <typename size_type, typename scalar_t, typename determinant_actor_t,
+          typename inverse_actor_t>
+using actor = cmath::matrix::actor<size_type, matrix_type, scalar_t,
+                                   determinant_actor_t, inverse_actor_t,
+                                   element_getter_type<size_type, scalar_t>>;
+
+namespace determinant {
+
+// determinant aggregation
+template <typename size_type, typename scalar_t, class... As>
+using actor =
+    cmath::matrix::determinant::actor<size_type, matrix_type, scalar_t, As...>;
+
+// determinant::cofactor
+template <typename size_type, typename scalar_t, size_type... Ds>
+using cofactor = cmath::matrix::determinant::cofactor<
+    size_type, matrix_type, scalar_t, element_getter_type<size_type, scalar_t>,
+    Ds...>;
+
+// determinant::hard_coded
+template <typename size_type, typename scalar_t, size_type... Ds>
+using hard_coded = cmath::matrix::determinant::hard_coded<
+    size_type, matrix_type, scalar_t, element_getter_type<size_type, scalar_t>,
+    Ds...>;
+
+// preset0
+template <typename size_type, typename scalar_t>
+using preset0 = actor<size_type, scalar_t, cofactor<size_type, scalar_t>,
+                      hard_coded<size_type, scalar_t, 2>>;
+
+}  // namespace determinant
+
+namespace inverse {
+
+// inverion aggregation
+template <typename size_type, typename scalar_t, class... As>
+using actor =
+    cmath::matrix::inverse::actor<size_type, matrix_type, scalar_t, As...>;
+
+// inverse::cofactor
+template <typename size_type, typename scalar_t, size_type... Ds>
+using cofactor =
+    cmath::matrix::inverse::cofactor<size_type, matrix_type, scalar_t,
+                                     element_getter_type<size_type, scalar_t>,
+                                     Ds...>;
+
+// inverse::hard_coded
+template <typename size_type, typename scalar_t, size_type... Ds>
+using hard_coded =
+    cmath::matrix::inverse::hard_coded<size_type, matrix_type, scalar_t,
+                                       element_getter_type<size_type, scalar_t>,
+                                       Ds...>;
+
+// preset0
+template <typename size_type, typename scalar_t>
+using preset0 = actor<size_type, scalar_t, cofactor<size_type, scalar_t>,
+                      hard_coded<size_type, scalar_t, 2>>;
+
+}  // namespace inverse
+
+}  // namespace matrix
+
 }  // namespace algebra

--- a/frontend/vc_cmath/include/algebra/vc_cmath.hpp
+++ b/frontend/vc_cmath/include/algebra/vc_cmath.hpp
@@ -142,7 +142,7 @@ using hard_coded = cmath::matrix::determinant::hard_coded<
     size_type, matrix_type, scalar_t, element_getter_type<size_type, scalar_t>,
     Ds...>;
 
-// preset0
+// preset(s) as standard option(s) for user's convenience
 template <typename size_type, typename scalar_t>
 using preset0 = actor<size_type, scalar_t, cofactor<size_type, scalar_t>,
                       hard_coded<size_type, scalar_t, 2>>;
@@ -170,7 +170,7 @@ using hard_coded =
                                        element_getter_type<size_type, scalar_t>,
                                        Ds...>;
 
-// preset0
+// preset(s) as standard option(s) for user's convenience
 template <typename size_type, typename scalar_t>
 using preset0 = actor<size_type, scalar_t, cofactor<size_type, scalar_t>,
                       hard_coded<size_type, scalar_t, 2>>;

--- a/frontend/vc_vc/include/algebra/vc_vc.hpp
+++ b/frontend/vc_vc/include/algebra/vc_vc.hpp
@@ -181,7 +181,7 @@ using hard_coded = cmath::matrix::determinant::hard_coded<
     size_type, matrix_type, scalar_t, element_getter_type<size_type, scalar_t>,
     Ds...>;
 
-// preset0
+// preset(s) as standard option(s) for user's convenience
 template <typename size_type, typename scalar_t>
 using preset0 = actor<size_type, scalar_t, cofactor<size_type, scalar_t>,
                       hard_coded<size_type, scalar_t, 2>>;
@@ -209,7 +209,7 @@ using hard_coded =
                                        element_getter_type<size_type, scalar_t>,
                                        Ds...>;
 
-// preset0
+// preset(s) as standard option(s) for user's convenience
 template <typename size_type, typename scalar_t>
 using preset0 = actor<size_type, scalar_t, cofactor<size_type, scalar_t>,
                       hard_coded<size_type, scalar_t, 2>>;

--- a/frontend/vc_vc/include/algebra/vc_vc.hpp
+++ b/frontend/vc_vc/include/algebra/vc_vc.hpp
@@ -36,13 +36,13 @@ using math::perp;
 using math::phi;
 
 template <typename T>
-using transform3 = math::transform3<storage_type, T, vector3<T>, point2<T> >;
+using transform3 = math::transform3<storage_type, T, vector3<T>, point2<T>>;
 template <typename T>
-using cartesian2 = cmath::cartesian2<transform3<T> >;
+using cartesian2 = cmath::cartesian2<transform3<T>>;
 template <typename T>
-using polar2 = cmath::polar2<transform3<T> >;
+using polar2 = cmath::polar2<transform3<T>>;
 template <typename T>
-using cylindrical2 = cmath::cylindrical2<transform3<T> >;
+using cylindrical2 = cmath::cylindrical2<transform3<T>>;
 
 /// @}
 
@@ -145,4 +145,77 @@ using vc::math::normalize;
 /// @}
 
 }  // namespace vector
+
+namespace matrix {
+
+template <typename T, std::size_t ROWS, std::size_t COLS>
+using matrix_type = vc::matrix_type<T, ROWS, COLS>;
+
+template <typename size_type, typename scalar_t>
+using element_getter_type =
+    cmath::element_getter<size_type, Vc::array, scalar_t>;
+
+// matrix actor
+template <typename size_type, typename scalar_t, typename determinant_actor_t,
+          typename inverse_actor_t>
+using actor = cmath::matrix::actor<size_type, matrix_type, scalar_t,
+                                   determinant_actor_t, inverse_actor_t,
+                                   element_getter_type<size_type, scalar_t>>;
+
+namespace determinant {
+
+// determinant aggregation
+template <typename size_type, typename scalar_t, class... As>
+using actor =
+    cmath::matrix::determinant::actor<size_type, matrix_type, scalar_t, As...>;
+
+// determinant::cofactor
+template <typename size_type, typename scalar_t, size_type... Ds>
+using cofactor = cmath::matrix::determinant::cofactor<
+    size_type, matrix_type, scalar_t, element_getter_type<size_type, scalar_t>,
+    Ds...>;
+
+// determinant::hard_coded
+template <typename size_type, typename scalar_t, size_type... Ds>
+using hard_coded = cmath::matrix::determinant::hard_coded<
+    size_type, matrix_type, scalar_t, element_getter_type<size_type, scalar_t>,
+    Ds...>;
+
+// preset0
+template <typename size_type, typename scalar_t>
+using preset0 = actor<size_type, scalar_t, cofactor<size_type, scalar_t>,
+                      hard_coded<size_type, scalar_t, 2>>;
+
+}  // namespace determinant
+
+namespace inverse {
+
+// inverion aggregation
+template <typename size_type, typename scalar_t, class... As>
+using actor =
+    cmath::matrix::inverse::actor<size_type, matrix_type, scalar_t, As...>;
+
+// inverse::cofactor
+template <typename size_type, typename scalar_t, size_type... Ds>
+using cofactor =
+    cmath::matrix::inverse::cofactor<size_type, matrix_type, scalar_t,
+                                     element_getter_type<size_type, scalar_t>,
+                                     Ds...>;
+
+// inverse::hard_coded
+template <typename size_type, typename scalar_t, size_type... Ds>
+using hard_coded =
+    cmath::matrix::inverse::hard_coded<size_type, matrix_type, scalar_t,
+                                       element_getter_type<size_type, scalar_t>,
+                                       Ds...>;
+
+// preset0
+template <typename size_type, typename scalar_t>
+using preset0 = actor<size_type, scalar_t, cofactor<size_type, scalar_t>,
+                      hard_coded<size_type, scalar_t, 2>>;
+
+}  // namespace inverse
+
+}  // namespace matrix
+
 }  // namespace algebra

--- a/frontend/vecmem_cmath/include/algebra/vecmem_cmath.hpp
+++ b/frontend/vecmem_cmath/include/algebra/vecmem_cmath.hpp
@@ -29,11 +29,11 @@ namespace vecmem {
 template <typename T>
 using transform3 = cmath::transform3<std::size_t, vecmem::storage_type, T>;
 template <typename T>
-using cartesian2 = cmath::cartesian2<transform3<T> >;
+using cartesian2 = cmath::cartesian2<transform3<T>>;
 template <typename T>
-using polar2 = cmath::polar2<transform3<T> >;
+using polar2 = cmath::polar2<transform3<T>>;
 template <typename T>
-using cylindrical2 = cmath::cylindrical2<transform3<T> >;
+using cylindrical2 = cmath::cylindrical2<transform3<T>>;
 
 /// @}
 
@@ -85,4 +85,77 @@ using cmath::normalize;
 /// @}
 
 }  // namespace vector
+
+namespace matrix {
+
+template <typename T, std::size_t ROWS, std::size_t COLS>
+using matrix_type = vecmem::matrix_type<T, ROWS, COLS>;
+
+template <typename size_type, typename scalar_t>
+using element_getter_type =
+    cmath::element_getter<size_type, vecmem::storage_type, scalar_t>;
+
+// matrix actor
+template <typename size_type, typename scalar_t, typename determinant_actor_t,
+          typename inverse_actor_t>
+using actor = cmath::matrix::actor<size_type, matrix_type, scalar_t,
+                                   determinant_actor_t, inverse_actor_t,
+                                   element_getter_type<size_type, scalar_t>>;
+
+namespace determinant {
+
+// determinant aggregation
+template <typename size_type, typename scalar_t, class... As>
+using actor =
+    cmath::matrix::determinant::actor<size_type, matrix_type, scalar_t, As...>;
+
+// determinant::cofactor
+template <typename size_type, typename scalar_t, size_type... Ds>
+using cofactor = cmath::matrix::determinant::cofactor<
+    size_type, matrix_type, scalar_t, element_getter_type<size_type, scalar_t>,
+    Ds...>;
+
+// determinant::hard_coded
+template <typename size_type, typename scalar_t, size_type... Ds>
+using hard_coded = cmath::matrix::determinant::hard_coded<
+    size_type, matrix_type, scalar_t, element_getter_type<size_type, scalar_t>,
+    Ds...>;
+
+// preset0
+template <typename size_type, typename scalar_t>
+using preset0 = actor<size_type, scalar_t, cofactor<size_type, scalar_t>,
+                      hard_coded<size_type, scalar_t, 2>>;
+
+}  // namespace determinant
+
+namespace inverse {
+
+// inverion aggregation
+template <typename size_type, typename scalar_t, class... As>
+using actor =
+    cmath::matrix::inverse::actor<size_type, matrix_type, scalar_t, As...>;
+
+// inverse::cofactor
+template <typename size_type, typename scalar_t, size_type... Ds>
+using cofactor =
+    cmath::matrix::inverse::cofactor<size_type, matrix_type, scalar_t,
+                                     element_getter_type<size_type, scalar_t>,
+                                     Ds...>;
+
+// inverse::hard_coded
+template <typename size_type, typename scalar_t, size_type... Ds>
+using hard_coded =
+    cmath::matrix::inverse::hard_coded<size_type, matrix_type, scalar_t,
+                                       element_getter_type<size_type, scalar_t>,
+                                       Ds...>;
+
+// preset0
+template <typename size_type, typename scalar_t>
+using preset0 = actor<size_type, scalar_t, cofactor<size_type, scalar_t>,
+                      hard_coded<size_type, scalar_t, 2>>;
+
+}  // namespace inverse
+
+}  // namespace matrix
+
 }  // namespace algebra

--- a/frontend/vecmem_cmath/include/algebra/vecmem_cmath.hpp
+++ b/frontend/vecmem_cmath/include/algebra/vecmem_cmath.hpp
@@ -121,7 +121,7 @@ using hard_coded = cmath::matrix::determinant::hard_coded<
     size_type, matrix_type, scalar_t, element_getter_type<size_type, scalar_t>,
     Ds...>;
 
-// preset0
+// preset(s) as standard option(s) for user's convenience
 template <typename size_type, typename scalar_t>
 using preset0 = actor<size_type, scalar_t, cofactor<size_type, scalar_t>,
                       hard_coded<size_type, scalar_t, 2>>;
@@ -149,7 +149,7 @@ using hard_coded =
                                        element_getter_type<size_type, scalar_t>,
                                        Ds...>;
 
-// preset0
+// preset(s) as standard option(s) for user's convenience
 template <typename size_type, typename scalar_t>
 using preset0 = actor<size_type, scalar_t, cofactor<size_type, scalar_t>,
                       hard_coded<size_type, scalar_t, 2>>;

--- a/math/cmath/CMakeLists.txt
+++ b/math/cmath/CMakeLists.txt
@@ -6,13 +6,21 @@
 
 # Set up the library.
 algebra_add_library( algebra_cmath_math cmath_math
+   # impl include
    "include/algebra/math/cmath.hpp"
    "include/algebra/math/impl/cmath_cartesian2.hpp"
    "include/algebra/math/impl/cmath_cylindrical2.hpp"
    "include/algebra/math/impl/cmath_getter.hpp"
+   "include/algebra/math/impl/cmath_matrix.hpp"
    "include/algebra/math/impl/cmath_operator.hpp"
    "include/algebra/math/impl/cmath_polar2.hpp"
    "include/algebra/math/impl/cmath_transform3.hpp"
-   "include/algebra/math/impl/cmath_vector.hpp" )
+   "include/algebra/math/impl/cmath_vector.hpp"
+   # algorithms include
+   "include/algebra/math/algorithms/matrix/determinant/cofactor.hpp"
+   "include/algebra/math/algorithms/matrix/determinant/hard_coded.hpp"
+   "include/algebra/math/algorithms/matrix/inverse/cofactor.hpp"
+   "include/algebra/math/algorithms/matrix/inverse/hard_coded.hpp"
+   "include/algebra/math/algorithms/utils/algorithm_finder.hpp" )
 target_link_libraries( algebra_cmath_math
    INTERFACE algebra::common algebra::common_math )

--- a/math/cmath/include/algebra/math/algorithms/matrix/determinant/cofactor.hpp
+++ b/math/cmath/include/algebra/math/algorithms/matrix/determinant/cofactor.hpp
@@ -1,0 +1,109 @@
+/** Algebra plugins library, part of the ACTS project
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s).
+#include "algebra/qualifiers.hpp"
+
+// System include(s)
+#include <type_traits>
+
+namespace algebra::cmath::matrix::determinant {
+
+/// "Determinant getter", assuming a N X N matrix
+template <typename size_type,
+          template <typename, size_type, size_type> class matrix_t,
+          typename scalar_t, class element_getter_t, size_type... Ds>
+struct cofactor {
+
+  using _dims = std::integer_sequence<size_type, Ds...>;
+
+  /// Function (object) used for accessing a matrix element
+  using element_getter = element_getter_t;
+
+  /// 2D matrix type
+  template <size_type ROWS, size_type COLS>
+  using matrix_type = matrix_t<scalar_t, ROWS, COLS>;
+
+  template <size_type N>
+  ALGEBRA_HOST_DEVICE inline scalar_t operator()(
+      const matrix_type<N, N> &m) const {
+    return determinant_getter_helper<N>()(m);
+  }
+
+  template <size_type N, typename Enable = void>
+  struct determinant_getter_helper;
+
+  template <size_type N>
+  struct determinant_getter_helper<N, typename std::enable_if_t<N == 1>> {
+    template <class input_matrix_type>
+    ALGEBRA_HOST_DEVICE inline scalar_t operator()(
+        const input_matrix_type &m) const {
+      return element_getter()(m, 0, 0);
+    }
+  };
+
+  template <size_type N>
+  struct determinant_getter_helper<N, typename std::enable_if_t<N != 1>> {
+
+    template <class input_matrix_type>
+    ALGEBRA_HOST_DEVICE inline scalar_t operator()(
+        const input_matrix_type &m) const {
+
+      scalar_t D = 0;
+
+      // To store cofactors
+      matrix_type<N, N> temp;
+
+      // To store sign multiplier
+      int sign = 1;
+
+      // Iterate for each element of first row
+      for (size_type col = 0; col < N; col++) {
+        // Getting Cofactor of A[0][f]
+        this->get_cofactor(m, temp, size_type(0), col);
+        D += sign * element_getter()(m, 0, col) *
+             determinant_getter_helper<N - 1>()(temp);
+
+        // terms are to be added with alternate sign
+        sign = -sign;
+      }
+
+      return D;
+    }
+
+    template <class input_matrix_type>
+    ALGEBRA_HOST_DEVICE inline void get_cofactor(const input_matrix_type &m,
+                                                 matrix_type<N, N> &temp,
+                                                 size_type p,
+                                                 size_type q) const {
+
+      size_type i = 0, j = 0;
+
+      // Looping for each element of the matrix
+      for (size_type row = 0; row < N; row++) {
+        for (size_type col = 0; col < N; col++) {
+          //  Copying into temporary matrix only those element
+          //  which are not in given row and column
+          if (row != p && col != q) {
+            element_getter()(temp, i, j++) = element_getter()(m, row, col);
+
+            // Row is filled, so increase row index and
+            // reset col index
+            if (j == N - 1) {
+              j = 0;
+              i++;
+            }
+          }
+        }
+      }
+    }
+  };
+};
+
+}  // namespace algebra::cmath::matrix::determinant

--- a/math/cmath/include/algebra/math/algorithms/matrix/determinant/hard_coded.hpp
+++ b/math/cmath/include/algebra/math/algorithms/matrix/determinant/hard_coded.hpp
@@ -1,0 +1,45 @@
+/** Algebra plugins library, part of the ACTS project
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s).
+#include "algebra/qualifiers.hpp"
+
+// System include(s)
+#include <type_traits>
+
+namespace algebra::cmath::matrix::determinant {
+
+/// "Determinant getter", assuming a N X N matrix
+template <typename size_type,
+          template <typename, size_type, size_type> class matrix_t,
+          typename scalar_t, class element_getter_t, size_type... Ds>
+struct hard_coded {
+
+  using _dims = std::integer_sequence<size_type, Ds...>;
+
+  /// Function (object) used for accessing a matrix element
+  using element_getter = element_getter_t;
+
+  /// 2D matrix type
+  template <size_type ROWS, size_type COLS>
+  using matrix_type = matrix_t<scalar_t, ROWS, COLS>;
+
+  // 2 X 2 matrix determinant
+  template <size_type N, std::enable_if_t<N == 2, bool> = true>
+  ALGEBRA_HOST_DEVICE inline scalar_t operator()(
+      const matrix_type<N, N> &m) const {
+
+    scalar_t det = element_getter()(m, 0, 0) * element_getter()(m, 1, 1) -
+                   element_getter()(m, 0, 1) * element_getter()(m, 1, 0);
+
+    return det;
+  }
+};
+
+}  // namespace algebra::cmath::matrix::determinant

--- a/math/cmath/include/algebra/math/algorithms/matrix/inverse/cofactor.hpp
+++ b/math/cmath/include/algebra/math/algorithms/matrix/inverse/cofactor.hpp
@@ -1,0 +1,141 @@
+/** Algebra plugins library, part of the ACTS project
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s).
+#include "algebra/math/algorithms/matrix/determinant/cofactor.hpp"
+#include "algebra/qualifiers.hpp"
+
+// System include(s)
+#include <type_traits>
+
+namespace algebra::cmath::matrix::inverse {
+
+/// "Adjoint getter", assuming a N X N matrix
+template <typename size_type,
+          template <typename, size_type, size_type> class matrix_t,
+          typename scalar_t, class element_getter_t>
+struct adjoint_getter {
+
+  /// Function (object) used for accessing a matrix element
+  using element_getter = element_getter_t;
+
+  /// 2D matrix type
+  template <size_type ROWS, size_type COLS>
+  using matrix_type = matrix_t<scalar_t, ROWS, COLS>;
+
+  template <size_type N>
+  ALGEBRA_HOST_DEVICE inline matrix_type<N, N> operator()(
+      const matrix_type<N, N> &m) const {
+    return adjoint_getter_helper<N>()(m);
+  }
+
+  template <size_type N, typename Enable = void>
+  struct adjoint_getter_helper;
+
+  template <size_type N>
+  struct adjoint_getter_helper<N, typename std::enable_if_t<N == 1>> {
+
+    ALGEBRA_HOST_DEVICE inline matrix_type<N, N> operator()(
+        const matrix_type<N, N> & /*m*/) const {
+      matrix_type<N, N> ret;
+      element_getter()(ret, 0, 0) = 1;
+      return ret;
+    }
+  };
+
+  template <size_type N>
+  struct adjoint_getter_helper<N, typename std::enable_if_t<N != 1>> {
+
+    using determinant_getter_type =
+        determinant::cofactor<size_type, matrix_t, scalar_t, element_getter_t>;
+
+    ALGEBRA_HOST_DEVICE inline matrix_type<N, N> operator()(
+        const matrix_type<N, N> &m) const {
+
+      matrix_type<N, N> adj;
+
+      // temp is used to store cofactors of m
+      int sign = 1;
+
+      // To store cofactors
+      matrix_type<N, N> temp;
+
+      for (size_type i = 0; i < N; i++) {
+        for (size_type j = 0; j < N; j++) {
+          // Get cofactor of m[i][j]
+          typename determinant_getter_type::template determinant_getter_helper<
+              N>()
+              .get_cofactor(m, temp, i, j);
+
+          // sign of adj[j][i] positive if sum of row
+          // and column indexes is even.
+          sign = ((i + j) % 2 == 0) ? 1 : -1;
+
+          // Interchanging rows and columns to get the
+          // transpose of the cofactor matrix
+          element_getter()(adj, j, i) =
+              sign * typename determinant_getter_type::
+                         template determinant_getter_helper<N - 1>()(temp);
+        }
+      }
+
+      return adj;
+    }
+  };
+};
+
+/// "inverse getter", assuming a N X N matrix
+template <typename size_type,
+          template <typename, size_type, size_type> class matrix_t,
+          typename scalar_t, class element_getter_t, size_type... Ds>
+struct cofactor {
+
+  using _dims = std::integer_sequence<size_type, Ds...>;
+
+  /// Function (object) used for accessing a matrix element
+  using element_getter = element_getter_t;
+
+  /// 2D matrix type
+  template <size_type ROWS, size_type COLS>
+  using matrix_type = matrix_t<scalar_t, ROWS, COLS>;
+
+  using determinant_getter_type =
+      determinant::cofactor<size_type, matrix_t, scalar_t, element_getter_t>;
+
+  using adjoint_getter_type =
+      adjoint_getter<size_type, matrix_t, scalar_t, element_getter_t>;
+
+  template <size_type N>
+  ALGEBRA_HOST_DEVICE inline matrix_type<N, N> operator()(
+      const matrix_type<N, N> &m) const {
+
+    matrix_type<N, N> ret;
+
+    // Find determinant of A
+    scalar_t det = determinant_getter_type()(m);
+
+    // TODO: handle singular matrix error
+    // if (det == 0) {
+    // return ret;
+    //}
+
+    auto adj = adjoint_getter_type()(m);
+
+    // Find Inverse using formula "inverse(A) = adj(A)/det(A)"
+    for (size_type i = 0; i < N; i++) {
+      for (size_type j = 0; j < N; j++) {
+        element_getter()(ret, j, i) = element_getter()(adj, j, i) / det;
+      }
+    }
+
+    return ret;
+  }
+};
+
+}  // namespace algebra::cmath::matrix::inverse

--- a/math/cmath/include/algebra/math/algorithms/matrix/inverse/hard_coded.hpp
+++ b/math/cmath/include/algebra/math/algorithms/matrix/inverse/hard_coded.hpp
@@ -1,0 +1,55 @@
+/** Algebra plugins library, part of the ACTS project
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s).
+#include "algebra/math/algorithms/matrix/determinant/hard_coded.hpp"
+#include "algebra/qualifiers.hpp"
+
+// System include(s)
+#include <type_traits>
+
+namespace algebra::cmath::matrix::inverse {
+
+/// "inverse getter", assuming a N X N matrix
+template <typename size_type,
+          template <typename, size_type, size_type> class matrix_t,
+          typename scalar_t, class element_getter_t, size_type... Ds>
+struct hard_coded {
+
+  using _dims = std::integer_sequence<size_type, Ds...>;
+
+  /// Function (object) used for accessing a matrix element
+  using element_getter = element_getter_t;
+
+  /// 2D matrix type
+  template <size_type ROWS, size_type COLS>
+  using matrix_type = matrix_t<scalar_t, ROWS, COLS>;
+
+  using determinant_getter_type =
+      determinant::hard_coded<size_type, matrix_t, scalar_t, element_getter_t>;
+
+  // 2 X 2 matrix inverse
+  template <size_type N, std::enable_if_t<N == 2, bool> = true>
+  ALGEBRA_HOST_DEVICE inline matrix_type<N, N> operator()(
+      const matrix_type<N, N> &m) const {
+
+    matrix_type<N, N> ret;
+
+    scalar_t det = determinant_getter_type()(m);
+
+    element_getter()(ret, 0, 0) = element_getter()(m, 1, 1) / det;
+    element_getter()(ret, 0, 1) = -1 * element_getter()(m, 0, 1) / det;
+    element_getter()(ret, 1, 0) = -1 * element_getter()(m, 1, 0) / det;
+    element_getter()(ret, 1, 1) = element_getter()(m, 0, 0) / det;
+
+    return ret;
+  }
+};
+
+}  // namespace algebra::cmath::matrix::inverse

--- a/math/cmath/include/algebra/math/algorithms/utils/algorithm_finder.hpp
+++ b/math/cmath/include/algebra/math/algorithms/utils/algorithm_finder.hpp
@@ -1,0 +1,58 @@
+/** Algebra plugins library, part of the ACTS project
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// System include
+#include <utility>
+
+namespace algebra::cmath {
+
+template <typename size_type, size_type... Is>
+constexpr bool is_in(size_type i, std::integer_sequence<size_type, Is...>) {
+  // suppress unused parameter warning
+  (void)i;
+  return ((i == Is) || ...);
+}
+
+template <typename size_type, size_type N, typename A, typename... As>
+struct find_algorithm_or_default;
+
+template <typename size_type, size_type N, typename A>
+struct find_algorithm_or_default<size_type, N, A> {
+
+  using algorithm_type = A;
+  static constexpr bool found = false;
+};
+
+template <typename size_type, size_type N, typename Default, typename A,
+          typename... As>
+struct find_algorithm_or_default<size_type, N, Default, A, As...> {
+
+ private:
+  using next = find_algorithm_or_default<size_type, N, Default, As...>;
+
+ public:
+  using algorithm_type =
+      typename std::conditional_t<is_in(N, typename A::_dims{}), A,
+                                  typename next::algorithm_type>;
+
+  static constexpr bool found = is_in(N, typename A::_dims{}) || next::found;
+};
+
+template <typename size_type, size_type N, typename Default, typename... Ts>
+struct find_algorithm {
+ private:
+  using helper =
+      find_algorithm_or_default<size_type, N, Default, Default, Ts...>;
+
+ public:
+  using algorithm_type = typename helper::algorithm_type;
+  static constexpr bool found = helper::found;
+};
+
+}  // namespace algebra::cmath

--- a/math/cmath/include/algebra/math/cmath.hpp
+++ b/math/cmath/include/algebra/math/cmath.hpp
@@ -1,6 +1,6 @@
 /** Algebra plugins library, part of the ACTS project
  *
- * (c) 2020-2021 CERN for the benefit of the ACTS project
+ * (c) 2020-2022 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */

--- a/math/cmath/include/algebra/math/cmath.hpp
+++ b/math/cmath/include/algebra/math/cmath.hpp
@@ -7,11 +7,18 @@
 
 #pragma once
 
-// Project include(s).
+// Impl include(s).
 #include "algebra/math/impl/cmath_cartesian2.hpp"
 #include "algebra/math/impl/cmath_cylindrical2.hpp"
 #include "algebra/math/impl/cmath_getter.hpp"
+#include "algebra/math/impl/cmath_matrix.hpp"
 #include "algebra/math/impl/cmath_operator.hpp"
 #include "algebra/math/impl/cmath_polar2.hpp"
 #include "algebra/math/impl/cmath_transform3.hpp"
 #include "algebra/math/impl/cmath_vector.hpp"
+// Algorithms include(s).
+#include "algebra/math/algorithms/matrix/determinant/cofactor.hpp"
+#include "algebra/math/algorithms/matrix/determinant/hard_coded.hpp"
+#include "algebra/math/algorithms/matrix/inverse/cofactor.hpp"
+#include "algebra/math/algorithms/matrix/inverse/hard_coded.hpp"
+#include "algebra/math/algorithms/utils/algorithm_finder.hpp"

--- a/math/cmath/include/algebra/math/impl/cmath_getter.hpp
+++ b/math/cmath/include/algebra/math/impl/cmath_getter.hpp
@@ -145,7 +145,7 @@ ALGEBRA_HOST_DEVICE inline scalar_t &element(
 /// "Vector getter", assuming a simple 2D array access
 template <typename size_type, template <typename, size_type> class array_t,
           typename scalar_t, size_type SIZE,
-          typename result_t = array_t<scalar_t, SIZE> >
+          typename result_t = array_t<scalar_t, SIZE>>
 struct vector_getter {
 
   /// Result type

--- a/math/cmath/include/algebra/math/impl/cmath_matrix.hpp
+++ b/math/cmath/include/algebra/math/impl/cmath_matrix.hpp
@@ -1,0 +1,136 @@
+/** Algebra plugins library, part of the ACTS project
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s).
+#include "algebra/math/algorithms/utils/algorithm_finder.hpp"
+#include "algebra/qualifiers.hpp"
+
+namespace algebra::cmath::matrix {
+
+/// "Matrix actor", assuming a simple 2D matrix
+template <typename size_type,
+          template <typename, size_type, size_type> class matrix_t,
+          typename scalar_t, class determinant_actor_t, class inverse_actor_t,
+          class element_getter_t>
+struct actor {
+
+  /// Function (object) used for accessing a matrix element
+  using element_getter = element_getter_t;
+
+  /// 2D matrix type
+  template <size_type ROWS, size_type COLS>
+  using matrix_type = matrix_t<scalar_t, ROWS, COLS>;
+
+  // Create zero matrix
+  template <size_type ROWS, size_type COLS>
+  ALGEBRA_HOST_DEVICE inline matrix_type<ROWS, COLS> zero() {
+    matrix_type<ROWS, COLS> ret;
+
+    for (size_type i = 0; i < ROWS; ++i) {
+      for (size_type j = 0; j < COLS; ++j) {
+        element_getter()(ret, i, j) = 0;
+      }
+    }
+
+    return ret;
+  }
+
+  // Create identity matrix
+  template <size_type ROWS, size_type COLS>
+  ALGEBRA_HOST_DEVICE inline matrix_type<ROWS, COLS> identity() {
+    matrix_type<ROWS, COLS> ret;
+
+    for (size_type i = 0; i < ROWS; ++i) {
+      for (size_type j = 0; j < COLS; ++j) {
+        if (i == j) {
+          element_getter()(ret, i, j) = 1;
+        } else {
+          element_getter()(ret, i, j) = 0;
+        }
+      }
+    }
+
+    return ret;
+  }
+
+  // Create transpose matrix
+  template <size_type ROWS, size_type COLS>
+  ALGEBRA_HOST_DEVICE inline matrix_type<COLS, ROWS> transpose(
+      const matrix_type<ROWS, COLS> &m) {
+
+    matrix_type<COLS, ROWS> ret;
+
+    for (size_type i = 0; i < ROWS; ++i) {
+      for (size_type j = 0; j < COLS; ++j) {
+        element_getter()(ret, j, i) = element_getter()(m, i, j);
+      }
+    }
+
+    return ret;
+  }
+
+  // Get determinant
+  template <size_type N>
+  ALGEBRA_HOST_DEVICE inline scalar_t determinant(const matrix_type<N, N> &m) {
+
+    return determinant_actor_t()(m);
+  }
+
+  // Create inverse matrix
+  template <size_type N>
+  ALGEBRA_HOST_DEVICE inline matrix_type<N, N> inverse(
+      const matrix_type<N, N> &m) {
+
+    return inverse_actor_t()(m);
+  }
+};
+
+namespace determinant {
+
+template <typename size_type,
+          template <typename, size_type, size_type> class matrix_t,
+          typename scalar_t, class... As>
+struct actor {
+
+  /// 2D matrix type
+  template <size_type ROWS, size_type COLS>
+  using matrix_type = matrix_t<scalar_t, ROWS, COLS>;
+
+  template <size_type N>
+  ALGEBRA_HOST_DEVICE inline scalar_t operator()(
+      const matrix_type<N, N> &m) const {
+
+    return typename find_algorithm<size_type, N, As...>::algorithm_type()(m);
+  }
+};
+
+}  // namespace determinant
+
+namespace inverse {
+
+template <typename size_type,
+          template <typename, size_type, size_type> class matrix_t,
+          typename scalar_t, class... As>
+struct actor {
+
+  /// 2D matrix type
+  template <size_type ROWS, size_type COLS>
+  using matrix_type = matrix_t<scalar_t, ROWS, COLS>;
+
+  template <size_type N>
+  ALGEBRA_HOST_DEVICE inline matrix_type<N, N> operator()(
+      const matrix_type<N, N> &m) const {
+
+    return typename find_algorithm<size_type, N, As...>::algorithm_type()(m);
+  }
+};
+
+}  // namespace inverse
+
+}  // namespace algebra::cmath::matrix

--- a/math/cmath/include/algebra/math/impl/cmath_operator.hpp
+++ b/math/cmath/include/algebra/math/impl/cmath_operator.hpp
@@ -1,6 +1,6 @@
 /** Algebra plugins library, part of the ACTS project
  *
- * (c) 2020-2021 CERN for the benefit of the ACTS project
+ * (c) 2020-2022 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */

--- a/math/cmath/include/algebra/math/impl/cmath_operator.hpp
+++ b/math/cmath/include/algebra/math/impl/cmath_operator.hpp
@@ -18,42 +18,48 @@ namespace algebra::cmath {
 /// @name Operators on 2-element arrays
 /// @{
 
-template <template <typename, std::size_t> class array_t, typename scalar_t>
+template <template <typename, std::size_t> class array_t, typename scalar_t,
+          std::enable_if_t<std::is_scalar_v<scalar_t>, bool> = true>
 ALGEBRA_HOST_DEVICE inline array_t<scalar_t, 2> operator*(
     const array_t<scalar_t, 2> &a, float s) {
 
   return {a[0] * static_cast<scalar_t>(s), a[1] * static_cast<scalar_t>(s)};
 }
 
-template <template <typename, std::size_t> class array_t, typename scalar_t>
+template <template <typename, std::size_t> class array_t, typename scalar_t,
+          std::enable_if_t<std::is_scalar_v<scalar_t>, bool> = true>
 ALGEBRA_HOST_DEVICE inline array_t<scalar_t, 2> operator*(
     const array_t<scalar_t, 2> &a, double s) {
 
   return {a[0] * static_cast<scalar_t>(s), a[1] * static_cast<scalar_t>(s)};
 }
 
-template <template <typename, std::size_t> class array_t, typename scalar_t>
+template <template <typename, std::size_t> class array_t, typename scalar_t,
+          std::enable_if_t<std::is_scalar_v<scalar_t>, bool> = true>
 ALGEBRA_HOST_DEVICE inline array_t<scalar_t, 2> operator*(
     float s, const array_t<scalar_t, 2> &a) {
 
   return {static_cast<scalar_t>(s) * a[0], static_cast<scalar_t>(s) * a[1]};
 }
 
-template <template <typename, std::size_t> class array_t, typename scalar_t>
+template <template <typename, std::size_t> class array_t, typename scalar_t,
+          std::enable_if_t<std::is_scalar_v<scalar_t>, bool> = true>
 ALGEBRA_HOST_DEVICE inline array_t<scalar_t, 2> operator*(
     double s, const array_t<scalar_t, 2> &a) {
 
   return {static_cast<scalar_t>(s) * a[0], static_cast<scalar_t>(s) * a[1]};
 }
 
-template <template <typename, std::size_t> class array_t, typename scalar_t>
+template <template <typename, std::size_t> class array_t, typename scalar_t,
+          std::enable_if_t<std::is_scalar_v<scalar_t>, bool> = true>
 ALGEBRA_HOST_DEVICE inline array_t<scalar_t, 2> operator-(
     const array_t<scalar_t, 2> &a, const array_t<scalar_t, 2> &b) {
 
   return {a[0] - b[0], a[1] - b[1]};
 }
 
-template <template <typename, std::size_t> class array_t, typename scalar_t>
+template <template <typename, std::size_t> class array_t, typename scalar_t,
+          std::enable_if_t<std::is_scalar_v<scalar_t>, bool> = true>
 ALGEBRA_HOST_DEVICE inline array_t<scalar_t, 2> operator+(
     const array_t<scalar_t, 2> &a, const array_t<scalar_t, 2> &b) {
 
@@ -65,7 +71,8 @@ ALGEBRA_HOST_DEVICE inline array_t<scalar_t, 2> operator+(
 /// @name Operators on 3-element arrays
 /// @{
 
-template <template <typename, std::size_t> class array_t, typename scalar_t>
+template <template <typename, std::size_t> class array_t, typename scalar_t,
+          std::enable_if_t<std::is_scalar_v<scalar_t>, bool> = true>
 ALGEBRA_HOST_DEVICE inline array_t<scalar_t, 3> operator*(
     const array_t<scalar_t, 3> &a, float s) {
 
@@ -73,7 +80,8 @@ ALGEBRA_HOST_DEVICE inline array_t<scalar_t, 3> operator*(
           a[2] * static_cast<scalar_t>(s)};
 }
 
-template <template <typename, std::size_t> class array_t, typename scalar_t>
+template <template <typename, std::size_t> class array_t, typename scalar_t,
+          std::enable_if_t<std::is_scalar_v<scalar_t>, bool> = true>
 ALGEBRA_HOST_DEVICE inline array_t<scalar_t, 3> operator*(
     const array_t<scalar_t, 3> &a, double s) {
 
@@ -81,7 +89,8 @@ ALGEBRA_HOST_DEVICE inline array_t<scalar_t, 3> operator*(
           a[2] * static_cast<scalar_t>(s)};
 }
 
-template <template <typename, std::size_t> class array_t, typename scalar_t>
+template <template <typename, std::size_t> class array_t, typename scalar_t,
+          std::enable_if_t<std::is_scalar_v<scalar_t>, bool> = true>
 ALGEBRA_HOST_DEVICE inline array_t<scalar_t, 3> operator*(
     float s, const array_t<scalar_t, 3> &a) {
 
@@ -89,7 +98,8 @@ ALGEBRA_HOST_DEVICE inline array_t<scalar_t, 3> operator*(
           static_cast<scalar_t>(s) * a[2]};
 }
 
-template <template <typename, std::size_t> class array_t, typename scalar_t>
+template <template <typename, std::size_t> class array_t, typename scalar_t,
+          std::enable_if_t<std::is_scalar_v<scalar_t>, bool> = true>
 ALGEBRA_HOST_DEVICE inline array_t<scalar_t, 3> operator*(
     double s, const array_t<scalar_t, 3> &a) {
 
@@ -97,18 +107,154 @@ ALGEBRA_HOST_DEVICE inline array_t<scalar_t, 3> operator*(
           static_cast<scalar_t>(s) * a[2]};
 }
 
-template <template <typename, std::size_t> class array_t, typename scalar_t>
+template <template <typename, std::size_t> class array_t, typename scalar_t,
+          std::enable_if_t<std::is_scalar_v<scalar_t>, bool> = true>
 ALGEBRA_HOST_DEVICE inline array_t<scalar_t, 3> operator-(
     const array_t<scalar_t, 3> &a, const array_t<scalar_t, 3> &b) {
 
   return {a[0] - b[0], a[1] - b[1], a[2] - b[2]};
 }
 
-template <template <typename, std::size_t> class array_t, typename scalar_t>
+template <template <typename, std::size_t> class array_t, typename scalar_t,
+          std::enable_if_t<std::is_scalar_v<scalar_t>, bool> = true>
 ALGEBRA_HOST_DEVICE inline array_t<scalar_t, 3> operator+(
     const array_t<scalar_t, 3> &a, const array_t<scalar_t, 3> &b) {
 
   return {a[0] + b[0], a[1] + b[1], a[2] + b[2]};
+}
+
+/// @}
+
+/// @name Operators on matrix
+/// @{
+
+template <typename size_type, template <typename, size_type> class array_t,
+          typename scalar_t, size_type ROWS, size_type COLS,
+          std::enable_if_t<std::is_scalar_v<scalar_t>, bool> = true>
+ALGEBRA_HOST_DEVICE inline array_t<array_t<scalar_t, ROWS>, COLS> operator*(
+    const array_t<array_t<scalar_t, ROWS>, COLS> &a, float s) {
+
+  array_t<array_t<scalar_t, ROWS>, COLS> ret;
+
+  for (size_type i = 0; i < ROWS; ++i) {
+    for (size_type j = 0; j < COLS; ++j) {
+      ret[j][i] = a[j][i] * static_cast<scalar_t>(s);
+    }
+  }
+
+  return ret;
+}
+
+template <typename size_type, template <typename, size_type> class array_t,
+          typename scalar_t, size_type ROWS, size_type COLS,
+          std::enable_if_t<std::is_scalar_v<scalar_t>, bool> = true>
+ALGEBRA_HOST_DEVICE inline array_t<array_t<scalar_t, ROWS>, COLS> operator*(
+    const array_t<array_t<scalar_t, ROWS>, COLS> &a, double s) {
+
+  array_t<array_t<scalar_t, ROWS>, COLS> ret;
+
+  for (size_type i = 0; i < ROWS; ++i) {
+    for (size_type j = 0; j < COLS; ++j) {
+      ret[j][i] = a[j][i] * static_cast<scalar_t>(s);
+    }
+  }
+
+  return ret;
+}
+
+template <typename size_type, template <typename, size_type> class array_t,
+          typename scalar_t, size_type ROWS, size_type COLS,
+          std::enable_if_t<std::is_scalar_v<scalar_t>, bool> = true>
+ALGEBRA_HOST_DEVICE inline array_t<array_t<scalar_t, ROWS>, COLS> operator*(
+    float s, const array_t<array_t<scalar_t, ROWS>, COLS> &a) {
+
+  array_t<array_t<scalar_t, ROWS>, COLS> ret;
+
+  for (size_type i = 0; i < ROWS; ++i) {
+    for (size_type j = 0; j < COLS; ++j) {
+      ret[j][i] = a[j][i] * static_cast<scalar_t>(s);
+    }
+  }
+
+  return ret;
+}
+
+template <typename size_type, template <typename, size_type> class array_t,
+          typename scalar_t, size_type ROWS, size_type COLS,
+          std::enable_if_t<std::is_scalar_v<scalar_t>, bool> = true>
+ALGEBRA_HOST_DEVICE inline array_t<array_t<scalar_t, ROWS>, COLS> operator*(
+    double s, const array_t<array_t<scalar_t, ROWS>, COLS> &a) {
+
+  array_t<array_t<scalar_t, ROWS>, COLS> ret;
+
+  for (size_type i = 0; i < ROWS; ++i) {
+    for (size_type j = 0; j < COLS; ++j) {
+      ret[j][i] = a[j][i] * static_cast<scalar_t>(s);
+    }
+  }
+
+  return ret;
+}
+
+template <typename size_type, template <typename, size_type> class array_t,
+          typename scalar_t, size_type M, size_type N, size_type O,
+          std::enable_if_t<std::is_scalar_v<scalar_t>, bool> = true>
+ALGEBRA_HOST_DEVICE inline array_t<array_t<scalar_t, M>, O> operator*(
+    const array_t<array_t<scalar_t, M>, N> &A,
+    const array_t<array_t<scalar_t, N>, O> &B) {
+
+  array_t<array_t<scalar_t, M>, O> C;
+
+  for (size_type i = 0; i < M; ++i) {
+    for (size_type j = 0; j < O; ++j) {
+
+      scalar_t val = 0;
+
+      for (size_type k = 0; k < N; ++k) {
+        val += A[k][i] * B[j][k];
+      }
+
+      C[j][i] = val;
+    }
+  }
+
+  return C;
+}
+
+template <typename size_type, template <typename, size_type> class array_t,
+          typename scalar_t, size_type ROWS, size_type COLS,
+          std::enable_if_t<std::is_scalar_v<scalar_t>, bool> = true>
+ALGEBRA_HOST_DEVICE inline array_t<array_t<scalar_t, ROWS>, COLS> operator+(
+    const array_t<array_t<scalar_t, ROWS>, COLS> &A,
+    const array_t<array_t<scalar_t, ROWS>, COLS> &B) {
+
+  array_t<array_t<scalar_t, ROWS>, COLS> C;
+
+  for (size_type i = 0; i < ROWS; ++i) {
+    for (size_type j = 0; j < COLS; ++j) {
+      C[j][i] = A[j][i] + B[j][i];
+    }
+  }
+
+  return C;
+}
+
+template <typename size_type, template <typename, size_type> class array_t,
+          typename scalar_t, size_type ROWS, size_type COLS,
+          std::enable_if_t<std::is_scalar_v<scalar_t>, bool> = true>
+ALGEBRA_HOST_DEVICE inline array_t<array_t<scalar_t, ROWS>, COLS> operator-(
+    const array_t<array_t<scalar_t, ROWS>, COLS> &A,
+    const array_t<array_t<scalar_t, ROWS>, COLS> &B) {
+
+  array_t<array_t<scalar_t, ROWS>, COLS> C;
+
+  for (size_type i = 0; i < ROWS; ++i) {
+    for (size_type j = 0; j < COLS; ++j) {
+      C[j][i] = A[j][i] - B[j][i];
+    }
+  }
+
+  return C;
 }
 
 /// @}

--- a/math/eigen/CMakeLists.txt
+++ b/math/eigen/CMakeLists.txt
@@ -10,6 +10,7 @@ algebra_add_library( algebra_eigen_math eigen_math
    "include/algebra/math/impl/eigen_cartesian2.hpp"
    "include/algebra/math/impl/eigen_cylindrical2.hpp"
    "include/algebra/math/impl/eigen_getter.hpp"
+   "include/algebra/math/impl/eigen_matrix.hpp"
    "include/algebra/math/impl/eigen_polar2.hpp"
    "include/algebra/math/impl/eigen_transform3.hpp"
    "include/algebra/math/impl/eigen_vector.hpp" )

--- a/math/eigen/include/algebra/math/eigen.hpp
+++ b/math/eigen/include/algebra/math/eigen.hpp
@@ -1,6 +1,6 @@
 /** Algebra plugins library, part of the ACTS project
  *
- * (c) 2020-2021 CERN for the benefit of the ACTS project
+ * (c) 2020-2022 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */

--- a/math/eigen/include/algebra/math/eigen.hpp
+++ b/math/eigen/include/algebra/math/eigen.hpp
@@ -10,6 +10,7 @@
 // Project include(s).
 #include "algebra/math/impl/eigen_cylindrical2.hpp"
 #include "algebra/math/impl/eigen_getter.hpp"
+#include "algebra/math/impl/eigen_matrix.hpp"
 #include "algebra/math/impl/eigen_polar2.hpp"
 #include "algebra/math/impl/eigen_transform3.hpp"
 #include "algebra/math/impl/eigen_vector.hpp"

--- a/math/eigen/include/algebra/math/impl/eigen_matrix.hpp
+++ b/math/eigen/include/algebra/math/impl/eigen_matrix.hpp
@@ -1,0 +1,65 @@
+/** Algebra plugins library, part of the ACTS project
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s).
+#include "algebra/qualifiers.hpp"
+
+// Eigen include(s).
+#ifdef _MSC_VER
+#pragma warning(push, 0)
+#endif  // MSVC
+#include <Eigen/Core>
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif  // MSVC
+
+namespace algebra::eigen::matrix {
+
+/// "Matrix actor", assuming an Eigen matrix
+template <typename scalar_t>
+struct actor {
+
+  /// 2D matrix type
+  template <int ROWS, int COLS>
+  using matrix_type = Eigen::Matrix<scalar_t, ROWS, COLS, 0, ROWS, COLS>;
+
+  // Create zero matrix
+  template <int ROWS, int COLS>
+  ALGEBRA_HOST_DEVICE inline matrix_type<ROWS, COLS> zero() {
+    return matrix_type<ROWS, COLS>::Zero();
+  }
+
+  // Create identity matrix
+  template <int ROWS, int COLS>
+  ALGEBRA_HOST_DEVICE inline matrix_type<ROWS, COLS> identity() {
+    return matrix_type<ROWS, COLS>::Identity();
+  }
+
+  // Create transpose matrix
+  template <int ROWS, int COLS>
+  ALGEBRA_HOST_DEVICE inline matrix_type<COLS, ROWS> transpose(
+      const matrix_type<ROWS, COLS>& m) {
+    return m.transpose();
+  }
+
+  // Get determinant
+  template <int N>
+  ALGEBRA_HOST_DEVICE inline scalar_t determinant(const matrix_type<N, N>& m) {
+    return m.determinant();
+  }
+
+  // Create inverse matrix
+  template <int N>
+  ALGEBRA_HOST_DEVICE inline matrix_type<N, N> inverse(
+      const matrix_type<N, N>& m) {
+    return m.inverse();
+  }
+};
+
+}  // namespace algebra::eigen::matrix

--- a/math/smatrix/CMakeLists.txt
+++ b/math/smatrix/CMakeLists.txt
@@ -14,6 +14,7 @@ algebra_add_library( algebra_smatrix_math smatrix_math
    "include/algebra/math/impl/smatrix_cylindrical2.hpp"
    "include/algebra/math/impl/smatrix_errorcheck.hpp"
    "include/algebra/math/impl/smatrix_getter.hpp"
+   "include/algebra/math/impl/smatrix_matrix.hpp"
    "include/algebra/math/impl/smatrix_polar2.hpp"
    "include/algebra/math/impl/smatrix_transform3.hpp"
    "include/algebra/math/impl/smatrix_vector.hpp" )

--- a/math/smatrix/include/algebra/math/impl/smatrix_matrix.hpp
+++ b/math/smatrix/include/algebra/math/impl/smatrix_matrix.hpp
@@ -1,0 +1,75 @@
+/** Algebra plugins library, part of the ACTS project
+ *
+ * (c) 2020-2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s).
+#include "algebra/qualifiers.hpp"
+
+// ROOT/Smatrix include(s).
+#include <Math/SMatrix.h>
+
+namespace algebra::smatrix::matrix {
+
+/// "Matrix actor", assuming an Eigen matrix
+template <typename scalar_t>
+struct actor {
+
+  /// 2D matrix type
+  template <unsigned int ROWS, unsigned int COLS>
+  using matrix_type = ROOT::Math::SMatrix<scalar_t, ROWS, COLS>;
+
+  // Create zero matrix
+  template <unsigned int ROWS, unsigned int COLS>
+  ALGEBRA_HOST_DEVICE inline matrix_type<ROWS, COLS> zero() {
+    return matrix_type<ROWS, COLS>();
+  }
+
+  // Create identity matrix
+  template <unsigned int ROWS, unsigned int COLS>
+  ALGEBRA_HOST_DEVICE inline matrix_type<ROWS, COLS> identity() {
+    matrix_type<ROWS, COLS> ret = ROOT::Math::SMatrixIdentity();
+    return ret;
+  }
+
+  // Create transpose matrix
+  template <unsigned int ROWS, unsigned int COLS>
+  ALGEBRA_HOST_DEVICE inline matrix_type<COLS, ROWS> transpose(
+      const matrix_type<ROWS, COLS>& m) {
+    matrix_type<COLS, ROWS> ret;
+
+    for (unsigned int i = 0; i < ROWS; ++i) {
+      for (unsigned int j = 0; j < COLS; ++j) {
+        ret(j, i) = m(i, j);
+      }
+    }
+
+    return ret;
+  }
+
+  // Get determinant
+  template <unsigned int N>
+  ALGEBRA_HOST_DEVICE inline scalar_t determinant(const matrix_type<N, N>& m) {
+    scalar_t det;
+    bool success = m.Det2(det);
+
+    // suppress unused parameter warning
+    (void)success;
+
+    return det;
+  }
+
+  // Create inverse matrix
+  template <unsigned int N>
+  ALGEBRA_HOST_DEVICE inline matrix_type<N, N> inverse(
+      const matrix_type<N, N>& m) {
+    int ifail = 0;
+    return m.Inverse(ifail);
+  }
+};
+
+}  // namespace algebra::smatrix::matrix

--- a/math/smatrix/include/algebra/math/smatrix.hpp
+++ b/math/smatrix/include/algebra/math/smatrix.hpp
@@ -11,6 +11,7 @@
 #include "algebra/math/impl/smatrix_cartesian2.hpp"
 #include "algebra/math/impl/smatrix_cylindrical2.hpp"
 #include "algebra/math/impl/smatrix_getter.hpp"
+#include "algebra/math/impl/smatrix_matrix.hpp"
 #include "algebra/math/impl/smatrix_polar2.hpp"
 #include "algebra/math/impl/smatrix_transform3.hpp"
 #include "algebra/math/impl/smatrix_vector.hpp"

--- a/storage/eigen/include/algebra/storage/eigen.hpp
+++ b/storage/eigen/include/algebra/storage/eigen.hpp
@@ -16,11 +16,11 @@
 namespace algebra::eigen {
 
 /// Array type used in the Eigen storage model
-template <typename T, std::size_t N>
+template <typename T, int N>
 using storage_type = array<T, N>;
 /// Matrix type used in the Eigen storage model
-template <typename T, std::size_t ROWS, std::size_t COLS>
-using matrix_type = Eigen::Matrix<T, ROWS, COLS>;
+template <typename T, int ROWS, int COLS>
+using matrix_type = Eigen::Matrix<T, ROWS, COLS, 0, ROWS, COLS>;
 
 /// 3-element "vector" type, using @c algebra::eigen::array
 template <typename T>

--- a/storage/eigen/include/algebra/storage/impl/eigen_array.hpp
+++ b/storage/eigen/include/algebra/storage/impl/eigen_array.hpp
@@ -22,7 +22,7 @@
 namespace algebra::eigen {
 
 /// Eigen array type
-template <typename T, std::size_t N>
+template <typename T, int N>
 class array : public Eigen::Matrix<T, N, 1> {
 
  public:

--- a/tests/accelerator/common/test_basics_base.hpp
+++ b/tests/accelerator/common/test_basics_base.hpp
@@ -55,6 +55,10 @@ class test_basics_base : public testing::Test, public test_base<T> {
         std::make_unique<vecmem::vector<typename T::template matrix<6, 4> > >(
             s_arraySize, &m_resource);
 
+    m_m2 =
+        std::make_unique<vecmem::vector<typename T::template matrix<2, 2> > >(
+            s_arraySize, &m_resource);
+
     m_output_host = std::make_unique<vecmem::vector<typename T::scalar> >(
         s_arraySize, &m_resource);
     m_output_device = std::make_unique<vecmem::vector<typename T::scalar> >(
@@ -92,6 +96,11 @@ class test_basics_base : public testing::Test, public test_base<T> {
         }
       }
 
+      algebra::getter::element(m_m2->at(i), 0, 0) = 4;
+      algebra::getter::element(m_m2->at(i), 0, 1) = 3;
+      algebra::getter::element(m_m2->at(i), 1, 0) = 12;
+      algebra::getter::element(m_m2->at(i), 1, 1) = 13;
+
       m_output_host->at(i) = 0;
       m_output_device->at(i) = 0;
     }
@@ -108,6 +117,8 @@ class test_basics_base : public testing::Test, public test_base<T> {
     m_p2.reset();
     m_v1.reset();
     m_v2.reset();
+    m_m1.reset();
+    m_m2.reset();
 
     m_output_host.reset();
     m_output_device.reset();
@@ -134,6 +145,7 @@ class test_basics_base : public testing::Test, public test_base<T> {
   std::unique_ptr<vecmem::vector<typename T::point2> > m_p1, m_p2;
   std::unique_ptr<vecmem::vector<typename T::vector3> > m_v1, m_v2;
   std::unique_ptr<vecmem::vector<typename T::template matrix<6, 4> > > m_m1;
+  std::unique_ptr<vecmem::vector<typename T::template matrix<2, 2> > > m_m2;
 
   /// @}
 

--- a/tests/accelerator/common/test_basics_functors.hpp
+++ b/tests/accelerator/common/test_basics_functors.hpp
@@ -86,6 +86,26 @@ class matrix64_ops_functor : public functor_base<T> {
   }
 };
 
+/// Functor running @c test_device_basics::matrix22_ops
+template <typename T>
+class matrix22_ops_functor : public functor_base<T> {
+
+ public:
+  ALGEBRA_HOST_DEVICE void operator()(
+      std::size_t i,
+      vecmem::data::vector_view<const typename T::template matrix<2, 2> > m,
+      vecmem::data::vector_view<typename T::scalar> output) const {
+
+    // Create the VecMem vector(s).
+    vecmem::device_vector<const typename T::template matrix<2, 2> > vec_m(m);
+    vecmem::device_vector<typename T::scalar> vec_output(output);
+
+    // Perform the operation.
+    auto ii = static_cast<typename decltype(vec_output)::size_type>(i);
+    vec_output[ii] = this->m_tester.matrix22_ops(vec_m[ii]);
+  }
+};
+
 /// Functor running @c test_device_basics::transform3_ops
 template <typename T>
 class transform3_ops_functor : public functor_base<T> {

--- a/tests/accelerator/cuda/array_cmath.cu
+++ b/tests/accelerator/cuda/array_cmath.cu
@@ -39,13 +39,21 @@ typedef testing::Types<
         algebra::array::vector2<float>, algebra::array::vector3<float>,
         algebra::array::transform3<float>, algebra::array::cartesian2<float>,
         algebra::array::polar2<float>, algebra::array::cylindrical2<float>,
-        std::size_t, algebra::array::matrix_type>,
+        std::size_t, algebra::array::matrix_type,
+        algebra::matrix::actor<
+            std::size_t, float,
+            algebra::matrix::determinant::preset0<std::size_t, float>,
+            algebra::matrix::inverse::preset0<std::size_t, float>>>,
     test_types<
         double, algebra::array::point2<double>, algebra::array::point3<double>,
         algebra::array::vector2<double>, algebra::array::vector3<double>,
         algebra::array::transform3<double>, algebra::array::cartesian2<double>,
         algebra::array::polar2<double>, algebra::array::cylindrical2<double>,
-        std::size_t, algebra::array::matrix_type> >
+        std::size_t, algebra::array::matrix_type,
+        algebra::matrix::actor<
+            std::size_t, double,
+            algebra::matrix::determinant::preset0<std::size_t, double>,
+            algebra::matrix::inverse::preset0<std::size_t, double>>>>
     array_cmath_types;
 INSTANTIATE_TYPED_TEST_SUITE_P(algebra_plugins, test_cuda_basics,
                                array_cmath_types, test_specialisation_name);

--- a/tests/accelerator/cuda/common/test_cuda_basics.cuh
+++ b/tests/accelerator/cuda/common/test_cuda_basics.cuh
@@ -91,6 +91,21 @@ TYPED_TEST_P(test_cuda_basics, matrix64_ops) {
   this->compareOutputs();
 }
 
+/// Test for handling matrices
+TYPED_TEST_P(test_cuda_basics, matrix22_ops) {
+
+  // Run the test on the host, and on the/a device.
+  execute_host_test<matrix22_ops_functor<TypeParam> >(
+      this->m_m2->size(), vecmem::get_data(*(this->m_m2)),
+      vecmem::get_data(*(this->m_output_host)));
+  execute_cuda_test<matrix22_ops_functor<TypeParam> >(
+      this->m_m2->size(), vecmem::get_data(*(this->m_m2)),
+      vecmem::get_data(*(this->m_output_device)));
+
+  // Compare the outputs.
+  this->compareOutputs();
+}
+
 /// Test for some operations with @c transform3
 TYPED_TEST_P(test_cuda_basics, transform3) {
 
@@ -168,5 +183,5 @@ TYPED_TEST_P(test_cuda_basics, polar2) {
 }
 
 REGISTER_TYPED_TEST_SUITE_P(test_cuda_basics, vector_2d_ops, vector_3d_ops,
-                            matrix64_ops, transform3, cartesian2, cylindrical2,
-                            polar2);
+                            matrix64_ops, matrix22_ops, transform3, cartesian2,
+                            cylindrical2, polar2);

--- a/tests/accelerator/cuda/eigen_cmath.cu
+++ b/tests/accelerator/cuda/eigen_cmath.cu
@@ -38,14 +38,20 @@ typedef testing::Types<
         float, algebra::eigen::point2<float>, algebra::eigen::point3<float>,
         algebra::eigen::vector2<float>, algebra::eigen::vector3<float>,
         algebra::eigen::transform3<float>, algebra::eigen::cartesian2<float>,
-        algebra::eigen::polar2<float>, algebra::eigen::cylindrical2<float>,
-        std::size_t, algebra::eigen::matrix_type>,
+        algebra::eigen::polar2<float>, algebra::eigen::cylindrical2<float>, int,
+        algebra::eigen::matrix_type,
+        algebra::matrix::actor<
+            int, float, algebra::matrix::determinant::preset0<int, float>,
+            algebra::matrix::inverse::preset0<int, float>>>,
     test_types<
         double, algebra::eigen::point2<double>, algebra::eigen::point3<double>,
         algebra::eigen::vector2<double>, algebra::eigen::vector3<double>,
         algebra::eigen::transform3<double>, algebra::eigen::cartesian2<double>,
         algebra::eigen::polar2<double>, algebra::eigen::cylindrical2<double>,
-        std::size_t, algebra::eigen::matrix_type> >
+        int, algebra::eigen::matrix_type,
+        algebra::matrix::actor<
+            int, double, algebra::matrix::determinant::preset0<int, double>,
+            algebra::matrix::inverse::preset0<int, double>>>>
     eigen_cmath_types;
 INSTANTIATE_TYPED_TEST_SUITE_P(algebra_plugins, test_cuda_basics,
                                eigen_cmath_types, test_specialisation_name);

--- a/tests/accelerator/cuda/eigen_eigen.cu
+++ b/tests/accelerator/cuda/eigen_eigen.cu
@@ -38,14 +38,14 @@ typedef testing::Types<
         float, algebra::eigen::point2<float>, algebra::eigen::point3<float>,
         algebra::eigen::vector2<float>, algebra::eigen::vector3<float>,
         algebra::eigen::transform3<float>, algebra::eigen::cartesian2<float>,
-        algebra::eigen::polar2<float>, algebra::eigen::cylindrical2<float>,
-        std::size_t, algebra::eigen::matrix_type>,
+        algebra::eigen::polar2<float>, algebra::eigen::cylindrical2<float>, int,
+        algebra::eigen::matrix_type, algebra::matrix::actor<float>>,
     test_types<
         double, algebra::eigen::point2<double>, algebra::eigen::point3<double>,
         algebra::eigen::vector2<double>, algebra::eigen::vector3<double>,
         algebra::eigen::transform3<double>, algebra::eigen::cartesian2<double>,
         algebra::eigen::polar2<double>, algebra::eigen::cylindrical2<double>,
-        std::size_t, algebra::eigen::matrix_type> >
+        int, algebra::eigen::matrix_type, algebra::matrix::actor<double>>>
     eigen_eigen_types;
 INSTANTIATE_TYPED_TEST_SUITE_P(algebra_plugins, test_cuda_basics,
                                eigen_eigen_types, test_specialisation_name);

--- a/tests/accelerator/cuda/vecmem_cmath.cu
+++ b/tests/accelerator/cuda/vecmem_cmath.cu
@@ -39,14 +39,22 @@ typedef testing::Types<
         algebra::vecmem::vector2<float>, algebra::vecmem::vector3<float>,
         algebra::vecmem::transform3<float>, algebra::vecmem::cartesian2<float>,
         algebra::vecmem::polar2<float>, algebra::vecmem::cylindrical2<float>,
-        std::size_t, algebra::vecmem::matrix_type>,
+        std::size_t, algebra::vecmem::matrix_type,
+        algebra::matrix::actor<
+            std::size_t, float,
+            algebra::matrix::determinant::preset0<std::size_t, float>,
+            algebra::matrix::inverse::preset0<std::size_t, float>>>,
     test_types<
         double, algebra::vecmem::point2<double>,
         algebra::vecmem::point3<double>, algebra::vecmem::vector2<double>,
         algebra::vecmem::vector3<double>, algebra::vecmem::transform3<double>,
         algebra::vecmem::cartesian2<double>, algebra::vecmem::polar2<double>,
         algebra::vecmem::cylindrical2<double>, std::size_t,
-        algebra::vecmem::matrix_type> >
+        algebra::vecmem::matrix_type,
+        algebra::matrix::actor<
+            std::size_t, double,
+            algebra::matrix::determinant::preset0<std::size_t, double>,
+            algebra::matrix::inverse::preset0<std::size_t, double>>>>
     vecmem_cmath_types;
 INSTANTIATE_TYPED_TEST_SUITE_P(algebra_plugins, test_cuda_basics,
                                vecmem_cmath_types, test_specialisation_name);

--- a/tests/accelerator/sycl/array_cmath.sycl
+++ b/tests/accelerator/sycl/array_cmath.sycl
@@ -39,13 +39,21 @@ typedef testing::Types<
         algebra::array::vector2<float>, algebra::array::vector3<float>,
         algebra::array::transform3<float>, algebra::array::cartesian2<float>,
         algebra::array::polar2<float>, algebra::array::cylindrical2<float>,
-        std::size_t, algebra::array::matrix_type>,
+        std::size_t, algebra::array::matrix_type,
+        algebra::matrix::actor<
+            std::size_t, float,
+            algebra::matrix::determinant::preset0<std::size_t, float>,
+            algebra::matrix::inverse::preset0<std::size_t, float>>>,
     test_types<
         double, algebra::array::point2<double>, algebra::array::point3<double>,
         algebra::array::vector2<double>, algebra::array::vector3<double>,
         algebra::array::transform3<double>, algebra::array::cartesian2<double>,
         algebra::array::polar2<double>, algebra::array::cylindrical2<double>,
-        std::size_t, algebra::array::matrix_type> >
+        std::size_t, algebra::array::matrix_type,
+        algebra::matrix::actor<
+            std::size_t, double,
+            algebra::matrix::determinant::preset0<std::size_t, double>,
+            algebra::matrix::inverse::preset0<std::size_t, double>>>>
     array_cmath_types;
 INSTANTIATE_TYPED_TEST_SUITE_P(algebra_plugins, test_sycl_basics,
                                array_cmath_types, test_specialisation_name);

--- a/tests/accelerator/sycl/common/test_sycl_basics.hpp
+++ b/tests/accelerator/sycl/common/test_sycl_basics.hpp
@@ -96,6 +96,21 @@ TYPED_TEST_P(test_sycl_basics, matrix64_ops) {
   this->compareOutputs();
 }
 
+/// Test for handling matrices
+TYPED_TEST_P(test_sycl_basics, matrix22_ops) {
+
+  // Run the test on the host, and on the/a device.
+  execute_host_test<matrix22_ops_functor<TypeParam> >(
+      this->m_m2->size(), vecmem::get_data(*(this->m_m2)),
+      vecmem::get_data(*(this->m_output_host)));
+  execute_sycl_test<matrix22_ops_functor<TypeParam> >(
+      this->m_queue, this->m_m2->size(), vecmem::get_data(*(this->m_m2)),
+      vecmem::get_data(*(this->m_output_device)));
+
+  // Compare the outputs.
+  this->compareOutputs();
+}
+
 /// Test for some operations with @c transform3
 TYPED_TEST_P(test_sycl_basics, transform3) {
 
@@ -173,5 +188,5 @@ TYPED_TEST_P(test_sycl_basics, polar2) {
 }
 
 REGISTER_TYPED_TEST_SUITE_P(test_sycl_basics, vector_2d_ops, vector_3d_ops,
-                            matrix64_ops, transform3, cartesian2, cylindrical2,
-                            polar2);
+                            matrix64_ops, matrix22_ops, transform3, cartesian2,
+                            cylindrical2, polar2);

--- a/tests/accelerator/sycl/vecmem_cmath.sycl
+++ b/tests/accelerator/sycl/vecmem_cmath.sycl
@@ -39,14 +39,22 @@ typedef testing::Types<
         algebra::vecmem::vector2<float>, algebra::vecmem::vector3<float>,
         algebra::vecmem::transform3<float>, algebra::vecmem::cartesian2<float>,
         algebra::vecmem::polar2<float>, algebra::vecmem::cylindrical2<float>,
-        std::size_t, algebra::vecmem::matrix_type>,
+        std::size_t, algebra::vecmem::matrix_type,
+        algebra::matrix::actor<
+            std::size_t, float,
+            algebra::matrix::determinant::preset0<std::size_t, float>,
+            algebra::matrix::inverse::preset0<std::size_t, float>>>,
     test_types<
         double, algebra::vecmem::point2<double>,
         algebra::vecmem::point3<double>, algebra::vecmem::vector2<double>,
         algebra::vecmem::vector3<double>, algebra::vecmem::transform3<double>,
         algebra::vecmem::cartesian2<double>, algebra::vecmem::polar2<double>,
         algebra::vecmem::cylindrical2<double>, std::size_t,
-        algebra::vecmem::matrix_type> >
+        algebra::vecmem::matrix_type,
+        algebra::matrix::actor<
+            std::size_t, double,
+            algebra::matrix::determinant::preset0<std::size_t, double>,
+            algebra::matrix::inverse::preset0<std::size_t, double>>>>
     vecmem_cmath_types;
 INSTANTIATE_TYPED_TEST_SUITE_P(algebra_plugins, test_sycl_basics,
                                vecmem_cmath_types, test_specialisation_name);

--- a/tests/array/array_cmath.cpp
+++ b/tests/array/array_cmath.cpp
@@ -39,13 +39,21 @@ typedef testing::Types<
         algebra::array::vector2<float>, algebra::array::vector3<float>,
         algebra::array::transform3<float>, algebra::array::cartesian2<float>,
         algebra::array::polar2<float>, algebra::array::cylindrical2<float>,
-        std::size_t, algebra::array::matrix_type>,
+        std::size_t, algebra::array::matrix_type,
+        algebra::matrix::actor<
+            std::size_t, float,
+            algebra::matrix::determinant::preset0<std::size_t, float>,
+            algebra::matrix::inverse::preset0<std::size_t, float>>>,
     test_types<
         double, algebra::array::point2<double>, algebra::array::point3<double>,
         algebra::array::vector2<double>, algebra::array::vector3<double>,
         algebra::array::transform3<double>, algebra::array::cartesian2<double>,
         algebra::array::polar2<double>, algebra::array::cylindrical2<double>,
-        std::size_t, algebra::array::matrix_type> >
+        std::size_t, algebra::array::matrix_type,
+        algebra::matrix::actor<
+            std::size_t, double,
+            algebra::matrix::determinant::preset0<std::size_t, double>,
+            algebra::matrix::inverse::preset0<std::size_t, double>>>>
     array_cmath_types;
 INSTANTIATE_TYPED_TEST_SUITE_P(algebra_plugins, test_host_basics,
                                array_cmath_types, test_specialisation_name);

--- a/tests/common/test_base.hpp
+++ b/tests/common/test_base.hpp
@@ -18,14 +18,14 @@ template <class T>
 class test_base {};
 
 /// Test base class, using a @c test_types type argument
-template <typename scalar_t, typename point2_t, typename point3_t,
-          typename vector2_t, typename vector3_t, typename transform3_t,
-          typename cartesian2_t, typename polar2_t, typename cylindrical2_t,
-          typename size_ty,
-          template <typename, size_ty, size_ty> class matrix_t>
-class test_base<
-    test_types<scalar_t, point2_t, point3_t, vector2_t, vector3_t, transform3_t,
-               cartesian2_t, polar2_t, cylindrical2_t, size_ty, matrix_t> > {
+template <
+    typename scalar_t, typename point2_t, typename point3_t, typename vector2_t,
+    typename vector3_t, typename transform3_t, typename cartesian2_t,
+    typename polar2_t, typename cylindrical2_t, typename size_ty,
+    template <typename, size_ty, size_ty> class matrix_t, class matrix_actor_t>
+class test_base<test_types<scalar_t, point2_t, point3_t, vector2_t, vector3_t,
+                           transform3_t, cartesian2_t, polar2_t, cylindrical2_t,
+                           size_ty, matrix_t, matrix_actor_t> > {
 
  public:
   /// @name Type definitions
@@ -43,6 +43,7 @@ class test_base<
   using size_type = size_ty;
   template <size_type ROWS, size_type COLS>
   using matrix = matrix_t<scalar, ROWS, COLS>;
+  using matrix_actor = matrix_actor_t;
 
   /// @}
 

--- a/tests/common/test_device_basics.hpp
+++ b/tests/common/test_device_basics.hpp
@@ -37,6 +37,7 @@ class test_device_basics : public test_base<T> {
   using size_type = typename test_base<T>::size_type;
   template <size_type ROWS, size_type COLS>
   using matrix = typename test_base<T>::template matrix<ROWS, COLS>;
+  using matrix_actor = typename test_base<T>::matrix_actor;
 
   /// @}
 
@@ -96,6 +97,68 @@ class test_device_basics : public test_base<T> {
                   0.7f * algebra::getter::element(m2, i, j);
       }
     }
+    return result;
+  }
+
+  /// Perform some trivial operations on an asymmetrix matrix
+  ALGEBRA_HOST_DEVICE
+  scalar matrix22_ops(const matrix<2, 2>& m22) const {
+
+    // Test 2 X 2 matrix determinant
+    auto m22_det = matrix_actor().determinant(m22);
+
+    // Test 2 X 2 matrix inverse
+    auto m22_inv = matrix_actor().inverse(m22);
+
+    matrix<3, 3> m33;
+    algebra::getter::element(m33, 0, 0) = 1;
+    algebra::getter::element(m33, 0, 1) = 5;
+    algebra::getter::element(m33, 0, 2) = 7;
+    algebra::getter::element(m33, 1, 0) = 3;
+    algebra::getter::element(m33, 1, 1) = 5;
+    algebra::getter::element(m33, 1, 2) = 6;
+    algebra::getter::element(m33, 2, 0) = 2;
+    algebra::getter::element(m33, 2, 1) = 8;
+    algebra::getter::element(m33, 2, 2) = 9;
+
+    // Test 3 X 3 matrix determinant
+    auto m33_det = matrix_actor().determinant(m33);
+
+    // Test 3 X 3 matrix inverse
+    auto m33_inv = matrix_actor().inverse(m33);
+
+    // Test Zero
+    auto m23 = matrix_actor().template zero<2, 3>();
+    algebra::getter::element(m23, 0, 0) += 2;
+    algebra::getter::element(m23, 0, 1) += 3;
+    algebra::getter::element(m23, 0, 2) += 4;
+    algebra::getter::element(m23, 1, 0) += 5;
+    algebra::getter::element(m23, 1, 1) += 6;
+    algebra::getter::element(m23, 1, 2) += 7;
+
+    // Test scalar X Matrix
+    m23 = 2. * m23;
+
+    // Test Transpose
+    auto m32 = matrix_actor().transpose(m23);
+
+    // Test Identity and (Matrix + Matrix)
+    m32 = m32 + matrix_actor().template identity<3, 2>();
+
+    // Test Matrix X scalar
+    m32 = m32 * 2.;
+
+    // Test Matrix multiplication
+    auto new_m22 = m22_inv * m23 * m33_inv * m32;
+
+    scalar result = 0;
+    result += m22_det;
+    result += m33_det;
+    result += algebra::getter::element(new_m22, 0, 0);
+    result += algebra::getter::element(new_m22, 0, 1);
+    result += algebra::getter::element(new_m22, 1, 0);
+    result += algebra::getter::element(new_m22, 1, 1);
+
     return result;
   }
 

--- a/tests/common/test_host_basics.hpp
+++ b/tests/common/test_host_basics.hpp
@@ -136,6 +136,110 @@ TYPED_TEST_P(test_host_basics, matrix64) {
   }
 }
 
+// Test matrix operations with 3x3 matrix
+TYPED_TEST_P(test_host_basics, matrix22) {
+
+  typename TypeParam::template matrix<2, 2> m22;
+  algebra::getter::element(m22, 0, 0) = 4;
+  algebra::getter::element(m22, 0, 1) = 3;
+  algebra::getter::element(m22, 1, 0) = 12;
+  algebra::getter::element(m22, 1, 1) = 13;
+
+  // Test 2 X 2 matrix determinant
+  auto m22_det = typename TypeParam::matrix_actor().determinant(m22);
+  ASSERT_NEAR(m22_det, 16., this->m_isclose);
+
+  // Test 2 X 2 matrix inverse
+  auto m22_inv = typename TypeParam::matrix_actor().inverse(m22);
+  ASSERT_NEAR(algebra::getter::element(m22_inv, 0, 0), 13 / 16.,
+              this->m_isclose);
+  ASSERT_NEAR(algebra::getter::element(m22_inv, 0, 1), -3 / 16.,
+              this->m_isclose);
+  ASSERT_NEAR(algebra::getter::element(m22_inv, 1, 0), -12 / 16.,
+              this->m_isclose);
+  ASSERT_NEAR(algebra::getter::element(m22_inv, 1, 1), 4 / 16.,
+              this->m_isclose);
+
+  typename TypeParam::template matrix<3, 3> m33;
+  algebra::getter::element(m33, 0, 0) = 1;
+  algebra::getter::element(m33, 0, 1) = 5;
+  algebra::getter::element(m33, 0, 2) = 7;
+  algebra::getter::element(m33, 1, 0) = 3;
+  algebra::getter::element(m33, 1, 1) = 5;
+  algebra::getter::element(m33, 1, 2) = 6;
+  algebra::getter::element(m33, 2, 0) = 2;
+  algebra::getter::element(m33, 2, 1) = 8;
+  algebra::getter::element(m33, 2, 2) = 9;
+
+  // Test 3 X 3 matrix determinant
+  auto m33_det = typename TypeParam::matrix_actor().determinant(m33);
+  ASSERT_NEAR(m33_det, 20., this->m_isclose);
+
+  // Test 3 X 3 matrix inverse
+  auto m33_inv = typename TypeParam::matrix_actor().inverse(m33);
+  ASSERT_NEAR(algebra::getter::element(m33_inv, 0, 0), -3 / 20.,
+              this->m_isclose);
+  ASSERT_NEAR(algebra::getter::element(m33_inv, 0, 1), 11 / 20.,
+              this->m_isclose);
+  ASSERT_NEAR(algebra::getter::element(m33_inv, 0, 2), -5 / 20.,
+              this->m_isclose);
+  ASSERT_NEAR(algebra::getter::element(m33_inv, 1, 0), -15 / 20.,
+              this->m_isclose);
+  ASSERT_NEAR(algebra::getter::element(m33_inv, 1, 1), -5 / 20.,
+              this->m_isclose);
+  ASSERT_NEAR(algebra::getter::element(m33_inv, 1, 2), 15 / 20.,
+              this->m_isclose);
+  ASSERT_NEAR(algebra::getter::element(m33_inv, 2, 0), 14 / 20.,
+              this->m_isclose);
+  ASSERT_NEAR(algebra::getter::element(m33_inv, 2, 1), 2 / 20.,
+              this->m_isclose);
+  ASSERT_NEAR(algebra::getter::element(m33_inv, 2, 2), -10 / 20.,
+              this->m_isclose);
+
+  // Test Zero
+  typename TypeParam::template matrix<2, 3> m23 =
+      typename TypeParam::matrix_actor().template zero<2, 3>();
+  algebra::getter::element(m23, 0, 0) += 2;
+  algebra::getter::element(m23, 0, 1) += 3;
+  algebra::getter::element(m23, 0, 2) += 4;
+  algebra::getter::element(m23, 1, 0) += 5;
+  algebra::getter::element(m23, 1, 1) += 6;
+  algebra::getter::element(m23, 1, 2) += 7;
+
+  // Test scalar X Matrix
+  m23 = 2. * m23;
+  ASSERT_NEAR(algebra::getter::element(m23, 0, 0), 4., this->m_epsilon);
+  ASSERT_NEAR(algebra::getter::element(m23, 0, 1), 6., this->m_epsilon);
+  ASSERT_NEAR(algebra::getter::element(m23, 0, 2), 8., this->m_epsilon);
+  ASSERT_NEAR(algebra::getter::element(m23, 1, 0), 10., this->m_epsilon);
+  ASSERT_NEAR(algebra::getter::element(m23, 1, 1), 12., this->m_epsilon);
+  ASSERT_NEAR(algebra::getter::element(m23, 1, 2), 14., this->m_epsilon);
+
+  // Test Transpose
+  auto m32 = typename TypeParam::matrix_actor().transpose(m23);
+
+  // Test Identity and (Matrix + Matrix)
+  m32 = m32 + typename TypeParam::matrix_actor().template identity<3, 2>();
+
+  // Test Matrix X scalar
+  m32 = m32 * 2.;
+
+  ASSERT_NEAR(algebra::getter::element(m32, 0, 0), 10., this->m_epsilon);
+  ASSERT_NEAR(algebra::getter::element(m32, 0, 1), 20., this->m_epsilon);
+  ASSERT_NEAR(algebra::getter::element(m32, 1, 0), 12., this->m_epsilon);
+  ASSERT_NEAR(algebra::getter::element(m32, 1, 1), 26., this->m_epsilon);
+  ASSERT_NEAR(algebra::getter::element(m32, 2, 0), 16., this->m_epsilon);
+  ASSERT_NEAR(algebra::getter::element(m32, 2, 1), 28., this->m_epsilon);
+
+  // Test Matrix multiplication
+  m22 = m22_inv * m23 * m33_inv * m32;
+
+  ASSERT_NEAR(algebra::getter::element(m22, 0, 0), 6.225, this->m_isclose);
+  ASSERT_NEAR(algebra::getter::element(m22, 0, 1), 14.675, this->m_isclose);
+  ASSERT_NEAR(algebra::getter::element(m22, 1, 0), -3.3, this->m_isclose);
+  ASSERT_NEAR(algebra::getter::element(m22, 1, 1), -7.9, this->m_isclose);
+}
+
 // This defines the vector operation test suite
 TYPED_TEST_P(test_host_basics, getter) {
 
@@ -323,5 +427,5 @@ TYPED_TEST_P(test_host_basics, local_transformations) {
 }
 
 REGISTER_TYPED_TEST_SUITE_P(test_host_basics, local_vectors, vector3, matrix64,
-                            getter, transform3, global_transformations,
-                            local_transformations);
+                            matrix22, getter, transform3,
+                            global_transformations, local_transformations);

--- a/tests/common/test_types.hpp
+++ b/tests/common/test_types.hpp
@@ -8,11 +8,11 @@
 #pragma once
 
 /// Simple struct holding the types that describe a given plugin
-template <typename scalar_t, typename point2_t, typename point3_t,
-          typename vector2_t, typename vector3_t, typename transform3_t,
-          typename cartesian2_t, typename polar2_t, typename cylindrical2_t,
-          typename size_ty,
-          template <typename, size_ty, size_ty> class matrix_t>
+template <
+    typename scalar_t, typename point2_t, typename point3_t, typename vector2_t,
+    typename vector3_t, typename transform3_t, typename cartesian2_t,
+    typename polar2_t, typename cylindrical2_t, typename size_ty,
+    template <typename, size_ty, size_ty> class matrix_t, class matrix_actor_t>
 struct test_types {
 
   using scalar = scalar_t;
@@ -27,5 +27,6 @@ struct test_types {
   using size_type = size_ty;
   template <size_type ROWS, size_type COLS>
   using matrix = matrix_t<scalar, ROWS, COLS>;
+  using matrix_actor = matrix_actor_t;
 
 };  // struct test_types

--- a/tests/eigen/eigen_cmath.cpp
+++ b/tests/eigen/eigen_cmath.cpp
@@ -38,14 +38,20 @@ typedef testing::Types<
         float, algebra::eigen::point2<float>, algebra::eigen::point3<float>,
         algebra::eigen::vector2<float>, algebra::eigen::vector3<float>,
         algebra::eigen::transform3<float>, algebra::eigen::cartesian2<float>,
-        algebra::eigen::polar2<float>, algebra::eigen::cylindrical2<float>,
-        std::size_t, algebra::eigen::matrix_type>,
+        algebra::eigen::polar2<float>, algebra::eigen::cylindrical2<float>, int,
+        algebra::eigen::matrix_type,
+        algebra::matrix::actor<
+            int, float, algebra::matrix::determinant::preset0<int, float>,
+            algebra::matrix::inverse::preset0<int, float>>>,
     test_types<
         double, algebra::eigen::point2<double>, algebra::eigen::point3<double>,
         algebra::eigen::vector2<double>, algebra::eigen::vector3<double>,
         algebra::eigen::transform3<double>, algebra::eigen::cartesian2<double>,
         algebra::eigen::polar2<double>, algebra::eigen::cylindrical2<double>,
-        std::size_t, algebra::eigen::matrix_type> >
+        int, algebra::eigen::matrix_type,
+        algebra::matrix::actor<
+            int, double, algebra::matrix::determinant::preset0<int, double>,
+            algebra::matrix::inverse::preset0<int, double>>>>
     eigen_cmath_types;
 INSTANTIATE_TYPED_TEST_SUITE_P(algebra_plugins, test_host_basics,
                                eigen_cmath_types, test_specialisation_name);

--- a/tests/eigen/eigen_eigen.cpp
+++ b/tests/eigen/eigen_eigen.cpp
@@ -38,14 +38,14 @@ typedef testing::Types<
         float, algebra::eigen::point2<float>, algebra::eigen::point3<float>,
         algebra::eigen::vector2<float>, algebra::eigen::vector3<float>,
         algebra::eigen::transform3<float>, algebra::eigen::cartesian2<float>,
-        algebra::eigen::polar2<float>, algebra::eigen::cylindrical2<float>,
-        std::size_t, algebra::eigen::matrix_type>,
+        algebra::eigen::polar2<float>, algebra::eigen::cylindrical2<float>, int,
+        algebra::eigen::matrix_type, algebra::matrix::actor<float>>,
     test_types<
         double, algebra::eigen::point2<double>, algebra::eigen::point3<double>,
         algebra::eigen::vector2<double>, algebra::eigen::vector3<double>,
         algebra::eigen::transform3<double>, algebra::eigen::cartesian2<double>,
         algebra::eigen::polar2<double>, algebra::eigen::cylindrical2<double>,
-        std::size_t, algebra::eigen::matrix_type> >
+        int, algebra::eigen::matrix_type, algebra::matrix::actor<double>>>
     eigen_eigen_types;
 INSTANTIATE_TYPED_TEST_SUITE_P(algebra_plugins, test_host_basics,
                                eigen_eigen_types, test_specialisation_name);

--- a/tests/smatrix/smatrix_cmath.cpp
+++ b/tests/smatrix/smatrix_cmath.cpp
@@ -40,14 +40,22 @@ typedef testing::Types<
         algebra::smatrix::transform3<float>,
         algebra::smatrix::cartesian2<float>, algebra::smatrix::polar2<float>,
         algebra::smatrix::cylindrical2<float>, unsigned int,
-        algebra::smatrix::matrix_type>,
+        algebra::smatrix::matrix_type,
+        algebra::matrix::actor<
+            unsigned int, float,
+            algebra::matrix::determinant::preset0<unsigned int, float>,
+            algebra::matrix::inverse::preset0<unsigned int, float>>>,
     test_types<
         double, algebra::smatrix::point2<double>,
         algebra::smatrix::point3<double>, algebra::smatrix::vector2<double>,
         algebra::smatrix::vector3<double>, algebra::smatrix::transform3<double>,
         algebra::smatrix::cartesian2<double>, algebra::smatrix::polar2<double>,
         algebra::smatrix::cylindrical2<double>, unsigned int,
-        algebra::smatrix::matrix_type> >
+        algebra::smatrix::matrix_type,
+        algebra::matrix::actor<
+            unsigned int, double,
+            algebra::matrix::determinant::preset0<unsigned int, double>,
+            algebra::matrix::inverse::preset0<unsigned int, double>>>>
     smatrix_cmath_types;
 INSTANTIATE_TYPED_TEST_SUITE_P(algebra_plugins, test_host_basics,
                                smatrix_cmath_types, test_specialisation_name);

--- a/tests/smatrix/smatrix_smatrix.cpp
+++ b/tests/smatrix/smatrix_smatrix.cpp
@@ -40,14 +40,14 @@ typedef testing::Types<
         algebra::smatrix::transform3<float>,
         algebra::smatrix::cartesian2<float>, algebra::smatrix::polar2<float>,
         algebra::smatrix::cylindrical2<float>, unsigned int,
-        algebra::smatrix::matrix_type>,
+        algebra::smatrix::matrix_type, algebra::matrix::actor<float>>,
     test_types<
         double, algebra::smatrix::point2<double>,
         algebra::smatrix::point3<double>, algebra::smatrix::vector2<double>,
         algebra::smatrix::vector3<double>, algebra::smatrix::transform3<double>,
         algebra::smatrix::cartesian2<double>, algebra::smatrix::polar2<double>,
         algebra::smatrix::cylindrical2<double>, unsigned int,
-        algebra::smatrix::matrix_type> >
+        algebra::smatrix::matrix_type, algebra::matrix::actor<double>>>
     smatrix_smatrix_types;
 INSTANTIATE_TYPED_TEST_SUITE_P(algebra_plugins, test_host_basics,
                                smatrix_smatrix_types, test_specialisation_name);

--- a/tests/vc/vc_cmath.cpp
+++ b/tests/vc/vc_cmath.cpp
@@ -38,12 +38,20 @@ typedef testing::Types<
                algebra::vc::vector2<float>, algebra::vc::vector3<float>,
                algebra::vc::transform3<float>, algebra::vc::cartesian2<float>,
                algebra::vc::polar2<float>, algebra::vc::cylindrical2<float>,
-               std::size_t, algebra::vc::matrix_type>,
+               std::size_t, algebra::vc::matrix_type,
+               algebra::matrix::actor<
+                   std::size_t, float,
+                   algebra::matrix::determinant::preset0<std::size_t, float>,
+                   algebra::matrix::inverse::preset0<std::size_t, float>>>,
     test_types<double, algebra::vc::point2<double>, algebra::vc::point3<double>,
                algebra::vc::vector2<double>, algebra::vc::vector3<double>,
                algebra::vc::transform3<double>, algebra::vc::cartesian2<double>,
                algebra::vc::polar2<double>, algebra::vc::cylindrical2<double>,
-               std::size_t, algebra::vc::matrix_type> >
+               std::size_t, algebra::vc::matrix_type,
+               algebra::matrix::actor<
+                   std::size_t, double,
+                   algebra::matrix::determinant::preset0<std::size_t, double>,
+                   algebra::matrix::inverse::preset0<std::size_t, double>>>>
     vc_cmath_types;
 INSTANTIATE_TYPED_TEST_SUITE_P(algebra_plugins, test_host_basics,
                                vc_cmath_types, test_specialisation_name);

--- a/tests/vc/vc_vc.cpp
+++ b/tests/vc/vc_vc.cpp
@@ -38,12 +38,20 @@ typedef testing::Types<
                algebra::vc::vector2<float>, algebra::vc::vector3<float>,
                algebra::vc::transform3<float>, algebra::vc::cartesian2<float>,
                algebra::vc::polar2<float>, algebra::vc::cylindrical2<float>,
-               std::size_t, algebra::vc::matrix_type>,
+               std::size_t, algebra::vc::matrix_type,
+               algebra::matrix::actor<
+                   std::size_t, float,
+                   algebra::matrix::determinant::preset0<std::size_t, float>,
+                   algebra::matrix::inverse::preset0<std::size_t, float>>>,
     test_types<double, algebra::vc::point2<double>, algebra::vc::point3<double>,
                algebra::vc::vector2<double>, algebra::vc::vector3<double>,
                algebra::vc::transform3<double>, algebra::vc::cartesian2<double>,
                algebra::vc::polar2<double>, algebra::vc::cylindrical2<double>,
-               std::size_t, algebra::vc::matrix_type> >
+               std::size_t, algebra::vc::matrix_type,
+               algebra::matrix::actor<
+                   std::size_t, double,
+                   algebra::matrix::determinant::preset0<std::size_t, double>,
+                   algebra::matrix::inverse::preset0<std::size_t, double>>>>
     vc_vc_types;
 INSTANTIATE_TYPED_TEST_SUITE_P(algebra_plugins, test_host_basics, vc_vc_types,
                                test_specialisation_name);

--- a/tests/vecmem/vecmem_cmath.cpp
+++ b/tests/vecmem/vecmem_cmath.cpp
@@ -39,14 +39,22 @@ typedef testing::Types<
         algebra::vecmem::vector2<float>, algebra::vecmem::vector3<float>,
         algebra::vecmem::transform3<float>, algebra::vecmem::cartesian2<float>,
         algebra::vecmem::polar2<float>, algebra::vecmem::cylindrical2<float>,
-        std::size_t, algebra::vecmem::matrix_type>,
+        std::size_t, algebra::vecmem::matrix_type,
+        algebra::matrix::actor<
+            std::size_t, float,
+            algebra::matrix::determinant::preset0<std::size_t, float>,
+            algebra::matrix::inverse::preset0<std::size_t, float>>>,
     test_types<
         double, algebra::vecmem::point2<double>,
         algebra::vecmem::point3<double>, algebra::vecmem::vector2<double>,
         algebra::vecmem::vector3<double>, algebra::vecmem::transform3<double>,
         algebra::vecmem::cartesian2<double>, algebra::vecmem::polar2<double>,
         algebra::vecmem::cylindrical2<double>, std::size_t,
-        algebra::vecmem::matrix_type> >
+        algebra::vecmem::matrix_type,
+        algebra::matrix::actor<
+            std::size_t, double,
+            algebra::matrix::determinant::preset0<std::size_t, double>,
+            algebra::matrix::inverse::preset0<std::size_t, double>>>>
     vecmem_cmath_types;
 INSTANTIATE_TYPED_TEST_SUITE_P(algebra_plugins, test_host_basics,
                                vecmem_cmath_types, test_specialisation_name);


### PR DESCRIPTION
This PR addresses #51 by adding generalized matrix operations.

I added operations only for `cmath` to get comments before moving forward.

Inversion algorithm just follows the simple cofactor method but don't throw me tomatoes...

@krasznaa Could you check if the overall structure is okay?

---------------------------------------------------------------------

## Update - March 19

After getting some comments during the last parallelization meeting, I made the customization of `cmath` matrix operation very user-friendly. In a nutshell, users can decide _which algorithm to use with which dimensions_ by composing the `matrix_getter` object with `algorithm<size_t ... dim>` structs.

### How to use

In this PR,  `matrix_getter` only supports the inversion operation but we can easily extend it to the multiplication operations as well.

```c++
  // Base inversion operation: LU decomposition
  // For {1x1, 2x2, 3x3} matrices, we want to use cofactor method
  // For {4x4, 5x5} matrices, we want to use hard coded calculation
  // For any other dimension, LU decomposition will be used
  using inverse_getter = inverse_getter<LU_decomposition<>, cofactor<1,2,3>, hard_code<4,5>>;
  using matrix_getter = matrix_getter<inverse_getter>
  
  matrix<2,2> m22;
  matrix<4,4> m44;
  matrix<9,9> m99;
  auto m22_inv = matrix_getter().inverse(m22) // cofactor
  auto m44_inv = matrix_getter().inverse(m44) // hard coded inversion operation
  auto m99_inv = matrix_getter().inverse(m99) // LU_decomposition
```

IMAO, this composition is a super strong feature because users can build their own operation with pre-existing algorithms. (BTW, the algorithms that I added in this PR are just cofactor method and 2X2 hard coded calculation. We will need to add more algorithms)


Now let me explain three new structs one-by-one

### 1. Matrix getter

matrix getter is the downstream type which can operate the matrix operations. It takes matrix operation types as a template parameter.

```c++
// Defined in cmath_getter.hpp
template <typename size_type, template <typename, size_type> class array_t,
          template <typename, size_type, size_type> class matrix_t,
          typename scalar_t, class inverse_getter_t,
          class element_getter_t = element_getter<size_type, array_t, scalar_t>>
struct matrix_getter { 
  // Create inverse matrix
  template <size_type N>
  ALGEBRA_HOST_DEVICE inline matrix_type<N, N> inverse(
      const matrix_type<N, N> &m) {

    return inverse_getter_t()(m);
  }
}
```

As I said earlier, there is only inversion operator currently - but we can also add multiplication operation just by adding one more template parameter.


### 2. Matrix operation type

Matrix operation (such as `inverse_getter`) is an aggregation of the algorithms for the same operation type. For example, the `inverse_getter` can be composed with different inversion algorithms (e.g.) cofactor method, hard coded calculation, LU decomposition) each of which is applied to different matrix dimensions. `find_algorithms`, defined in `algorithms/utils/algorithm_finder.hpp`, finds the algorithm any of whose given dimensions is matched to the dimension of input matrix.

```c++
// Defined in cmath_matrix.hpp
template <typename size_type, template <typename, size_type> class array_t,
          template <typename, size_type, size_type> class matrix_t,
          typename scalar_t, class element_getter_t, class... As>
struct inverse_getter {
  /// Function (object) used for accessing a matrix element
  using element_getter = element_getter_t;

  /// 2D matrix type
  template <size_type ROWS, size_type COLS>
  using matrix_type = matrix_t<scalar_t, ROWS, COLS>;

  template <size_type N>
  ALGEBRA_HOST_DEVICE inline matrix_type<N, N> operator()(
      const matrix_type<N, N> &m) const {

    return typename find_algorithm<size_type, N, As...>::algorithm_type()(m);
  }
}
```

### 3. Algorithm type

Any individual algorithm struct takes variadic variables (`size_type ... Ds`) that indicate which matrix dimensions will be operated by the algorithm.

```c++
/// Defined in algorithms/matrix_inversion/cofactor.hpp
template <typename size_type, template <typename, size_type> class array_t,
          template <typename, size_type, size_type> class matrix_t,
          typename scalar_t, class element_getter_t, size_type... Ds>
struct inverse_cofactor {
  /// 2D matrix type
  template <size_type ROWS, size_type COLS>
  using matrix_type = matrix_t<scalar_t, ROWS, COLS>;

  template <size_type N>
  ALGEBRA_HOST_DEVICE inline matrix_type<N, N> operator()(
      const matrix_type<N, N> &m) const {
     //... actual algorithm written
  }
}
```