### PR TITLE
Add set block function in matrix

### DIFF
--- a/math/cmath/include/algebra/math/impl/cmath_matrix.hpp
+++ b/math/cmath/include/algebra/math/impl/cmath_matrix.hpp
@@ -64,6 +64,18 @@ struct actor {
     return block_getter().template operator()<ROWS, COLS>(m, row, col);
   }
 
+  /// Operator setting a block
+  template <size_type ROWS, size_type COLS, class input_matrix_type>
+  ALGEBRA_HOST_DEVICE void set_block(input_matrix_type &m,
+                                     const matrix_type<ROWS, COLS> &b, int row,
+                                     int col) {
+    for (size_type i = 0; i < ROWS; ++i) {
+      for (size_type j = 0; j < COLS; ++j) {
+        element_getter()(m, i + row, j + col) = element_getter()(b, i, j);
+      }
+    }
+  }
+
   // Create zero matrix
   template <size_type ROWS, size_type COLS>
   ALGEBRA_HOST_DEVICE inline matrix_type<ROWS, COLS> zero() const {

--- a/math/eigen/include/algebra/math/impl/eigen_matrix.hpp
+++ b/math/eigen/include/algebra/math/impl/eigen_matrix.hpp
@@ -50,6 +50,14 @@ struct actor {
     return m.template block<ROWS, COLS>(row, col);
   }
 
+  /// Operator setting a block
+  template <int ROWS, int COLS, class input_matrix_type>
+  ALGEBRA_HOST_DEVICE void set_block(input_matrix_type &m,
+                                     const matrix_type<ROWS, COLS> &b, int row,
+                                     int col) {
+    m.template block<ROWS, COLS>(row, col) = b;
+  }
+
   // Create zero matrix
   template <int ROWS, int COLS>
   ALGEBRA_HOST_DEVICE inline matrix_type<ROWS, COLS> zero() {

--- a/math/smatrix/include/algebra/math/impl/smatrix_matrix.hpp
+++ b/math/smatrix/include/algebra/math/impl/smatrix_matrix.hpp
@@ -47,6 +47,18 @@ struct actor {
     return m.template Sub<matrix_type<ROWS, COLS> >(row, col);
   }
 
+  /// Operator setting a block
+  template <unsigned int ROWS, unsigned int COLS, class input_matrix_type>
+  ALGEBRA_HOST_DEVICE void set_block(input_matrix_type &m,
+                                     const matrix_type<ROWS, COLS> &b,
+                                     unsigned int row, unsigned int col) {
+    for (unsigned int i = 0; i < ROWS; ++i) {
+      for (unsigned int j = 0; j < COLS; ++j) {
+        m(i + row, j + col) = b(i, j);
+      }
+    }
+  }
+
   // Create zero matrix
   template <unsigned int ROWS, unsigned int COLS>
   ALGEBRA_HOST_DEVICE inline matrix_type<ROWS, COLS> zero() {

--- a/tests/common/test_device_basics.hpp
+++ b/tests/common/test_device_basics.hpp
@@ -98,6 +98,7 @@ class test_device_basics : public test_base<T> {
       }
     }
 
+    // Test set_zero
     matrix_actor().set_zero(m2);
     for (size_type i = 0; i < 6; ++i) {
       for (size_type j = 0; j < 4; ++j) {
@@ -105,10 +106,27 @@ class test_device_basics : public test_base<T> {
       }
     }
 
+    // Test set_identity
     matrix_actor().set_identity(m2);
     for (size_type i = 0; i < 6; ++i) {
       for (size_type j = 0; j < 4; ++j) {
         result += 0.3f * algebra::getter::element(m2, i, j);
+      }
+    }
+
+    // Test block operations
+    auto b32 = matrix_actor().template block<3, 2>(m2, 2, 2);
+    algebra::getter::element(b32, 0, 0) = 4;
+    algebra::getter::element(b32, 0, 1) = 3;
+    algebra::getter::element(b32, 1, 0) = 12;
+    algebra::getter::element(b32, 1, 1) = 13;
+    algebra::getter::element(b32, 2, 0) = 5;
+    algebra::getter::element(b32, 2, 1) = 6;
+
+    matrix_actor().set_block(m2, b32, 2, 2);
+    for (size_type i = 0; i < 6; ++i) {
+      for (size_type j = 0; j < 4; ++j) {
+        result += 0.57f * algebra::getter::element(m2, i, j);
       }
     }
 

--- a/tests/common/test_host_basics.hpp
+++ b/tests/common/test_host_basics.hpp
@@ -178,8 +178,6 @@ TYPED_TEST_P(test_host_basics, matrix64) {
   ASSERT_NEAR(algebra::getter::element(m, 3, 3), 13., this->m_epsilon);
   ASSERT_NEAR(algebra::getter::element(m, 4, 2), 5., this->m_epsilon);
   ASSERT_NEAR(algebra::getter::element(m, 4, 3), 6., this->m_epsilon);
-
-  // Test block setter
 }
 
 // Test matrix operations with 3x3 matrix

--- a/tests/common/test_host_basics.hpp
+++ b/tests/common/test_host_basics.hpp
@@ -156,22 +156,22 @@ TYPED_TEST_P(test_host_basics, matrix64) {
   }
 
   // Test block operations
-  auto b23 = typename TypeParam::matrix_actor().template block<3, 2>(m, 2, 2);
-  ASSERT_NEAR(algebra::getter::element(b23, 0, 0), 1., this->m_epsilon);
-  ASSERT_NEAR(algebra::getter::element(b23, 0, 1), 0., this->m_epsilon);
-  ASSERT_NEAR(algebra::getter::element(b23, 1, 0), 0., this->m_epsilon);
-  ASSERT_NEAR(algebra::getter::element(b23, 1, 1), 1., this->m_epsilon);
-  ASSERT_NEAR(algebra::getter::element(b23, 2, 0), 0., this->m_epsilon);
-  ASSERT_NEAR(algebra::getter::element(b23, 2, 1), 0., this->m_epsilon);
+  auto b32 = typename TypeParam::matrix_actor().template block<3, 2>(m, 2, 2);
+  ASSERT_NEAR(algebra::getter::element(b32, 0, 0), 1., this->m_epsilon);
+  ASSERT_NEAR(algebra::getter::element(b32, 0, 1), 0., this->m_epsilon);
+  ASSERT_NEAR(algebra::getter::element(b32, 1, 0), 0., this->m_epsilon);
+  ASSERT_NEAR(algebra::getter::element(b32, 1, 1), 1., this->m_epsilon);
+  ASSERT_NEAR(algebra::getter::element(b32, 2, 0), 0., this->m_epsilon);
+  ASSERT_NEAR(algebra::getter::element(b32, 2, 1), 0., this->m_epsilon);
 
-  algebra::getter::element(b23, 0, 0) = 4;
-  algebra::getter::element(b23, 0, 1) = 3;
-  algebra::getter::element(b23, 1, 0) = 12;
-  algebra::getter::element(b23, 1, 1) = 13;
-  algebra::getter::element(b23, 2, 0) = 5;
-  algebra::getter::element(b23, 2, 1) = 6;
+  algebra::getter::element(b32, 0, 0) = 4;
+  algebra::getter::element(b32, 0, 1) = 3;
+  algebra::getter::element(b32, 1, 0) = 12;
+  algebra::getter::element(b32, 1, 1) = 13;
+  algebra::getter::element(b32, 2, 0) = 5;
+  algebra::getter::element(b32, 2, 1) = 6;
 
-  typename TypeParam::matrix_actor().set_block(m, b23, 2, 2);
+  typename TypeParam::matrix_actor().set_block(m, b32, 2, 2);
   ASSERT_NEAR(algebra::getter::element(m, 2, 2), 4., this->m_epsilon);
   ASSERT_NEAR(algebra::getter::element(m, 2, 3), 3., this->m_epsilon);
   ASSERT_NEAR(algebra::getter::element(m, 3, 2), 12., this->m_epsilon);

--- a/tests/common/test_host_basics.hpp
+++ b/tests/common/test_host_basics.hpp
@@ -154,6 +154,32 @@ TYPED_TEST_P(test_host_basics, matrix64) {
       }
     }
   }
+
+  // Test block operations
+  auto b23 = typename TypeParam::matrix_actor().template block<3, 2>(m, 2, 2);
+  ASSERT_NEAR(algebra::getter::element(b23, 0, 0), 1., this->m_epsilon);
+  ASSERT_NEAR(algebra::getter::element(b23, 0, 1), 0., this->m_epsilon);
+  ASSERT_NEAR(algebra::getter::element(b23, 1, 0), 0., this->m_epsilon);
+  ASSERT_NEAR(algebra::getter::element(b23, 1, 1), 1., this->m_epsilon);
+  ASSERT_NEAR(algebra::getter::element(b23, 2, 0), 0., this->m_epsilon);
+  ASSERT_NEAR(algebra::getter::element(b23, 2, 1), 0., this->m_epsilon);
+
+  algebra::getter::element(b23, 0, 0) = 4;
+  algebra::getter::element(b23, 0, 1) = 3;
+  algebra::getter::element(b23, 1, 0) = 12;
+  algebra::getter::element(b23, 1, 1) = 13;
+  algebra::getter::element(b23, 2, 0) = 5;
+  algebra::getter::element(b23, 2, 1) = 6;
+
+  typename TypeParam::matrix_actor().set_block(m, b23, 2, 2);
+  ASSERT_NEAR(algebra::getter::element(m, 2, 2), 4., this->m_epsilon);
+  ASSERT_NEAR(algebra::getter::element(m, 2, 3), 3., this->m_epsilon);
+  ASSERT_NEAR(algebra::getter::element(m, 3, 2), 12., this->m_epsilon);
+  ASSERT_NEAR(algebra::getter::element(m, 3, 3), 13., this->m_epsilon);
+  ASSERT_NEAR(algebra::getter::element(m, 4, 2), 5., this->m_epsilon);
+  ASSERT_NEAR(algebra::getter::element(m, 4, 3), 6., this->m_epsilon);
+
+  // Test block setter
 }
 
 // Test matrix operations with 3x3 matrix


### PR DESCRIPTION
This is possibly the last update for the moment ( I hope ... )

This PR adds `set_block` function to matrix backend.
Eigen backend doesn't need `set_block` as `block` supports lvalue.
Meanwhile, `block` operator of cmath and smtrix backends don't support lvalue so I needed to setup a new function

Yeah so it is an awful implementation and might degrade the performance. We need to think about how to make all backends support lvalue block operation. Or, at least find a better alternative

Following snippet is what I want to achieve in the end

```c++
matrix<4,4> m;
auto b22 = matrix_actor().template block<2,2>(m,1,1); // get 2x2 block matrix which can be used as lvalue
element_getter()(b22,0,0) = 1; //  m(1,1) is also changed
```