### PR TITLE
Refactor Transform3 with Matrix Actor

### DIFF
--- a/frontend/array_cmath/include/algebra/array_cmath.hpp
+++ b/frontend/array_cmath/include/algebra/array_cmath.hpp
@@ -21,23 +21,6 @@ using algebra::cmath::operator+;
 /// @}
 
 namespace algebra {
-namespace array {
-
-/// @name cmath based transforms on @c algebra::array::storage_type
-/// @{
-
-template <typename T>
-using transform3 = cmath::transform3<std::size_t, array::storage_type, T>;
-template <typename T>
-using cartesian2 = cmath::cartesian2<transform3<T>>;
-template <typename T>
-using polar2 = cmath::polar2<transform3<T>>;
-template <typename T>
-using cylindrical2 = cmath::cylindrical2<transform3<T>>;
-
-/// @}
-
-}  // namespace array
 
 namespace getter {
 
@@ -87,19 +70,26 @@ using cmath::normalize;
 
 namespace matrix {
 
+template <typename T, std::size_t N>
+using array_type = array::storage_type<T, N>;
+
 template <typename T, std::size_t ROWS, std::size_t COLS>
 using matrix_type = array::matrix_type<T, ROWS, COLS>;
 
 template <typename size_type, typename scalar_t>
 using element_getter_type =
-    cmath::element_getter<size_type, array::storage_type, scalar_t>;
+    cmath::element_getter<size_type, array_type, scalar_t>;
+
+template <typename size_type, typename scalar_t>
+using block_getter_type = cmath::block_getter<size_type, array_type, scalar_t>;
 
 // matrix actor
 template <typename size_type, typename scalar_t, typename determinant_actor_t,
           typename inverse_actor_t>
-using actor = cmath::matrix::actor<size_type, matrix_type, scalar_t,
+using actor = cmath::matrix::actor<size_type, array_type, matrix_type, scalar_t,
                                    determinant_actor_t, inverse_actor_t,
-                                   element_getter_type<size_type, scalar_t>>;
+                                   element_getter_type<size_type, scalar_t>,
+                                   block_getter_type<size_type, scalar_t>>;
 
 namespace determinant {
 
@@ -123,7 +113,7 @@ using hard_coded = cmath::matrix::determinant::hard_coded<
 // preset(s) as standard option(s) for user's convenience
 template <typename size_type, typename scalar_t>
 using preset0 = actor<size_type, scalar_t, cofactor<size_type, scalar_t>,
-                      hard_coded<size_type, scalar_t, 2>>;
+                      hard_coded<size_type, scalar_t, 2, 4>>;
 
 }  // namespace determinant
 
@@ -151,10 +141,33 @@ using hard_coded =
 // preset(s) as standard option(s) for user's convenience
 template <typename size_type, typename scalar_t>
 using preset0 = actor<size_type, scalar_t, cofactor<size_type, scalar_t>,
-                      hard_coded<size_type, scalar_t, 2>>;
+                      hard_coded<size_type, scalar_t, 2, 4>>;
 
 }  // namespace inverse
 
 }  // namespace matrix
+
+namespace array {
+
+/// @name cmath based transforms on @c algebra::matrix::actor
+/// @{
+
+template <typename T>
+using transform3_actor =
+    matrix::actor<std::size_t, T, matrix::determinant::preset0<std::size_t, T>,
+                  matrix::inverse::preset0<std::size_t, T>>;
+
+template <typename T>
+using transform3 = cmath::transform3<transform3_actor<T>>;
+template <typename T>
+using cartesian2 = cmath::cartesian2<transform3<T>>;
+template <typename T>
+using polar2 = cmath::polar2<transform3<T>>;
+template <typename T>
+using cylindrical2 = cmath::cylindrical2<transform3<T>>;
+
+/// @}
+
+}  // namespace array
 
 }  // namespace algebra

--- a/frontend/eigen_cmath/include/algebra/eigen_cmath.hpp
+++ b/frontend/eigen_cmath/include/algebra/eigen_cmath.hpp
@@ -23,26 +23,6 @@
 #include <type_traits>
 
 namespace algebra {
-namespace eigen {
-
-/// @name cmath based transforms on @c algebra::eigen::storage_type
-/// @{
-
-template <typename T>
-using transform3 = cmath::transform3<
-    int, eigen::storage_type, T,
-    typename Eigen::Transform<T, 3, Eigen::Affine>::MatrixType,
-    math::element_getter, math::block_getter>;
-template <typename T>
-using cartesian2 = cmath::cartesian2<transform3<T>>;
-template <typename T>
-using polar2 = cmath::polar2<transform3<T>>;
-template <typename T>
-using cylindrical2 = cmath::cylindrical2<transform3<T>>;
-
-/// @}
-
-}  // namespace eigen
 
 namespace getter {
 
@@ -90,16 +70,19 @@ using eigen::math::normalize;
 
 namespace matrix {
 
+template <typename T, int N>
+using array_type = eigen::storage_type<T, N>;
 template <typename T, int ROWS, int COLS>
 using matrix_type = eigen::matrix_type<T, ROWS, COLS>;
 using element_getter_type = eigen::math::element_getter;
+using block_getter_type = eigen::math::block_getter;
 
 // matrix actor
 template <typename size_type, typename scalar_t, typename determinant_actor_t,
           typename inverse_actor_t>
-using actor =
-    cmath::matrix::actor<size_type, matrix_type, scalar_t, determinant_actor_t,
-                         inverse_actor_t, element_getter_type>;
+using actor = cmath::matrix::actor<size_type, array_type, matrix_type, scalar_t,
+                                   determinant_actor_t, inverse_actor_t,
+                                   element_getter_type, block_getter_type>;
 
 namespace determinant {
 
@@ -123,7 +106,7 @@ using hard_coded =
 // preset(s) as standard option(s) for user's convenience
 template <typename size_type, typename scalar_t>
 using preset0 = actor<size_type, scalar_t, cofactor<size_type, scalar_t>,
-                      hard_coded<size_type, scalar_t, 2>>;
+                      hard_coded<size_type, scalar_t, 2, 4>>;
 
 }  // namespace determinant
 
@@ -149,10 +132,34 @@ using hard_coded =
 // preset(s) as standard option(s) for user's convenience
 template <typename size_type, typename scalar_t>
 using preset0 = actor<size_type, scalar_t, cofactor<size_type, scalar_t>,
-                      hard_coded<size_type, scalar_t, 2>>;
+                      hard_coded<size_type, scalar_t, 2, 4>>;
 
 }  // namespace inverse
 
 }  // namespace matrix
+
+namespace eigen {
+
+/// @name cmath based transforms on @c algebra::matrix::actor
+/// @{
+
+template <typename T>
+using transform3_actor =
+    algebra::matrix::actor<int, T,
+                           algebra::matrix::determinant::preset0<int, T>,
+                           algebra::matrix::inverse::preset0<int, T>>;
+
+template <typename T>
+using transform3 = cmath::transform3<transform3_actor<T>>;
+template <typename T>
+using cartesian2 = cmath::cartesian2<transform3<T>>;
+template <typename T>
+using polar2 = cmath::polar2<transform3<T>>;
+template <typename T>
+using cylindrical2 = cmath::cylindrical2<transform3<T>>;
+
+/// @}
+
+}  // namespace eigen
 
 }  // namespace algebra

--- a/frontend/smatrix_cmath/include/algebra/smatrix_cmath.hpp
+++ b/frontend/smatrix_cmath/include/algebra/smatrix_cmath.hpp
@@ -16,27 +16,6 @@
 #include <Math/SMatrix.h>
 
 namespace algebra {
-namespace smatrix {
-
-/// @name cmath based transforms on @c algebra::smatrix::storage_type
-/// @{
-
-template <typename T>
-using transform3 =
-    cmath::transform3<unsigned int, smatrix::storage_type, T,
-                      ROOT::Math::SMatrix<T, 4, 4>, math::element_getter<T>,
-                      math::block_getter<T>>;
-template <typename T>
-using cartesian2 = cmath::cartesian2<transform3<T>>;
-template <typename T>
-using polar2 = cmath::polar2<transform3<T>>;
-template <typename T>
-using cylindrical2 = cmath::cylindrical2<transform3<T>>;
-
-/// @}
-
-}  // namespace smatrix
-
 namespace getter {
 
 /// @name Getter functions on @c algebra::smatrix::storage_type
@@ -85,17 +64,22 @@ using smatrix::math::normalize;
 
 namespace matrix {
 
+template <typename T, unsigned int N>
+using array_type = smatrix::storage_type<T, N>;
 template <typename T, unsigned int ROWS, unsigned int COLS>
 using matrix_type = smatrix::matrix_type<T, ROWS, COLS>;
 template <typename scalar_t>
 using element_getter_type = smatrix::math::element_getter<scalar_t>;
+template <typename scalar_t>
+using block_getter_type = smatrix::math::block_getter<scalar_t>;
 
 // matrix actor
 template <typename size_type, typename scalar_t, typename determinant_actor_t,
           typename inverse_actor_t>
-using actor =
-    cmath::matrix::actor<size_type, matrix_type, scalar_t, determinant_actor_t,
-                         inverse_actor_t, element_getter_type<scalar_t>>;
+using actor = cmath::matrix::actor<size_type, array_type, matrix_type, scalar_t,
+                                   determinant_actor_t, inverse_actor_t,
+                                   element_getter_type<scalar_t>,
+                                   block_getter_type<scalar_t>>;
 
 namespace determinant {
 
@@ -118,7 +102,7 @@ using hard_coded = cmath::matrix::determinant::hard_coded<
 // preset(s) as standard option(s) for user's convenience
 template <typename size_type, typename scalar_t>
 using preset0 = actor<size_type, scalar_t, cofactor<size_type, scalar_t>,
-                      hard_coded<size_type, scalar_t, 2>>;
+                      hard_coded<size_type, scalar_t, 2, 4>>;
 
 }  // namespace determinant
 
@@ -144,10 +128,33 @@ using hard_coded =
 // preset(s) as standard option(s) for user's convenience
 template <typename size_type, typename scalar_t>
 using preset0 = actor<size_type, scalar_t, cofactor<size_type, scalar_t>,
-                      hard_coded<size_type, scalar_t, 2>>;
+                      hard_coded<size_type, scalar_t, 2, 4>>;
 
 }  // namespace inverse
 
 }  // namespace matrix
+
+namespace smatrix {
+
+/// @name cmath based transforms on @c algebra::matrix::actor
+/// @{
+
+template <typename T>
+using transform3_actor = algebra::matrix::actor<
+    unsigned int, T, algebra::matrix::determinant::preset0<unsigned int, T>,
+    algebra::matrix::inverse::preset0<unsigned int, T>>;
+
+template <typename T>
+using transform3 = cmath::transform3<transform3_actor<T>>;
+template <typename T>
+using cartesian2 = cmath::cartesian2<transform3<T>>;
+template <typename T>
+using polar2 = cmath::polar2<transform3<T>>;
+template <typename T>
+using cylindrical2 = cmath::cylindrical2<transform3<T>>;
+
+/// @}
+
+}  // namespace smatrix
 
 }  // namespace algebra

--- a/frontend/vc_cmath/include/algebra/vc_cmath.hpp
+++ b/frontend/vc_cmath/include/algebra/vc_cmath.hpp
@@ -89,10 +89,10 @@ using matrix_type = vc::matrix_type<T, ROWS, COLS>;
 
 template <typename size_type, typename scalar_t>
 using element_getter_type =
-    cmath::element_getter<size_type, Vc::array, scalar_t>;
+    cmath::element_getter<size_type, array_type, scalar_t>;
 
 template <typename size_type, typename scalar_t>
-using block_getter_type = cmath::block_getter<size_type, Vc::array, scalar_t>;
+using block_getter_type = cmath::block_getter<size_type, array_type, scalar_t>;
 
 // matrix actor
 template <typename size_type, typename scalar_t, typename determinant_actor_t,

--- a/frontend/vc_cmath/include/algebra/vc_cmath.hpp
+++ b/frontend/vc_cmath/include/algebra/vc_cmath.hpp
@@ -22,34 +22,6 @@ using algebra::cmath::operator+;
 /// @}
 
 namespace algebra {
-namespace vc {
-
-/// @name cmath based transforms on @c algebra::vc types
-/// @{
-
-// Pull in the definitions needed by the cmath transforms, into this namespace.
-using math::cross;
-using math::perp;
-using math::phi;
-
-template <typename T>
-using transform3 =
-    cmath::transform3<std::size_t, vc::storage_type, T,
-                      Vc::array<Vc::array<T, 4>, 4>,
-                      cmath::element_getter<std::size_t, Vc::array, T>,
-                      cmath::block_getter<std::size_t, Vc::array, T>,
-                      vc::vector3<T>, vc::point2<T>>;
-template <typename T>
-using cartesian2 = cmath::cartesian2<transform3<T>>;
-template <typename T>
-using polar2 = cmath::polar2<transform3<T>>;
-template <typename T>
-using cylindrical2 = cmath::cylindrical2<transform3<T>>;
-
-/// @}
-
-}  // namespace vc
-
 namespace getter {
 
 /// @name Getter functions on @c algebra::vc types
@@ -109,6 +81,9 @@ using vc::math::normalize;
 
 namespace matrix {
 
+template <typename T, std::size_t N>
+using array_type = Vc::array<T, N>;
+
 template <typename T, std::size_t ROWS, std::size_t COLS>
 using matrix_type = vc::matrix_type<T, ROWS, COLS>;
 
@@ -116,12 +91,16 @@ template <typename size_type, typename scalar_t>
 using element_getter_type =
     cmath::element_getter<size_type, Vc::array, scalar_t>;
 
+template <typename size_type, typename scalar_t>
+using block_getter_type = cmath::block_getter<size_type, Vc::array, scalar_t>;
+
 // matrix actor
 template <typename size_type, typename scalar_t, typename determinant_actor_t,
           typename inverse_actor_t>
-using actor = cmath::matrix::actor<size_type, matrix_type, scalar_t,
+using actor = cmath::matrix::actor<size_type, array_type, matrix_type, scalar_t,
                                    determinant_actor_t, inverse_actor_t,
-                                   element_getter_type<size_type, scalar_t>>;
+                                   element_getter_type<size_type, scalar_t>,
+                                   block_getter_type<size_type, scalar_t>>;
 
 namespace determinant {
 
@@ -145,7 +124,7 @@ using hard_coded = cmath::matrix::determinant::hard_coded<
 // preset(s) as standard option(s) for user's convenience
 template <typename size_type, typename scalar_t>
 using preset0 = actor<size_type, scalar_t, cofactor<size_type, scalar_t>,
-                      hard_coded<size_type, scalar_t, 2>>;
+                      hard_coded<size_type, scalar_t, 2, 4>>;
 
 }  // namespace determinant
 
@@ -173,10 +152,33 @@ using hard_coded =
 // preset(s) as standard option(s) for user's convenience
 template <typename size_type, typename scalar_t>
 using preset0 = actor<size_type, scalar_t, cofactor<size_type, scalar_t>,
-                      hard_coded<size_type, scalar_t, 2>>;
+                      hard_coded<size_type, scalar_t, 2, 4>>;
 
 }  // namespace inverse
 
 }  // namespace matrix
+
+namespace vc {
+
+/// @name cmath based transforms on @c algebra::matrix::actor
+/// @{
+
+template <typename T>
+using transform3_actor =
+    matrix::actor<std::size_t, T, matrix::determinant::preset0<std::size_t, T>,
+                  matrix::inverse::preset0<std::size_t, T>>;
+
+template <typename T>
+using transform3 = cmath::transform3<transform3_actor<T>>;
+template <typename T>
+using cartesian2 = cmath::cartesian2<transform3<T>>;
+template <typename T>
+using polar2 = cmath::polar2<transform3<T>>;
+template <typename T>
+using cylindrical2 = cmath::cylindrical2<transform3<T>>;
+
+/// @}
+
+}  // namespace vc
 
 }  // namespace algebra

--- a/frontend/vc_vc/include/algebra/vc_vc.hpp
+++ b/frontend/vc_vc/include/algebra/vc_vc.hpp
@@ -148,6 +148,9 @@ using vc::math::normalize;
 
 namespace matrix {
 
+template <typename T, std::size_t N>
+using array_type = vc::storage_type<T, N>;
+
 template <typename T, std::size_t ROWS, std::size_t COLS>
 using matrix_type = vc::matrix_type<T, ROWS, COLS>;
 
@@ -155,12 +158,16 @@ template <typename size_type, typename scalar_t>
 using element_getter_type =
     cmath::element_getter<size_type, Vc::array, scalar_t>;
 
+template <typename size_type, typename scalar_t>
+using block_getter_type = cmath::block_getter<size_type, Vc::array, scalar_t>;
+
 // matrix actor
 template <typename size_type, typename scalar_t, typename determinant_actor_t,
           typename inverse_actor_t>
-using actor = cmath::matrix::actor<size_type, matrix_type, scalar_t,
+using actor = cmath::matrix::actor<size_type, array_type, matrix_type, scalar_t,
                                    determinant_actor_t, inverse_actor_t,
-                                   element_getter_type<size_type, scalar_t>>;
+                                   element_getter_type<size_type, scalar_t>,
+                                   block_getter_type<size_type, scalar_t>>;
 
 namespace determinant {
 
@@ -184,7 +191,7 @@ using hard_coded = cmath::matrix::determinant::hard_coded<
 // preset(s) as standard option(s) for user's convenience
 template <typename size_type, typename scalar_t>
 using preset0 = actor<size_type, scalar_t, cofactor<size_type, scalar_t>,
-                      hard_coded<size_type, scalar_t, 2>>;
+                      hard_coded<size_type, scalar_t, 2, 4>>;
 
 }  // namespace determinant
 
@@ -212,10 +219,9 @@ using hard_coded =
 // preset(s) as standard option(s) for user's convenience
 template <typename size_type, typename scalar_t>
 using preset0 = actor<size_type, scalar_t, cofactor<size_type, scalar_t>,
-                      hard_coded<size_type, scalar_t, 2>>;
+                      hard_coded<size_type, scalar_t, 2, 4>>;
 
 }  // namespace inverse
 
 }  // namespace matrix
-
 }  // namespace algebra

--- a/frontend/vecmem_cmath/include/algebra/vecmem_cmath.hpp
+++ b/frontend/vecmem_cmath/include/algebra/vecmem_cmath.hpp
@@ -21,23 +21,6 @@ using algebra::cmath::operator+;
 /// @}
 
 namespace algebra {
-namespace vecmem {
-
-/// @name cmath based transforms on @c algebra::vecmem::storage_type
-/// @{
-
-template <typename T>
-using transform3 = cmath::transform3<std::size_t, vecmem::storage_type, T>;
-template <typename T>
-using cartesian2 = cmath::cartesian2<transform3<T>>;
-template <typename T>
-using polar2 = cmath::polar2<transform3<T>>;
-template <typename T>
-using cylindrical2 = cmath::cylindrical2<transform3<T>>;
-
-/// @}
-
-}  // namespace vecmem
 
 namespace getter {
 
@@ -88,19 +71,25 @@ using cmath::normalize;
 
 namespace matrix {
 
+template <typename T, std::size_t N>
+using array_type = vecmem::storage_type<T, N>;
 template <typename T, std::size_t ROWS, std::size_t COLS>
 using matrix_type = vecmem::matrix_type<T, ROWS, COLS>;
 
 template <typename size_type, typename scalar_t>
 using element_getter_type =
-    cmath::element_getter<size_type, vecmem::storage_type, scalar_t>;
+    cmath::element_getter<size_type, array_type, scalar_t>;
+
+template <typename size_type, typename scalar_t>
+using block_getter_type = cmath::block_getter<size_type, array_type, scalar_t>;
 
 // matrix actor
 template <typename size_type, typename scalar_t, typename determinant_actor_t,
           typename inverse_actor_t>
-using actor = cmath::matrix::actor<size_type, matrix_type, scalar_t,
+using actor = cmath::matrix::actor<size_type, array_type, matrix_type, scalar_t,
                                    determinant_actor_t, inverse_actor_t,
-                                   element_getter_type<size_type, scalar_t>>;
+                                   element_getter_type<size_type, scalar_t>,
+                                   block_getter_type<size_type, scalar_t>>;
 
 namespace determinant {
 
@@ -124,7 +113,7 @@ using hard_coded = cmath::matrix::determinant::hard_coded<
 // preset(s) as standard option(s) for user's convenience
 template <typename size_type, typename scalar_t>
 using preset0 = actor<size_type, scalar_t, cofactor<size_type, scalar_t>,
-                      hard_coded<size_type, scalar_t, 2>>;
+                      hard_coded<size_type, scalar_t, 2, 4>>;
 
 }  // namespace determinant
 
@@ -152,10 +141,33 @@ using hard_coded =
 // preset(s) as standard option(s) for user's convenience
 template <typename size_type, typename scalar_t>
 using preset0 = actor<size_type, scalar_t, cofactor<size_type, scalar_t>,
-                      hard_coded<size_type, scalar_t, 2>>;
+                      hard_coded<size_type, scalar_t, 2, 4>>;
 
 }  // namespace inverse
 
 }  // namespace matrix
+
+namespace vecmem {
+
+/// @name cmath based transforms on @c algebra::matrix::actor
+/// @{
+
+template <typename T>
+using transform3_actor =
+    matrix::actor<std::size_t, T, matrix::determinant::preset0<std::size_t, T>,
+                  matrix::inverse::preset0<std::size_t, T>>;
+
+template <typename T>
+using transform3 = cmath::transform3<transform3_actor<T>>;
+template <typename T>
+using cartesian2 = cmath::cartesian2<transform3<T>>;
+template <typename T>
+using polar2 = cmath::polar2<transform3<T>>;
+template <typename T>
+using cylindrical2 = cmath::cylindrical2<transform3<T>>;
+
+/// @}
+
+}  // namespace vecmem
 
 }  // namespace algebra

--- a/math/cmath/include/algebra/math/algorithms/matrix/determinant/hard_coded.hpp
+++ b/math/cmath/include/algebra/math/algorithms/matrix/determinant/hard_coded.hpp
@@ -35,10 +35,63 @@ struct hard_coded {
   ALGEBRA_HOST_DEVICE inline scalar_t operator()(
       const matrix_type<N, N> &m) const {
 
-    scalar_t det = element_getter()(m, 0, 0) * element_getter()(m, 1, 1) -
-                   element_getter()(m, 0, 1) * element_getter()(m, 1, 0);
+    return element_getter()(m, 0, 0) * element_getter()(m, 1, 1) -
+           element_getter()(m, 0, 1) * element_getter()(m, 1, 0);
+  }
 
-    return det;
+  // 4 X 4 matrix determinant
+  template <size_type N, std::enable_if_t<N == 4, bool> = true>
+  ALGEBRA_HOST_DEVICE inline scalar_t operator()(
+      const matrix_type<N, N> &m) const {
+
+    return element_getter()(m, 0, 3) * element_getter()(m, 1, 2) *
+               element_getter()(m, 2, 1) * element_getter()(m, 3, 0) -
+           element_getter()(m, 0, 2) * element_getter()(m, 1, 3) *
+               element_getter()(m, 2, 1) * element_getter()(m, 3, 0) -
+           element_getter()(m, 0, 3) * element_getter()(m, 1, 1) *
+               element_getter()(m, 2, 2) * element_getter()(m, 3, 0) +
+           element_getter()(m, 0, 1) * element_getter()(m, 1, 3) *
+               element_getter()(m, 2, 2) * element_getter()(m, 3, 0) +
+           element_getter()(m, 0, 2) * element_getter()(m, 1, 1) *
+               element_getter()(m, 2, 3) * element_getter()(m, 3, 0) -
+           element_getter()(m, 0, 1) * element_getter()(m, 1, 2) *
+               element_getter()(m, 2, 3) * element_getter()(m, 3, 0) -
+           element_getter()(m, 0, 3) * element_getter()(m, 1, 2) *
+               element_getter()(m, 2, 0) * element_getter()(m, 3, 1) +
+           element_getter()(m, 0, 2) * element_getter()(m, 1, 3) *
+               element_getter()(m, 2, 0) * element_getter()(m, 3, 1) +
+           element_getter()(m, 0, 3) * element_getter()(m, 1, 0) *
+               element_getter()(m, 2, 2) * element_getter()(m, 3, 1) -
+           element_getter()(m, 0, 0) * element_getter()(m, 1, 3) *
+               element_getter()(m, 2, 2) * element_getter()(m, 3, 1) -
+           element_getter()(m, 0, 2) * element_getter()(m, 1, 0) *
+               element_getter()(m, 2, 3) * element_getter()(m, 3, 1) +
+           element_getter()(m, 0, 0) * element_getter()(m, 1, 2) *
+               element_getter()(m, 2, 3) * element_getter()(m, 3, 1) +
+           element_getter()(m, 0, 3) * element_getter()(m, 1, 1) *
+               element_getter()(m, 2, 0) * element_getter()(m, 3, 2) -
+           element_getter()(m, 0, 1) * element_getter()(m, 1, 3) *
+               element_getter()(m, 2, 0) * element_getter()(m, 3, 2) -
+           element_getter()(m, 0, 3) * element_getter()(m, 1, 0) *
+               element_getter()(m, 2, 1) * element_getter()(m, 3, 2) +
+           element_getter()(m, 0, 0) * element_getter()(m, 1, 3) *
+               element_getter()(m, 2, 1) * element_getter()(m, 3, 2) +
+           element_getter()(m, 0, 1) * element_getter()(m, 1, 0) *
+               element_getter()(m, 2, 3) * element_getter()(m, 3, 2) -
+           element_getter()(m, 0, 0) * element_getter()(m, 1, 1) *
+               element_getter()(m, 2, 3) * element_getter()(m, 3, 2) -
+           element_getter()(m, 0, 2) * element_getter()(m, 1, 1) *
+               element_getter()(m, 2, 0) * element_getter()(m, 3, 3) +
+           element_getter()(m, 0, 1) * element_getter()(m, 1, 2) *
+               element_getter()(m, 2, 0) * element_getter()(m, 3, 3) +
+           element_getter()(m, 0, 2) * element_getter()(m, 1, 0) *
+               element_getter()(m, 2, 1) * element_getter()(m, 3, 3) -
+           element_getter()(m, 0, 0) * element_getter()(m, 1, 2) *
+               element_getter()(m, 2, 1) * element_getter()(m, 3, 3) -
+           element_getter()(m, 0, 1) * element_getter()(m, 1, 0) *
+               element_getter()(m, 2, 2) * element_getter()(m, 3, 3) +
+           element_getter()(m, 0, 0) * element_getter()(m, 1, 1) *
+               element_getter()(m, 2, 2) * element_getter()(m, 3, 3);
   }
 };
 

--- a/math/cmath/include/algebra/math/algorithms/matrix/inverse/hard_coded.hpp
+++ b/math/cmath/include/algebra/math/algorithms/matrix/inverse/hard_coded.hpp
@@ -50,6 +50,230 @@ struct hard_coded {
 
     return ret;
   }
+
+  // 4 X 4 matrix inverse
+  template <size_type N, std::enable_if_t<N == 4, bool> = true>
+  ALGEBRA_HOST_DEVICE inline matrix_type<N, N> operator()(
+      const matrix_type<N, N> &m) const {
+
+    matrix_type<N, N> ret;
+    element_getter()(ret, 0, 0) =
+        element_getter()(m, 1, 2) * element_getter()(m, 2, 3) *
+            element_getter()(m, 3, 1) -
+        element_getter()(m, 1, 3) * element_getter()(m, 2, 2) *
+            element_getter()(m, 3, 1) +
+        element_getter()(m, 1, 3) * element_getter()(m, 2, 1) *
+            element_getter()(m, 3, 2) -
+        element_getter()(m, 1, 1) * element_getter()(m, 2, 3) *
+            element_getter()(m, 3, 2) -
+        element_getter()(m, 1, 2) * element_getter()(m, 2, 1) *
+            element_getter()(m, 3, 3) +
+        element_getter()(m, 1, 1) * element_getter()(m, 2, 2) *
+            element_getter()(m, 3, 3);
+    element_getter()(ret, 0, 1) =
+        element_getter()(m, 0, 3) * element_getter()(m, 2, 2) *
+            element_getter()(m, 3, 1) -
+        element_getter()(m, 0, 2) * element_getter()(m, 2, 3) *
+            element_getter()(m, 3, 1) -
+        element_getter()(m, 0, 3) * element_getter()(m, 2, 1) *
+            element_getter()(m, 3, 2) +
+        element_getter()(m, 0, 1) * element_getter()(m, 2, 3) *
+            element_getter()(m, 3, 2) +
+        element_getter()(m, 0, 2) * element_getter()(m, 2, 1) *
+            element_getter()(m, 3, 3) -
+        element_getter()(m, 0, 1) * element_getter()(m, 2, 2) *
+            element_getter()(m, 3, 3);
+    element_getter()(ret, 0, 2) =
+        element_getter()(m, 0, 2) * element_getter()(m, 1, 3) *
+            element_getter()(m, 3, 1) -
+        element_getter()(m, 0, 3) * element_getter()(m, 1, 2) *
+            element_getter()(m, 3, 1) +
+        element_getter()(m, 0, 3) * element_getter()(m, 1, 1) *
+            element_getter()(m, 3, 2) -
+        element_getter()(m, 0, 1) * element_getter()(m, 1, 3) *
+            element_getter()(m, 3, 2) -
+        element_getter()(m, 0, 2) * element_getter()(m, 1, 1) *
+            element_getter()(m, 3, 3) +
+        element_getter()(m, 0, 1) * element_getter()(m, 1, 2) *
+            element_getter()(m, 3, 3);
+    element_getter()(ret, 0, 3) =
+        element_getter()(m, 0, 3) * element_getter()(m, 1, 2) *
+            element_getter()(m, 2, 1) -
+        element_getter()(m, 0, 2) * element_getter()(m, 1, 3) *
+            element_getter()(m, 2, 1) -
+        element_getter()(m, 0, 3) * element_getter()(m, 1, 1) *
+            element_getter()(m, 2, 2) +
+        element_getter()(m, 0, 1) * element_getter()(m, 1, 3) *
+            element_getter()(m, 2, 2) +
+        element_getter()(m, 0, 2) * element_getter()(m, 1, 1) *
+            element_getter()(m, 2, 3) -
+        element_getter()(m, 0, 1) * element_getter()(m, 1, 2) *
+            element_getter()(m, 2, 3);
+    element_getter()(ret, 1, 0) =
+        element_getter()(m, 1, 3) * element_getter()(m, 2, 2) *
+            element_getter()(m, 3, 0) -
+        element_getter()(m, 1, 2) * element_getter()(m, 2, 3) *
+            element_getter()(m, 3, 0) -
+        element_getter()(m, 1, 3) * element_getter()(m, 2, 0) *
+            element_getter()(m, 3, 2) +
+        element_getter()(m, 1, 0) * element_getter()(m, 2, 3) *
+            element_getter()(m, 3, 2) +
+        element_getter()(m, 1, 2) * element_getter()(m, 2, 0) *
+            element_getter()(m, 3, 3) -
+        element_getter()(m, 1, 0) * element_getter()(m, 2, 2) *
+            element_getter()(m, 3, 3);
+    element_getter()(ret, 1, 1) =
+        element_getter()(m, 0, 2) * element_getter()(m, 2, 3) *
+            element_getter()(m, 3, 0) -
+        element_getter()(m, 0, 3) * element_getter()(m, 2, 2) *
+            element_getter()(m, 3, 0) +
+        element_getter()(m, 0, 3) * element_getter()(m, 2, 0) *
+            element_getter()(m, 3, 2) -
+        element_getter()(m, 0, 0) * element_getter()(m, 2, 3) *
+            element_getter()(m, 3, 2) -
+        element_getter()(m, 0, 2) * element_getter()(m, 2, 0) *
+            element_getter()(m, 3, 3) +
+        element_getter()(m, 0, 0) * element_getter()(m, 2, 2) *
+            element_getter()(m, 3, 3);
+    element_getter()(ret, 1, 2) =
+        element_getter()(m, 0, 3) * element_getter()(m, 1, 2) *
+            element_getter()(m, 3, 0) -
+        element_getter()(m, 0, 2) * element_getter()(m, 1, 3) *
+            element_getter()(m, 3, 0) -
+        element_getter()(m, 0, 3) * element_getter()(m, 1, 0) *
+            element_getter()(m, 3, 2) +
+        element_getter()(m, 0, 0) * element_getter()(m, 1, 3) *
+            element_getter()(m, 3, 2) +
+        element_getter()(m, 0, 2) * element_getter()(m, 1, 0) *
+            element_getter()(m, 3, 3) -
+        element_getter()(m, 0, 0) * element_getter()(m, 1, 2) *
+            element_getter()(m, 3, 3);
+    element_getter()(ret, 1, 3) =
+        element_getter()(m, 0, 2) * element_getter()(m, 1, 3) *
+            element_getter()(m, 2, 0) -
+        element_getter()(m, 0, 3) * element_getter()(m, 1, 2) *
+            element_getter()(m, 2, 0) +
+        element_getter()(m, 0, 3) * element_getter()(m, 1, 0) *
+            element_getter()(m, 2, 2) -
+        element_getter()(m, 0, 0) * element_getter()(m, 1, 3) *
+            element_getter()(m, 2, 2) -
+        element_getter()(m, 0, 2) * element_getter()(m, 1, 0) *
+            element_getter()(m, 2, 3) +
+        element_getter()(m, 0, 0) * element_getter()(m, 1, 2) *
+            element_getter()(m, 2, 3);
+    element_getter()(ret, 2, 0) =
+        element_getter()(m, 1, 1) * element_getter()(m, 2, 3) *
+            element_getter()(m, 3, 0) -
+        element_getter()(m, 1, 3) * element_getter()(m, 2, 1) *
+            element_getter()(m, 3, 0) +
+        element_getter()(m, 1, 3) * element_getter()(m, 2, 0) *
+            element_getter()(m, 3, 1) -
+        element_getter()(m, 1, 0) * element_getter()(m, 2, 3) *
+            element_getter()(m, 3, 1) -
+        element_getter()(m, 1, 1) * element_getter()(m, 2, 0) *
+            element_getter()(m, 3, 3) +
+        element_getter()(m, 1, 0) * element_getter()(m, 2, 1) *
+            element_getter()(m, 3, 3);
+    element_getter()(ret, 2, 1) =
+        element_getter()(m, 0, 3) * element_getter()(m, 2, 1) *
+            element_getter()(m, 3, 0) -
+        element_getter()(m, 0, 1) * element_getter()(m, 2, 3) *
+            element_getter()(m, 3, 0) -
+        element_getter()(m, 0, 3) * element_getter()(m, 2, 0) *
+            element_getter()(m, 3, 1) +
+        element_getter()(m, 0, 0) * element_getter()(m, 2, 3) *
+            element_getter()(m, 3, 1) +
+        element_getter()(m, 0, 1) * element_getter()(m, 2, 0) *
+            element_getter()(m, 3, 3) -
+        element_getter()(m, 0, 0) * element_getter()(m, 2, 1) *
+            element_getter()(m, 3, 3);
+    element_getter()(ret, 2, 2) =
+        element_getter()(m, 0, 1) * element_getter()(m, 1, 3) *
+            element_getter()(m, 3, 0) -
+        element_getter()(m, 0, 3) * element_getter()(m, 1, 1) *
+            element_getter()(m, 3, 0) +
+        element_getter()(m, 0, 3) * element_getter()(m, 1, 0) *
+            element_getter()(m, 3, 1) -
+        element_getter()(m, 0, 0) * element_getter()(m, 1, 3) *
+            element_getter()(m, 3, 1) -
+        element_getter()(m, 0, 1) * element_getter()(m, 1, 0) *
+            element_getter()(m, 3, 3) +
+        element_getter()(m, 0, 0) * element_getter()(m, 1, 1) *
+            element_getter()(m, 3, 3);
+    element_getter()(ret, 2, 3) =
+        element_getter()(m, 0, 3) * element_getter()(m, 1, 1) *
+            element_getter()(m, 2, 0) -
+        element_getter()(m, 0, 1) * element_getter()(m, 1, 3) *
+            element_getter()(m, 2, 0) -
+        element_getter()(m, 0, 3) * element_getter()(m, 1, 0) *
+            element_getter()(m, 2, 1) +
+        element_getter()(m, 0, 0) * element_getter()(m, 1, 3) *
+            element_getter()(m, 2, 1) +
+        element_getter()(m, 0, 1) * element_getter()(m, 1, 0) *
+            element_getter()(m, 2, 3) -
+        element_getter()(m, 0, 0) * element_getter()(m, 1, 1) *
+            element_getter()(m, 2, 3);
+    element_getter()(ret, 3, 0) =
+        element_getter()(m, 1, 2) * element_getter()(m, 2, 1) *
+            element_getter()(m, 3, 0) -
+        element_getter()(m, 1, 1) * element_getter()(m, 2, 2) *
+            element_getter()(m, 3, 0) -
+        element_getter()(m, 1, 2) * element_getter()(m, 2, 0) *
+            element_getter()(m, 3, 1) +
+        element_getter()(m, 1, 0) * element_getter()(m, 2, 2) *
+            element_getter()(m, 3, 1) +
+        element_getter()(m, 1, 1) * element_getter()(m, 2, 0) *
+            element_getter()(m, 3, 2) -
+        element_getter()(m, 1, 0) * element_getter()(m, 2, 1) *
+            element_getter()(m, 3, 2);
+    element_getter()(ret, 3, 1) =
+        element_getter()(m, 0, 1) * element_getter()(m, 2, 2) *
+            element_getter()(m, 3, 0) -
+        element_getter()(m, 0, 2) * element_getter()(m, 2, 1) *
+            element_getter()(m, 3, 0) +
+        element_getter()(m, 0, 2) * element_getter()(m, 2, 0) *
+            element_getter()(m, 3, 1) -
+        element_getter()(m, 0, 0) * element_getter()(m, 2, 2) *
+            element_getter()(m, 3, 1) -
+        element_getter()(m, 0, 1) * element_getter()(m, 2, 0) *
+            element_getter()(m, 3, 2) +
+        element_getter()(m, 0, 0) * element_getter()(m, 2, 1) *
+            element_getter()(m, 3, 2);
+    element_getter()(ret, 3, 2) =
+        element_getter()(m, 0, 2) * element_getter()(m, 1, 1) *
+            element_getter()(m, 3, 0) -
+        element_getter()(m, 0, 1) * element_getter()(m, 1, 2) *
+            element_getter()(m, 3, 0) -
+        element_getter()(m, 0, 2) * element_getter()(m, 1, 0) *
+            element_getter()(m, 3, 1) +
+        element_getter()(m, 0, 0) * element_getter()(m, 1, 2) *
+            element_getter()(m, 3, 1) +
+        element_getter()(m, 0, 1) * element_getter()(m, 1, 0) *
+            element_getter()(m, 3, 2) -
+        element_getter()(m, 0, 0) * element_getter()(m, 1, 1) *
+            element_getter()(m, 3, 2);
+    element_getter()(ret, 3, 3) =
+        element_getter()(m, 0, 1) * element_getter()(m, 1, 2) *
+            element_getter()(m, 2, 0) -
+        element_getter()(m, 0, 2) * element_getter()(m, 1, 1) *
+            element_getter()(m, 2, 0) +
+        element_getter()(m, 0, 2) * element_getter()(m, 1, 0) *
+            element_getter()(m, 2, 1) -
+        element_getter()(m, 0, 0) * element_getter()(m, 1, 2) *
+            element_getter()(m, 2, 1) -
+        element_getter()(m, 0, 1) * element_getter()(m, 1, 0) *
+            element_getter()(m, 2, 2) +
+        element_getter()(m, 0, 0) * element_getter()(m, 1, 1) *
+            element_getter()(m, 2, 2);
+
+    scalar_t idet = static_cast<scalar_t>(1.) / determinant_getter_type()(ret);
+    for (unsigned int c = 0; c < 4; ++c) {
+      for (unsigned int r = 0; r < 4; ++r) {
+        element_getter()(ret, c, r) *= idet;
+      }
+    }
+    return ret;
+  }
 };
 
 }  // namespace algebra::cmath::matrix::inverse

--- a/math/cmath/include/algebra/math/impl/cmath_matrix.hpp
+++ b/math/cmath/include/algebra/math/impl/cmath_matrix.hpp
@@ -66,7 +66,7 @@ struct actor {
 
   // Create zero matrix
   template <size_type ROWS, size_type COLS>
-  ALGEBRA_HOST_DEVICE inline matrix_type<ROWS, COLS> zero() {
+  ALGEBRA_HOST_DEVICE inline matrix_type<ROWS, COLS> zero() const {
     matrix_type<ROWS, COLS> ret;
 
     for (size_type i = 0; i < ROWS; ++i) {
@@ -80,7 +80,7 @@ struct actor {
 
   // Create identity matrix
   template <size_type ROWS, size_type COLS>
-  ALGEBRA_HOST_DEVICE inline matrix_type<ROWS, COLS> identity() {
+  ALGEBRA_HOST_DEVICE inline matrix_type<ROWS, COLS> identity() const {
     matrix_type<ROWS, COLS> ret;
 
     for (size_type i = 0; i < ROWS; ++i) {
@@ -96,10 +96,28 @@ struct actor {
     return ret;
   }
 
+  // Set input matrix as identity matrix
+  template <size_type ROWS, size_type COLS>
+  ALGEBRA_HOST_DEVICE inline void set_identity(
+      matrix_type<ROWS, COLS> &m) const {
+
+    for (size_type i = 0; i < ROWS; ++i) {
+      for (size_type j = 0; j < COLS; ++j) {
+        if (i == j) {
+          element_getter()(m, i, j) = 1;
+        } else {
+          element_getter()(m, i, j) = 0;
+        }
+      }
+    }
+
+    return;
+  }
+
   // Create transpose matrix
   template <size_type ROWS, size_type COLS>
   ALGEBRA_HOST_DEVICE inline matrix_type<COLS, ROWS> transpose(
-      const matrix_type<ROWS, COLS> &m) {
+      const matrix_type<ROWS, COLS> &m) const {
 
     matrix_type<COLS, ROWS> ret;
 
@@ -114,7 +132,8 @@ struct actor {
 
   // Get determinant
   template <size_type N>
-  ALGEBRA_HOST_DEVICE inline scalar_t determinant(const matrix_type<N, N> &m) {
+  ALGEBRA_HOST_DEVICE inline scalar_t determinant(
+      const matrix_type<N, N> &m) const {
 
     return determinant_actor_t()(m);
   }
@@ -122,7 +141,7 @@ struct actor {
   // Create inverse matrix
   template <size_type N>
   ALGEBRA_HOST_DEVICE inline matrix_type<N, N> inverse(
-      const matrix_type<N, N> &m) {
+      const matrix_type<N, N> &m) const {
 
     return inverse_actor_t()(m);
   }

--- a/math/cmath/include/algebra/math/impl/cmath_matrix.hpp
+++ b/math/cmath/include/algebra/math/impl/cmath_matrix.hpp
@@ -14,18 +14,55 @@
 namespace algebra::cmath::matrix {
 
 /// "Matrix actor", assuming a simple 2D matrix
-template <typename size_type,
+template <typename size_type, template <typename, size_type> class array_t,
           template <typename, size_type, size_type> class matrix_t,
           typename scalar_t, class determinant_actor_t, class inverse_actor_t,
-          class element_getter_t>
+          class element_getter_t, class block_getter_t>
 struct actor {
+
+  /// Size type
+  using size_ty = size_type;
+
+  /// Scalar type
+  using scalar_type = scalar_t;
 
   /// Function (object) used for accessing a matrix element
   using element_getter = element_getter_t;
 
+  /// Function (object) used for accessing a matrix block
+  using block_getter = block_getter_t;
+
   /// 2D matrix type
   template <size_type ROWS, size_type COLS>
   using matrix_type = matrix_t<scalar_t, ROWS, COLS>;
+
+  /// Array type
+  template <size_type N>
+  using array_type = array_t<scalar_t, N>;
+
+  /// Operator getting a reference to one element of a non-const matrix
+  template <size_type ROWS, size_type COLS>
+  ALGEBRA_HOST_DEVICE inline scalar_t &element(matrix_type<ROWS, COLS> &m,
+                                               size_type row,
+                                               size_type col) const {
+    return element_getter()(m, row, col);
+  }
+
+  /// Operator getting one value of a const matrix
+  template <size_type ROWS, size_type COLS>
+  ALGEBRA_HOST_DEVICE inline scalar_t element(const matrix_type<ROWS, COLS> &m,
+                                              size_type row,
+                                              size_type col) const {
+    return element_getter()(m, row, col);
+  }
+
+  /// Operator getting a block of a const matrix
+  template <size_type ROWS, size_type COLS, class input_matrix_type>
+  ALGEBRA_HOST_DEVICE matrix_type<ROWS, COLS> block(const input_matrix_type &m,
+                                                    size_type row,
+                                                    size_type col) {
+    return block_getter().template operator()<ROWS, COLS>(m, row, col);
+  }
 
   // Create zero matrix
   template <size_type ROWS, size_type COLS>

--- a/math/cmath/include/algebra/math/impl/cmath_transform3.hpp
+++ b/math/cmath/include/algebra/math/impl/cmath_transform3.hpp
@@ -169,8 +169,7 @@ struct transform3 {
    **/
   ALGEBRA_HOST_DEVICE
   transform3() {
-    // TODO: Make SetIdentity function in matrix actor
-    _data = matrix_actor().template identity<4, 4>();
+    matrix_actor().set_identity(_data);
     _data_inv = _data;
   }
 

--- a/math/cmath/include/algebra/math/impl/cmath_transform3.hpp
+++ b/math/cmath/include/algebra/math/impl/cmath_transform3.hpp
@@ -16,38 +16,44 @@ namespace algebra::cmath {
 
 /** Transform wrapper class to ensure standard API within differnt plugins
  **/
-template <typename size_type, template <typename, size_type> class array_t,
-          typename scalar_t,
-          typename matrix44_t = array_t<array_t<scalar_t, 4>, 4>,
-          class element_getter_t = element_getter<size_type, array_t, scalar_t>,
-          class block_getter_t = block_getter<size_type, array_t, scalar_t>,
-          typename vector3_t = array_t<scalar_t, 3>,
-          typename point2_t = array_t<scalar_t, 2> >
+template <typename matrix_actor_t>
 struct transform3 {
 
   /// @name Type definitions for the struct
   /// @{
 
-  /// Array type used by the transform
-  template <typename T, size_type N>
-  using array_type = array_t<T, N>;
-  /// Scalar type used by the transform
-  using scalar_type = scalar_t;
+  /// Matrix actor
+  using matrix_actor = matrix_actor_t;
+
+  /// Size type
+  using size_type = typename matrix_actor_t::size_ty;
+
+  /// Scalar type
+  using scalar_type = typename matrix_actor_t::scalar_type;
+
+  /// 2D Matrix type
+  template <size_type ROWS, size_type COLS>
+  using matrix_type = typename matrix_actor::template matrix_type<ROWS, COLS>;
+
+  /// Array type
+  template <size_type N>
+  using array_type = typename matrix_actor::template array_type<N>;
+
+  // 4 x 4 Matrix
+  using matrix44 = matrix_type<4, 4>;
 
   /// 3-element "vector" type
-  using vector3 = vector3_t;
+  using vector3 = array_type<3>;
   /// Point in 3D space
   using point3 = vector3;
   /// Point in 2D space
-  using point2 = point2_t;
-
-  /// 4x4 matrix type
-  using matrix44 = matrix44_t;
+  using point2 = array_type<2>;
 
   /// Function (object) used for accessing a matrix element
-  using element_getter = element_getter_t;
-  /// Function (object) used for accessing a sub-matrix of a matrix
-  using block_getter = block_getter_t;
+  using element_getter = typename matrix_actor::element_getter;
+
+  /// Function (object) used for accessing a matrix block
+  using block_getter = typename matrix_actor::block_getter;
 
   /// @}
 
@@ -72,24 +78,25 @@ struct transform3 {
   transform3(const vector3 &t, const vector3 &z, const vector3 &x) {
 
     auto y = cross(z, x);
-    element_getter()(_data, 0, 0) = x[0];
-    element_getter()(_data, 1, 0) = x[1];
-    element_getter()(_data, 2, 0) = x[2];
-    element_getter()(_data, 3, 0) = 0.;
-    element_getter()(_data, 0, 1) = y[0];
-    element_getter()(_data, 1, 1) = y[1];
-    element_getter()(_data, 2, 1) = y[2];
-    element_getter()(_data, 3, 1) = 0.;
-    element_getter()(_data, 0, 2) = z[0];
-    element_getter()(_data, 1, 2) = z[1];
-    element_getter()(_data, 2, 2) = z[2];
-    element_getter()(_data, 3, 2) = 0.;
-    element_getter()(_data, 0, 3) = t[0];
-    element_getter()(_data, 1, 3) = t[1];
-    element_getter()(_data, 2, 3) = t[2];
-    element_getter()(_data, 3, 3) = 1.;
 
-    _data_inv = invert(_data);
+    matrix_actor().element(_data, 0, 0) = x[0];
+    matrix_actor().element(_data, 1, 0) = x[1];
+    matrix_actor().element(_data, 2, 0) = x[2];
+    matrix_actor().element(_data, 3, 0) = 0.;
+    matrix_actor().element(_data, 0, 1) = y[0];
+    matrix_actor().element(_data, 1, 1) = y[1];
+    matrix_actor().element(_data, 2, 1) = y[2];
+    matrix_actor().element(_data, 3, 1) = 0.;
+    matrix_actor().element(_data, 0, 2) = z[0];
+    matrix_actor().element(_data, 1, 2) = z[1];
+    matrix_actor().element(_data, 2, 2) = z[2];
+    matrix_actor().element(_data, 3, 2) = 0.;
+    matrix_actor().element(_data, 0, 3) = t[0];
+    matrix_actor().element(_data, 1, 3) = t[1];
+    matrix_actor().element(_data, 2, 3) = t[2];
+    matrix_actor().element(_data, 3, 3) = 1.;
+
+    _data_inv = matrix_actor().inverse(_data);
   }
 
   /** Constructor with arguments: translation
@@ -99,24 +106,24 @@ struct transform3 {
   ALGEBRA_HOST_DEVICE
   transform3(const vector3 &t) {
 
-    element_getter()(_data, 0, 0) = 1.;
-    element_getter()(_data, 1, 0) = 0.;
-    element_getter()(_data, 2, 0) = 0.;
-    element_getter()(_data, 3, 0) = 0.;
-    element_getter()(_data, 0, 1) = 0.;
-    element_getter()(_data, 1, 1) = 1.;
-    element_getter()(_data, 2, 1) = 0.;
-    element_getter()(_data, 3, 1) = 0.;
-    element_getter()(_data, 0, 2) = 0.;
-    element_getter()(_data, 1, 2) = 0.;
-    element_getter()(_data, 2, 2) = 1.;
-    element_getter()(_data, 3, 2) = 0.;
-    element_getter()(_data, 0, 3) = t[0];
-    element_getter()(_data, 1, 3) = t[1];
-    element_getter()(_data, 2, 3) = t[2];
-    element_getter()(_data, 3, 3) = 1.;
+    matrix_actor().element(_data, 0, 0) = 1.;
+    matrix_actor().element(_data, 1, 0) = 0.;
+    matrix_actor().element(_data, 2, 0) = 0.;
+    matrix_actor().element(_data, 3, 0) = 0.;
+    matrix_actor().element(_data, 0, 1) = 0.;
+    matrix_actor().element(_data, 1, 1) = 1.;
+    matrix_actor().element(_data, 2, 1) = 0.;
+    matrix_actor().element(_data, 3, 1) = 0.;
+    matrix_actor().element(_data, 0, 2) = 0.;
+    matrix_actor().element(_data, 1, 2) = 0.;
+    matrix_actor().element(_data, 2, 2) = 1.;
+    matrix_actor().element(_data, 3, 2) = 0.;
+    matrix_actor().element(_data, 0, 3) = t[0];
+    matrix_actor().element(_data, 1, 3) = t[1];
+    matrix_actor().element(_data, 2, 3) = t[2];
+    matrix_actor().element(_data, 3, 3) = 1.;
 
-    _data_inv = invert(_data);
+    _data_inv = matrix_actor().inverse(_data);
   }
 
   /** Constructor with arguments: matrix
@@ -127,7 +134,7 @@ struct transform3 {
   transform3(const matrix44 &m) {
 
     _data = m;
-    _data_inv = invert(_data);
+    _data_inv = matrix_actor().inverse(_data);
   }
 
   /** Constructor with arguments: matrix as array of scalar
@@ -135,26 +142,26 @@ struct transform3 {
    * @param ma is the full 4x4 matrix 16 array
    **/
   ALGEBRA_HOST_DEVICE
-  transform3(const array_type<scalar_type, 16> &ma) {
+  transform3(const array_type<16> &ma) {
 
-    element_getter()(_data, 0, 0) = ma[0];
-    element_getter()(_data, 1, 0) = ma[4];
-    element_getter()(_data, 2, 0) = ma[8];
-    element_getter()(_data, 3, 0) = ma[12];
-    element_getter()(_data, 0, 1) = ma[1];
-    element_getter()(_data, 1, 1) = ma[5];
-    element_getter()(_data, 2, 1) = ma[9];
-    element_getter()(_data, 3, 1) = ma[13];
-    element_getter()(_data, 0, 2) = ma[2];
-    element_getter()(_data, 1, 2) = ma[6];
-    element_getter()(_data, 2, 2) = ma[10];
-    element_getter()(_data, 3, 2) = ma[14];
-    element_getter()(_data, 0, 3) = ma[3];
-    element_getter()(_data, 1, 3) = ma[7];
-    element_getter()(_data, 2, 3) = ma[11];
-    element_getter()(_data, 3, 3) = ma[15];
+    matrix_actor().element(_data, 0, 0) = ma[0];
+    matrix_actor().element(_data, 1, 0) = ma[4];
+    matrix_actor().element(_data, 2, 0) = ma[8];
+    matrix_actor().element(_data, 3, 0) = ma[12];
+    matrix_actor().element(_data, 0, 1) = ma[1];
+    matrix_actor().element(_data, 1, 1) = ma[5];
+    matrix_actor().element(_data, 2, 1) = ma[9];
+    matrix_actor().element(_data, 3, 1) = ma[13];
+    matrix_actor().element(_data, 0, 2) = ma[2];
+    matrix_actor().element(_data, 1, 2) = ma[6];
+    matrix_actor().element(_data, 2, 2) = ma[10];
+    matrix_actor().element(_data, 3, 2) = ma[14];
+    matrix_actor().element(_data, 0, 3) = ma[3];
+    matrix_actor().element(_data, 1, 3) = ma[7];
+    matrix_actor().element(_data, 2, 3) = ma[11];
+    matrix_actor().element(_data, 3, 3) = ma[15];
 
-    _data_inv = invert(_data);
+    _data_inv = matrix_actor().inverse(_data);
   }
 
   /** Constructor with arguments: identity
@@ -162,24 +169,8 @@ struct transform3 {
    **/
   ALGEBRA_HOST_DEVICE
   transform3() {
-
-    element_getter()(_data, 0, 0) = 1.;
-    element_getter()(_data, 0, 1) = 0.;
-    element_getter()(_data, 0, 2) = 0.;
-    element_getter()(_data, 0, 3) = 0.;
-    element_getter()(_data, 1, 0) = 0.;
-    element_getter()(_data, 1, 1) = 1.;
-    element_getter()(_data, 1, 2) = 0.;
-    element_getter()(_data, 1, 3) = 0.;
-    element_getter()(_data, 2, 0) = 0.;
-    element_getter()(_data, 2, 1) = 0.;
-    element_getter()(_data, 2, 2) = 1.;
-    element_getter()(_data, 2, 3) = 0.;
-    element_getter()(_data, 3, 0) = 0.;
-    element_getter()(_data, 3, 1) = 0.;
-    element_getter()(_data, 3, 2) = 0.;
-    element_getter()(_data, 3, 3) = 1.;
-
+    // TODO: Make SetIdentity function in matrix actor
+    _data = matrix_actor().template identity<4, 4>();
     _data_inv = _data;
   }
 
@@ -189,8 +180,8 @@ struct transform3 {
 
     for (int i = 0; i < 4; i++) {
       for (int j = 0; j < 4; j++) {
-        if (element_getter()(_data, i, j) !=
-            element_getter()(rhs._data, i, j)) {
+        if (matrix_actor().element(_data, i, j) !=
+            matrix_actor().element(rhs._data, i, j)) {
           return false;
         }
       }
@@ -208,54 +199,7 @@ struct transform3 {
   ALGEBRA_HOST_DEVICE
   static inline scalar_type determinant(const matrix44 &m) {
 
-    return element_getter()(m, 0, 3) * element_getter()(m, 1, 2) *
-               element_getter()(m, 2, 1) * element_getter()(m, 3, 0) -
-           element_getter()(m, 0, 2) * element_getter()(m, 1, 3) *
-               element_getter()(m, 2, 1) * element_getter()(m, 3, 0) -
-           element_getter()(m, 0, 3) * element_getter()(m, 1, 1) *
-               element_getter()(m, 2, 2) * element_getter()(m, 3, 0) +
-           element_getter()(m, 0, 1) * element_getter()(m, 1, 3) *
-               element_getter()(m, 2, 2) * element_getter()(m, 3, 0) +
-           element_getter()(m, 0, 2) * element_getter()(m, 1, 1) *
-               element_getter()(m, 2, 3) * element_getter()(m, 3, 0) -
-           element_getter()(m, 0, 1) * element_getter()(m, 1, 2) *
-               element_getter()(m, 2, 3) * element_getter()(m, 3, 0) -
-           element_getter()(m, 0, 3) * element_getter()(m, 1, 2) *
-               element_getter()(m, 2, 0) * element_getter()(m, 3, 1) +
-           element_getter()(m, 0, 2) * element_getter()(m, 1, 3) *
-               element_getter()(m, 2, 0) * element_getter()(m, 3, 1) +
-           element_getter()(m, 0, 3) * element_getter()(m, 1, 0) *
-               element_getter()(m, 2, 2) * element_getter()(m, 3, 1) -
-           element_getter()(m, 0, 0) * element_getter()(m, 1, 3) *
-               element_getter()(m, 2, 2) * element_getter()(m, 3, 1) -
-           element_getter()(m, 0, 2) * element_getter()(m, 1, 0) *
-               element_getter()(m, 2, 3) * element_getter()(m, 3, 1) +
-           element_getter()(m, 0, 0) * element_getter()(m, 1, 2) *
-               element_getter()(m, 2, 3) * element_getter()(m, 3, 1) +
-           element_getter()(m, 0, 3) * element_getter()(m, 1, 1) *
-               element_getter()(m, 2, 0) * element_getter()(m, 3, 2) -
-           element_getter()(m, 0, 1) * element_getter()(m, 1, 3) *
-               element_getter()(m, 2, 0) * element_getter()(m, 3, 2) -
-           element_getter()(m, 0, 3) * element_getter()(m, 1, 0) *
-               element_getter()(m, 2, 1) * element_getter()(m, 3, 2) +
-           element_getter()(m, 0, 0) * element_getter()(m, 1, 3) *
-               element_getter()(m, 2, 1) * element_getter()(m, 3, 2) +
-           element_getter()(m, 0, 1) * element_getter()(m, 1, 0) *
-               element_getter()(m, 2, 3) * element_getter()(m, 3, 2) -
-           element_getter()(m, 0, 0) * element_getter()(m, 1, 1) *
-               element_getter()(m, 2, 3) * element_getter()(m, 3, 2) -
-           element_getter()(m, 0, 2) * element_getter()(m, 1, 1) *
-               element_getter()(m, 2, 0) * element_getter()(m, 3, 3) +
-           element_getter()(m, 0, 1) * element_getter()(m, 1, 2) *
-               element_getter()(m, 2, 0) * element_getter()(m, 3, 3) +
-           element_getter()(m, 0, 2) * element_getter()(m, 1, 0) *
-               element_getter()(m, 2, 1) * element_getter()(m, 3, 3) -
-           element_getter()(m, 0, 0) * element_getter()(m, 1, 2) *
-               element_getter()(m, 2, 1) * element_getter()(m, 3, 3) -
-           element_getter()(m, 0, 1) * element_getter()(m, 1, 0) *
-               element_getter()(m, 2, 2) * element_getter()(m, 3, 3) +
-           element_getter()(m, 0, 0) * element_getter()(m, 1, 1) *
-               element_getter()(m, 2, 2) * element_getter()(m, 3, 3);
+    return matrix_actor().determinant(m);
   }
 
   /** The inverse of a 4x4 matrix
@@ -267,222 +211,7 @@ struct transform3 {
   ALGEBRA_HOST_DEVICE
   static inline matrix44 invert(const matrix44 &m) {
 
-    matrix44 i;
-    element_getter()(i, 0, 0) =
-        element_getter()(m, 1, 2) * element_getter()(m, 2, 3) *
-            element_getter()(m, 3, 1) -
-        element_getter()(m, 1, 3) * element_getter()(m, 2, 2) *
-            element_getter()(m, 3, 1) +
-        element_getter()(m, 1, 3) * element_getter()(m, 2, 1) *
-            element_getter()(m, 3, 2) -
-        element_getter()(m, 1, 1) * element_getter()(m, 2, 3) *
-            element_getter()(m, 3, 2) -
-        element_getter()(m, 1, 2) * element_getter()(m, 2, 1) *
-            element_getter()(m, 3, 3) +
-        element_getter()(m, 1, 1) * element_getter()(m, 2, 2) *
-            element_getter()(m, 3, 3);
-    element_getter()(i, 0, 1) =
-        element_getter()(m, 0, 3) * element_getter()(m, 2, 2) *
-            element_getter()(m, 3, 1) -
-        element_getter()(m, 0, 2) * element_getter()(m, 2, 3) *
-            element_getter()(m, 3, 1) -
-        element_getter()(m, 0, 3) * element_getter()(m, 2, 1) *
-            element_getter()(m, 3, 2) +
-        element_getter()(m, 0, 1) * element_getter()(m, 2, 3) *
-            element_getter()(m, 3, 2) +
-        element_getter()(m, 0, 2) * element_getter()(m, 2, 1) *
-            element_getter()(m, 3, 3) -
-        element_getter()(m, 0, 1) * element_getter()(m, 2, 2) *
-            element_getter()(m, 3, 3);
-    element_getter()(i, 0, 2) =
-        element_getter()(m, 0, 2) * element_getter()(m, 1, 3) *
-            element_getter()(m, 3, 1) -
-        element_getter()(m, 0, 3) * element_getter()(m, 1, 2) *
-            element_getter()(m, 3, 1) +
-        element_getter()(m, 0, 3) * element_getter()(m, 1, 1) *
-            element_getter()(m, 3, 2) -
-        element_getter()(m, 0, 1) * element_getter()(m, 1, 3) *
-            element_getter()(m, 3, 2) -
-        element_getter()(m, 0, 2) * element_getter()(m, 1, 1) *
-            element_getter()(m, 3, 3) +
-        element_getter()(m, 0, 1) * element_getter()(m, 1, 2) *
-            element_getter()(m, 3, 3);
-    element_getter()(i, 0, 3) =
-        element_getter()(m, 0, 3) * element_getter()(m, 1, 2) *
-            element_getter()(m, 2, 1) -
-        element_getter()(m, 0, 2) * element_getter()(m, 1, 3) *
-            element_getter()(m, 2, 1) -
-        element_getter()(m, 0, 3) * element_getter()(m, 1, 1) *
-            element_getter()(m, 2, 2) +
-        element_getter()(m, 0, 1) * element_getter()(m, 1, 3) *
-            element_getter()(m, 2, 2) +
-        element_getter()(m, 0, 2) * element_getter()(m, 1, 1) *
-            element_getter()(m, 2, 3) -
-        element_getter()(m, 0, 1) * element_getter()(m, 1, 2) *
-            element_getter()(m, 2, 3);
-    element_getter()(i, 1, 0) =
-        element_getter()(m, 1, 3) * element_getter()(m, 2, 2) *
-            element_getter()(m, 3, 0) -
-        element_getter()(m, 1, 2) * element_getter()(m, 2, 3) *
-            element_getter()(m, 3, 0) -
-        element_getter()(m, 1, 3) * element_getter()(m, 2, 0) *
-            element_getter()(m, 3, 2) +
-        element_getter()(m, 1, 0) * element_getter()(m, 2, 3) *
-            element_getter()(m, 3, 2) +
-        element_getter()(m, 1, 2) * element_getter()(m, 2, 0) *
-            element_getter()(m, 3, 3) -
-        element_getter()(m, 1, 0) * element_getter()(m, 2, 2) *
-            element_getter()(m, 3, 3);
-    element_getter()(i, 1, 1) =
-        element_getter()(m, 0, 2) * element_getter()(m, 2, 3) *
-            element_getter()(m, 3, 0) -
-        element_getter()(m, 0, 3) * element_getter()(m, 2, 2) *
-            element_getter()(m, 3, 0) +
-        element_getter()(m, 0, 3) * element_getter()(m, 2, 0) *
-            element_getter()(m, 3, 2) -
-        element_getter()(m, 0, 0) * element_getter()(m, 2, 3) *
-            element_getter()(m, 3, 2) -
-        element_getter()(m, 0, 2) * element_getter()(m, 2, 0) *
-            element_getter()(m, 3, 3) +
-        element_getter()(m, 0, 0) * element_getter()(m, 2, 2) *
-            element_getter()(m, 3, 3);
-    element_getter()(i, 1, 2) =
-        element_getter()(m, 0, 3) * element_getter()(m, 1, 2) *
-            element_getter()(m, 3, 0) -
-        element_getter()(m, 0, 2) * element_getter()(m, 1, 3) *
-            element_getter()(m, 3, 0) -
-        element_getter()(m, 0, 3) * element_getter()(m, 1, 0) *
-            element_getter()(m, 3, 2) +
-        element_getter()(m, 0, 0) * element_getter()(m, 1, 3) *
-            element_getter()(m, 3, 2) +
-        element_getter()(m, 0, 2) * element_getter()(m, 1, 0) *
-            element_getter()(m, 3, 3) -
-        element_getter()(m, 0, 0) * element_getter()(m, 1, 2) *
-            element_getter()(m, 3, 3);
-    element_getter()(i, 1, 3) =
-        element_getter()(m, 0, 2) * element_getter()(m, 1, 3) *
-            element_getter()(m, 2, 0) -
-        element_getter()(m, 0, 3) * element_getter()(m, 1, 2) *
-            element_getter()(m, 2, 0) +
-        element_getter()(m, 0, 3) * element_getter()(m, 1, 0) *
-            element_getter()(m, 2, 2) -
-        element_getter()(m, 0, 0) * element_getter()(m, 1, 3) *
-            element_getter()(m, 2, 2) -
-        element_getter()(m, 0, 2) * element_getter()(m, 1, 0) *
-            element_getter()(m, 2, 3) +
-        element_getter()(m, 0, 0) * element_getter()(m, 1, 2) *
-            element_getter()(m, 2, 3);
-    element_getter()(i, 2, 0) =
-        element_getter()(m, 1, 1) * element_getter()(m, 2, 3) *
-            element_getter()(m, 3, 0) -
-        element_getter()(m, 1, 3) * element_getter()(m, 2, 1) *
-            element_getter()(m, 3, 0) +
-        element_getter()(m, 1, 3) * element_getter()(m, 2, 0) *
-            element_getter()(m, 3, 1) -
-        element_getter()(m, 1, 0) * element_getter()(m, 2, 3) *
-            element_getter()(m, 3, 1) -
-        element_getter()(m, 1, 1) * element_getter()(m, 2, 0) *
-            element_getter()(m, 3, 3) +
-        element_getter()(m, 1, 0) * element_getter()(m, 2, 1) *
-            element_getter()(m, 3, 3);
-    element_getter()(i, 2, 1) =
-        element_getter()(m, 0, 3) * element_getter()(m, 2, 1) *
-            element_getter()(m, 3, 0) -
-        element_getter()(m, 0, 1) * element_getter()(m, 2, 3) *
-            element_getter()(m, 3, 0) -
-        element_getter()(m, 0, 3) * element_getter()(m, 2, 0) *
-            element_getter()(m, 3, 1) +
-        element_getter()(m, 0, 0) * element_getter()(m, 2, 3) *
-            element_getter()(m, 3, 1) +
-        element_getter()(m, 0, 1) * element_getter()(m, 2, 0) *
-            element_getter()(m, 3, 3) -
-        element_getter()(m, 0, 0) * element_getter()(m, 2, 1) *
-            element_getter()(m, 3, 3);
-    element_getter()(i, 2, 2) =
-        element_getter()(m, 0, 1) * element_getter()(m, 1, 3) *
-            element_getter()(m, 3, 0) -
-        element_getter()(m, 0, 3) * element_getter()(m, 1, 1) *
-            element_getter()(m, 3, 0) +
-        element_getter()(m, 0, 3) * element_getter()(m, 1, 0) *
-            element_getter()(m, 3, 1) -
-        element_getter()(m, 0, 0) * element_getter()(m, 1, 3) *
-            element_getter()(m, 3, 1) -
-        element_getter()(m, 0, 1) * element_getter()(m, 1, 0) *
-            element_getter()(m, 3, 3) +
-        element_getter()(m, 0, 0) * element_getter()(m, 1, 1) *
-            element_getter()(m, 3, 3);
-    element_getter()(i, 2, 3) =
-        element_getter()(m, 0, 3) * element_getter()(m, 1, 1) *
-            element_getter()(m, 2, 0) -
-        element_getter()(m, 0, 1) * element_getter()(m, 1, 3) *
-            element_getter()(m, 2, 0) -
-        element_getter()(m, 0, 3) * element_getter()(m, 1, 0) *
-            element_getter()(m, 2, 1) +
-        element_getter()(m, 0, 0) * element_getter()(m, 1, 3) *
-            element_getter()(m, 2, 1) +
-        element_getter()(m, 0, 1) * element_getter()(m, 1, 0) *
-            element_getter()(m, 2, 3) -
-        element_getter()(m, 0, 0) * element_getter()(m, 1, 1) *
-            element_getter()(m, 2, 3);
-    element_getter()(i, 3, 0) =
-        element_getter()(m, 1, 2) * element_getter()(m, 2, 1) *
-            element_getter()(m, 3, 0) -
-        element_getter()(m, 1, 1) * element_getter()(m, 2, 2) *
-            element_getter()(m, 3, 0) -
-        element_getter()(m, 1, 2) * element_getter()(m, 2, 0) *
-            element_getter()(m, 3, 1) +
-        element_getter()(m, 1, 0) * element_getter()(m, 2, 2) *
-            element_getter()(m, 3, 1) +
-        element_getter()(m, 1, 1) * element_getter()(m, 2, 0) *
-            element_getter()(m, 3, 2) -
-        element_getter()(m, 1, 0) * element_getter()(m, 2, 1) *
-            element_getter()(m, 3, 2);
-    element_getter()(i, 3, 1) =
-        element_getter()(m, 0, 1) * element_getter()(m, 2, 2) *
-            element_getter()(m, 3, 0) -
-        element_getter()(m, 0, 2) * element_getter()(m, 2, 1) *
-            element_getter()(m, 3, 0) +
-        element_getter()(m, 0, 2) * element_getter()(m, 2, 0) *
-            element_getter()(m, 3, 1) -
-        element_getter()(m, 0, 0) * element_getter()(m, 2, 2) *
-            element_getter()(m, 3, 1) -
-        element_getter()(m, 0, 1) * element_getter()(m, 2, 0) *
-            element_getter()(m, 3, 2) +
-        element_getter()(m, 0, 0) * element_getter()(m, 2, 1) *
-            element_getter()(m, 3, 2);
-    element_getter()(i, 3, 2) =
-        element_getter()(m, 0, 2) * element_getter()(m, 1, 1) *
-            element_getter()(m, 3, 0) -
-        element_getter()(m, 0, 1) * element_getter()(m, 1, 2) *
-            element_getter()(m, 3, 0) -
-        element_getter()(m, 0, 2) * element_getter()(m, 1, 0) *
-            element_getter()(m, 3, 1) +
-        element_getter()(m, 0, 0) * element_getter()(m, 1, 2) *
-            element_getter()(m, 3, 1) +
-        element_getter()(m, 0, 1) * element_getter()(m, 1, 0) *
-            element_getter()(m, 3, 2) -
-        element_getter()(m, 0, 0) * element_getter()(m, 1, 1) *
-            element_getter()(m, 3, 2);
-    element_getter()(i, 3, 3) =
-        element_getter()(m, 0, 1) * element_getter()(m, 1, 2) *
-            element_getter()(m, 2, 0) -
-        element_getter()(m, 0, 2) * element_getter()(m, 1, 1) *
-            element_getter()(m, 2, 0) +
-        element_getter()(m, 0, 2) * element_getter()(m, 1, 0) *
-            element_getter()(m, 2, 1) -
-        element_getter()(m, 0, 0) * element_getter()(m, 1, 2) *
-            element_getter()(m, 2, 1) -
-        element_getter()(m, 0, 1) * element_getter()(m, 1, 0) *
-            element_getter()(m, 2, 2) +
-        element_getter()(m, 0, 0) * element_getter()(m, 1, 1) *
-            element_getter()(m, 2, 2);
-    scalar_type idet = static_cast<scalar_type>(1.) / determinant(i);
-    for (unsigned int c = 0; c < 4; ++c) {
-      for (unsigned int r = 0; r < 4; ++r) {
-        element_getter()(i, c, r) *= idet;
-      }
-    }
-    return i;
+    return matrix_actor().inverse(m);
   }
 
   /** Rotate a vector into / from a frame
@@ -493,28 +222,31 @@ struct transform3 {
   ALGEBRA_HOST_DEVICE
   static inline vector3 rotate(const matrix44 &m, const vector3 &v) {
 
-    return {
-        element_getter()(m, 0, 0) * v[0] + element_getter()(m, 0, 1) * v[1] +
-            element_getter()(m, 0, 2) * v[2],
-        element_getter()(m, 1, 0) * v[0] + element_getter()(m, 1, 1) * v[1] +
-            element_getter()(m, 1, 2) * v[2],
-        element_getter()(m, 2, 0) * v[0] + element_getter()(m, 2, 1) * v[1] +
-            element_getter()(m, 2, 2) * v[2]};
+    return {matrix_actor().element(m, 0, 0) * v[0] +
+                matrix_actor().element(m, 0, 1) * v[1] +
+                matrix_actor().element(m, 0, 2) * v[2],
+            matrix_actor().element(m, 1, 0) * v[0] +
+                matrix_actor().element(m, 1, 1) * v[1] +
+                matrix_actor().element(m, 1, 2) * v[2],
+            matrix_actor().element(m, 2, 0) * v[0] +
+                matrix_actor().element(m, 2, 1) * v[1] +
+                matrix_actor().element(m, 2, 2) * v[2]};
   }
 
   /** This method retrieves the rotation of a transform */
   ALGEBRA_HOST_DEVICE
   auto inline rotation() const {
 
-    return block_getter().template operator()<3, 3>(_data, 0, 0);
+    return matrix_actor().template block<3, 3>(_data, 0, 0);
   }
 
   /** This method retrieves the translation of a transform */
   ALGEBRA_HOST_DEVICE
   inline point3 translation() const {
 
-    return {element_getter()(_data, 0, 3), element_getter()(_data, 1, 3),
-            element_getter()(_data, 2, 3)};
+    return {matrix_actor().element(_data, 0, 3),
+            matrix_actor().element(_data, 1, 3),
+            matrix_actor().element(_data, 2, 3)};
   }
 
   /** This method retrieves the 4x4 matrix of a transform */
@@ -526,9 +258,9 @@ struct transform3 {
   ALGEBRA_HOST_DEVICE inline point3 point_to_global(const point3 &v) const {
 
     const vector3 rg = rotate(_data, v);
-    return {rg[0] + element_getter()(_data, 0, 3),
-            rg[1] + element_getter()(_data, 1, 3),
-            rg[2] + element_getter()(_data, 2, 3)};
+    return {rg[0] + matrix_actor().element(_data, 0, 3),
+            rg[1] + matrix_actor().element(_data, 1, 3),
+            rg[2] + matrix_actor().element(_data, 2, 3)};
   }
 
   /** This method transform from a vector from the global 3D cartesian frame
@@ -537,9 +269,9 @@ struct transform3 {
   ALGEBRA_HOST_DEVICE inline point3 point_to_local(const point3 &v) const {
 
     const vector3 rg = rotate(_data_inv, v);
-    return {rg[0] + element_getter()(_data_inv, 0, 3),
-            rg[1] + element_getter()(_data_inv, 1, 3),
-            rg[2] + element_getter()(_data_inv, 2, 3)};
+    return {rg[0] + matrix_actor().element(_data_inv, 0, 3),
+            rg[1] + matrix_actor().element(_data_inv, 1, 3),
+            rg[2] + matrix_actor().element(_data_inv, 2, 3)};
   }
 
   /** This method transform from a vector from the local 3D cartesian frame to

--- a/math/eigen/include/algebra/math/impl/eigen_getter.hpp
+++ b/math/eigen/include/algebra/math/impl/eigen_getter.hpp
@@ -103,16 +103,14 @@ struct element_getter {
                                        Eigen::MatrixBase<derived_type> >::value,
                        bool> = true>
   ALGEBRA_HOST_DEVICE inline auto &operator()(
-      Eigen::MatrixBase<derived_type> &m, std::size_t row,
-      std::size_t col) const {
+      Eigen::MatrixBase<derived_type> &m, int row, int col) const {
 
     return m(row, col);
   }
   /// Get const access to a matrix element
   template <typename derived_type>
   ALGEBRA_HOST_DEVICE inline auto operator()(
-      const Eigen::MatrixBase<derived_type> &m, std::size_t row,
-      std::size_t col) const {
+      const Eigen::MatrixBase<derived_type> &m, int row, int col) const {
 
     return m(row, col);
   }
@@ -121,8 +119,7 @@ struct element_getter {
 /// Function extracting an element from a matrix (const)
 template <typename derived_type>
 ALGEBRA_HOST_DEVICE inline auto element(
-    const Eigen::MatrixBase<derived_type> &m, std::size_t row,
-    std::size_t col) {
+    const Eigen::MatrixBase<derived_type> &m, int row, int col) {
 
   return element_getter()(m, row, col);
 }
@@ -135,16 +132,16 @@ template <
                                      Eigen::MatrixBase<derived_type> >::value,
                      bool> = true>
 ALGEBRA_HOST_DEVICE inline auto &element(Eigen::MatrixBase<derived_type> &m,
-                                         std::size_t row, std::size_t col) {
+                                         int row, int col) {
 
   return element_getter()(m, row, col);
 }
 
 /// Functor used to extract a block from Eigen matrices
 struct block_getter {
-  template <std::size_t kROWS, std::size_t kCOLS, typename matrix_type>
-  ALGEBRA_HOST_DEVICE auto operator()(const matrix_type &m, std::size_t row,
-                                      std::size_t col) const {
+  template <int kROWS, int kCOLS, typename matrix_type>
+  ALGEBRA_HOST_DEVICE auto operator()(const matrix_type &m, int row,
+                                      int col) const {
 
     return m.template block<kROWS, kCOLS>(row, col);
   }

--- a/math/eigen/include/algebra/math/impl/eigen_matrix.hpp
+++ b/math/eigen/include/algebra/math/impl/eigen_matrix.hpp
@@ -29,6 +29,27 @@ struct actor {
   template <int ROWS, int COLS>
   using matrix_type = Eigen::Matrix<scalar_t, ROWS, COLS, 0, ROWS, COLS>;
 
+  /// Operator getting a reference to one element of a non-const matrix
+  template <int ROWS, int COLS>
+  ALGEBRA_HOST_DEVICE inline scalar_t &element(matrix_type<ROWS, COLS> &m,
+                                               int row, int col) const {
+    return m(row, col);
+  }
+
+  /// Operator getting one value of a const matrix
+  template <int ROWS, int COLS>
+  ALGEBRA_HOST_DEVICE inline scalar_t element(const matrix_type<ROWS, COLS> &m,
+                                              int row, int col) const {
+    return m(row, col);
+  }
+
+  /// Operator getting a block of a const matrix
+  template <int ROWS, int COLS, class input_matrix_type>
+  ALGEBRA_HOST_DEVICE matrix_type<ROWS, COLS> block(const input_matrix_type &m,
+                                                    int row, int col) {
+    return m.template block<ROWS, COLS>(row, col);
+  }
+
   // Create zero matrix
   template <int ROWS, int COLS>
   ALGEBRA_HOST_DEVICE inline matrix_type<ROWS, COLS> zero() {
@@ -44,20 +65,20 @@ struct actor {
   // Create transpose matrix
   template <int ROWS, int COLS>
   ALGEBRA_HOST_DEVICE inline matrix_type<COLS, ROWS> transpose(
-      const matrix_type<ROWS, COLS>& m) {
+      const matrix_type<ROWS, COLS> &m) {
     return m.transpose();
   }
 
   // Get determinant
   template <int N>
-  ALGEBRA_HOST_DEVICE inline scalar_t determinant(const matrix_type<N, N>& m) {
+  ALGEBRA_HOST_DEVICE inline scalar_t determinant(const matrix_type<N, N> &m) {
     return m.determinant();
   }
 
   // Create inverse matrix
   template <int N>
   ALGEBRA_HOST_DEVICE inline matrix_type<N, N> inverse(
-      const matrix_type<N, N>& m) {
+      const matrix_type<N, N> &m) {
     return m.inverse();
   }
 };

--- a/math/eigen/include/algebra/math/impl/eigen_transform3.hpp
+++ b/math/eigen/include/algebra/math/impl/eigen_transform3.hpp
@@ -33,17 +33,17 @@ struct transform3 {
   /// @{
 
   /// Array type used by the transform
-  template <typename T, std::size_t N>
-  using array_type = Eigen::Matrix<T, N, 1>;
+  template <int N>
+  using array_type = Eigen::Matrix<scalar_t, N, 1, 0, N, 1>;
   /// Scalar type used by the transform
   using scalar_type = scalar_t;
 
   /// 3-element "vector" type
-  using vector3 = array_type<scalar_type, 3>;
+  using vector3 = array_type<3>;
   /// Point in 3D space
   using point3 = vector3;
   /// Point in 2D space
-  using point2 = array_type<scalar_type, 2>;
+  using point2 = array_type<2>;
 
   /// 4x4 matrix type
   using matrix44 =
@@ -115,7 +115,7 @@ struct transform3 {
    * @param ma is the full 4x4 matrix as a 16 array
    **/
   ALGEBRA_HOST_DEVICE
-  transform3(const array_type<scalar_type, 16> &ma) {
+  transform3(const array_type<16> &ma) {
 
     _data.matrix() << ma[0], ma[1], ma[2], ma[3], ma[4], ma[5], ma[6], ma[7],
         ma[8], ma[9], ma[10], ma[11], ma[12], ma[13], ma[14], ma[15];

--- a/math/smatrix/include/algebra/math/impl/smatrix_getter.hpp
+++ b/math/smatrix/include/algebra/math/impl/smatrix_getter.hpp
@@ -149,8 +149,8 @@ struct element_getter {
 /// Function extracting an element from a matrix (const)
 template <typename scalar_t, unsigned int ROWS, unsigned int COLS>
 ALGEBRA_HOST_DEVICE inline scalar_t element(
-    const ROOT::Math::SMatrix<scalar_t, ROWS, COLS> &m, std::size_t row,
-    std::size_t col) {
+    const ROOT::Math::SMatrix<scalar_t, ROWS, COLS> &m, unsigned int row,
+    unsigned int col) {
 
   return element_getter<scalar_t>()(m, row, col);
 }
@@ -158,8 +158,8 @@ ALGEBRA_HOST_DEVICE inline scalar_t element(
 /// Function extracting an element from a matrix (non-const)
 template <typename scalar_t, unsigned int ROWS, unsigned int COLS>
 ALGEBRA_HOST_DEVICE inline scalar_t &element(
-    ROOT::Math::SMatrix<scalar_t, ROWS, COLS> &m, std::size_t row,
-    std::size_t col) {
+    ROOT::Math::SMatrix<scalar_t, ROWS, COLS> &m, unsigned int row,
+    unsigned int col) {
 
   return element_getter<scalar_t>()(m, row, col);
 }

--- a/math/smatrix/include/algebra/math/impl/smatrix_matrix.hpp
+++ b/math/smatrix/include/algebra/math/impl/smatrix_matrix.hpp
@@ -23,6 +23,30 @@ struct actor {
   template <unsigned int ROWS, unsigned int COLS>
   using matrix_type = ROOT::Math::SMatrix<scalar_t, ROWS, COLS>;
 
+  /// Operator getting a reference to one element of a non-const matrix
+  template <unsigned int ROWS, unsigned int COLS>
+  ALGEBRA_HOST_DEVICE inline scalar_t &element(matrix_type<ROWS, COLS> &m,
+                                               unsigned int row,
+                                               unsigned int col) const {
+    return m(row, col);
+  }
+
+  /// Operator getting one value of a const matrix
+  template <unsigned int ROWS, unsigned int COLS>
+  ALGEBRA_HOST_DEVICE inline scalar_t element(const matrix_type<ROWS, COLS> &m,
+                                              unsigned int row,
+                                              unsigned int col) const {
+    return m(row, col);
+  }
+
+  /// Operator getting a block of a const matrix
+  template <unsigned int ROWS, unsigned int COLS, class input_matrix_type>
+  ALGEBRA_HOST_DEVICE matrix_type<ROWS, COLS> block(const input_matrix_type &m,
+                                                    unsigned int row,
+                                                    unsigned int col) {
+    return m.template Sub<matrix_type<ROWS, COLS> >(row, col);
+  }
+
   // Create zero matrix
   template <unsigned int ROWS, unsigned int COLS>
   ALGEBRA_HOST_DEVICE inline matrix_type<ROWS, COLS> zero() {
@@ -39,21 +63,13 @@ struct actor {
   // Create transpose matrix
   template <unsigned int ROWS, unsigned int COLS>
   ALGEBRA_HOST_DEVICE inline matrix_type<COLS, ROWS> transpose(
-      const matrix_type<ROWS, COLS>& m) {
-    matrix_type<COLS, ROWS> ret;
-
-    for (unsigned int i = 0; i < ROWS; ++i) {
-      for (unsigned int j = 0; j < COLS; ++j) {
-        ret(j, i) = m(i, j);
-      }
-    }
-
-    return ret;
+      const matrix_type<ROWS, COLS> &m) {
+    return ROOT::Math::Transpose(m);
   }
 
   // Get determinant
   template <unsigned int N>
-  ALGEBRA_HOST_DEVICE inline scalar_t determinant(const matrix_type<N, N>& m) {
+  ALGEBRA_HOST_DEVICE inline scalar_t determinant(const matrix_type<N, N> &m) {
     scalar_t det;
     bool success = m.Det2(det);
 
@@ -66,7 +82,7 @@ struct actor {
   // Create inverse matrix
   template <unsigned int N>
   ALGEBRA_HOST_DEVICE inline matrix_type<N, N> inverse(
-      const matrix_type<N, N>& m) {
+      const matrix_type<N, N> &m) {
     int ifail = 0;
     return m.Inverse(ifail);
   }

--- a/math/smatrix/include/algebra/math/impl/smatrix_transform3.hpp
+++ b/math/smatrix/include/algebra/math/impl/smatrix_transform3.hpp
@@ -27,17 +27,17 @@ struct transform3 {
   /// @{
 
   /// Array type used by the transform
-  template <typename T, std::size_t N>
-  using array_type = ROOT::Math::SVector<T, N>;
+  template <unsigned int N>
+  using array_type = ROOT::Math::SVector<scalar_t, N>;
   /// Scalar type used by the transform
   using scalar_type = scalar_t;
 
   /// 3-element "vector" type
-  using vector3 = array_type<scalar_type, 3>;
+  using vector3 = array_type<3>;
   /// Point in 3D space
   using point3 = vector3;
   /// Point in 2D space
-  using point2 = array_type<scalar_type, 2>;
+  using point2 = array_type<2>;
 
   /// 4x4 matrix type
   using matrix44 = ROOT::Math::SMatrix<scalar_type, 4, 4>;
@@ -119,7 +119,7 @@ struct transform3 {
    * @param ma is the full 4x4 matrix asa 16 array
    **/
   ALGEBRA_HOST
-  transform3(const array_type<scalar_type, 16> &ma) {
+  transform3(const array_type<16> &ma) {
 
     _data(0, 0) = ma[0];
     _data(1, 0) = ma[4];

--- a/math/vc/include/algebra/math/impl/vc_transform3.hpp
+++ b/math/vc/include/algebra/math/impl/vc_transform3.hpp
@@ -43,11 +43,11 @@ struct matrix44 {
 };  // struct matrix44
 
 /// Functor used to access elements of Vc matrices
-template <template <typename, std::size_t> class array_t, typename scalar_t>
+template <template <std::size_t> class array_t, typename scalar_t>
 struct element_getter {
 
   /// Get const access to a matrix element
-  ALGEBRA_HOST inline scalar_t operator()(const array_t<scalar_t, 16> &m,
+  ALGEBRA_HOST inline scalar_t operator()(const array_t<16> &m,
                                           unsigned int row,
                                           unsigned int col) const {
 
@@ -98,8 +98,8 @@ struct transform3 {
   /// @{
 
   /// Array type used by the transform
-  template <typename T, std::size_t N>
-  using array_type = array_t<T, N>;
+  template <std::size_t N>
+  using array_type = array_t<scalar_t, N>;
   /// Scalar type used by the transform
   using scalar_type = scalar_t;
 
@@ -178,7 +178,7 @@ struct transform3 {
    * @param ma is the full 4x4 matrix 16 array
    **/
   ALGEBRA_HOST_DEVICE
-  transform3(const array_type<scalar_type, 16> &ma) {
+  transform3(const array_type<16> &ma) {
 
     _data.x = {ma[0], ma[4], ma[8], ma[12]};
     _data.y = {ma[1], ma[5], ma[9], ma[13]};
@@ -326,9 +326,9 @@ struct transform3 {
 
   /** This method retrieves the rotation of a transform */
   ALGEBRA_HOST_DEVICE
-  inline array_type<scalar_type, 16> rotation() const {
+  inline array_type<16> rotation() const {
 
-    array_type<scalar_type, 16> submatrix;
+    array_type<16> submatrix;
     for (unsigned int irow = 0; irow < 3; ++irow) {
       for (unsigned int icol = 0; icol < 3; ++icol) {
         submatrix[icol + irow * 4] = element_getter()(_data, irow, icol);

--- a/storage/eigen/include/algebra/storage/impl/eigen_array.hpp
+++ b/storage/eigen/include/algebra/storage/impl/eigen_array.hpp
@@ -23,11 +23,11 @@ namespace algebra::eigen {
 
 /// Eigen array type
 template <typename T, int N>
-class array : public Eigen::Matrix<T, N, 1> {
+class array : public Eigen::Matrix<T, N, 1, 0, N, 1> {
 
  public:
   /// Inherit all constructors from the base class
-  using Eigen::Matrix<T, N, 1>::Matrix;
+  using Eigen::Matrix<T, N, 1, 0, N, 1>::Matrix;
 
 };  // class array
 

--- a/tests/common/test_host_basics.hpp
+++ b/tests/common/test_host_basics.hpp
@@ -329,9 +329,7 @@ TYPED_TEST_P(test_host_basics, transform3) {
   // Check a contruction from an array[16]
   std::array<typename TypeParam::scalar, 16> matray_helper = {
       1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0};
-  typename TypeParam::transform3::template array_type<
-      typename TypeParam::scalar, 16>
-      matray;
+  typename TypeParam::transform3::template array_type<16> matray;
   for (int i = 0; i < 16; ++i) {
     matray[i] = matray_helper[i];
   }
@@ -358,7 +356,7 @@ TYPED_TEST_P(test_host_basics, transform3) {
 // This test global coordinate transforms
 TYPED_TEST_P(test_host_basics, global_transformations) {
 
-  // Preparatioon work
+  // Preparation work
   typename TypeParam::vector3 z =
       algebra::vector::normalize(typename TypeParam::vector3{3., 2., 1.});
   typename TypeParam::vector3 x =

--- a/tests/vc/vc_cmath.cpp
+++ b/tests/vc/vc_cmath.cpp
@@ -34,8 +34,8 @@ struct test_specialisation_name {
 
 // Instantiate the test(s).
 typedef testing::Types<
-    test_types<float, algebra::vc::point2<float>, algebra::vc::point3<float>,
-               algebra::vc::vector2<float>, algebra::vc::vector3<float>,
+    test_types<float, Vc::array<float, 2>, Vc::array<float, 3>,
+               Vc::array<float, 2>, Vc::array<float, 3>,
                algebra::vc::transform3<float>, algebra::vc::cartesian2<float>,
                algebra::vc::polar2<float>, algebra::vc::cylindrical2<float>,
                std::size_t, algebra::vc::matrix_type,
@@ -43,8 +43,8 @@ typedef testing::Types<
                    std::size_t, float,
                    algebra::matrix::determinant::preset0<std::size_t, float>,
                    algebra::matrix::inverse::preset0<std::size_t, float>>>,
-    test_types<double, algebra::vc::point2<double>, algebra::vc::point3<double>,
-               algebra::vc::vector2<double>, algebra::vc::vector3<double>,
+    test_types<double, Vc::array<double, 2>, Vc::array<double, 3>,
+               Vc::array<double, 2>, Vc::array<double, 3>,
                algebra::vc::transform3<double>, algebra::vc::cartesian2<double>,
                algebra::vc::polar2<double>, algebra::vc::cylindrical2<double>,
                std::size_t, algebra::vc::matrix_type,


### PR DESCRIPTION
This PR makes `cmath::transform3` have `matrix::actor` as a template parameter.
Hard coded inversion and determinant of 4x4 matrix are moved to cmath::matrix algorithms as well