### PR TITLE
Remove size type parameter in frontend matrix actor

### DIFF
--- a/frontend/array_cmath/include/algebra/array_cmath.hpp
+++ b/frontend/array_cmath/include/algebra/array_cmath.hpp
@@ -70,79 +70,75 @@ using cmath::normalize;
 
 namespace matrix {
 
-template <typename T, std::size_t N>
+using size_type = std::size_t;
+
+template <typename T, size_type N>
 using array_type = array::storage_type<T, N>;
 
-template <typename T, std::size_t ROWS, std::size_t COLS>
+template <typename T, size_type ROWS, size_type COLS>
 using matrix_type = array::matrix_type<T, ROWS, COLS>;
 
-template <typename size_type, typename scalar_t>
+template <typename scalar_t>
 using element_getter = cmath::element_getter<size_type, array_type, scalar_t>;
 
-template <typename size_type, typename scalar_t>
+template <typename scalar_t>
 using block_getter = cmath::block_getter<size_type, array_type, scalar_t>;
 
 // matrix actor
-template <typename size_type, typename scalar_t, typename determinant_actor_t,
+template <typename scalar_t, typename determinant_actor_t,
           typename inverse_actor_t>
-using actor = cmath::matrix::actor<size_type, array_type, matrix_type, scalar_t,
-                                   determinant_actor_t, inverse_actor_t,
-                                   element_getter<size_type, scalar_t>,
-                                   block_getter<size_type, scalar_t>>;
+using actor =
+    cmath::matrix::actor<size_type, array_type, matrix_type, scalar_t,
+                         determinant_actor_t, inverse_actor_t,
+                         element_getter<scalar_t>, block_getter<scalar_t>>;
 
 namespace determinant {
 
 // determinant aggregation
-template <typename size_type, typename scalar_t, class... As>
+template <typename scalar_t, class... As>
 using actor =
     cmath::matrix::determinant::actor<size_type, matrix_type, scalar_t, As...>;
 
 // determinant::cofactor
-template <typename size_type, typename scalar_t, size_type... Ds>
+template <typename scalar_t, size_type... Ds>
 using cofactor =
     cmath::matrix::determinant::cofactor<size_type, matrix_type, scalar_t,
-                                         element_getter<size_type, scalar_t>,
-                                         Ds...>;
+                                         element_getter<scalar_t>, Ds...>;
 
 // determinant::hard_coded
-template <typename size_type, typename scalar_t, size_type... Ds>
+template <typename scalar_t, size_type... Ds>
 using hard_coded =
     cmath::matrix::determinant::hard_coded<size_type, matrix_type, scalar_t,
-                                           element_getter<size_type, scalar_t>,
-                                           Ds...>;
+                                           element_getter<scalar_t>, Ds...>;
 
 // preset(s) as standard option(s) for user's convenience
-template <typename size_type, typename scalar_t>
-using preset0 = actor<size_type, scalar_t, cofactor<size_type, scalar_t>,
-                      hard_coded<size_type, scalar_t, 2, 4>>;
+template <typename scalar_t>
+using preset0 = actor<scalar_t, cofactor<scalar_t>, hard_coded<scalar_t, 2, 4>>;
 
 }  // namespace determinant
 
 namespace inverse {
 
 // inverion aggregation
-template <typename size_type, typename scalar_t, class... As>
+template <typename scalar_t, class... As>
 using actor =
     cmath::matrix::inverse::actor<size_type, matrix_type, scalar_t, As...>;
 
 // inverse::cofactor
-template <typename size_type, typename scalar_t, size_type... Ds>
+template <typename scalar_t, size_type... Ds>
 using cofactor =
     cmath::matrix::inverse::cofactor<size_type, matrix_type, scalar_t,
-                                     element_getter<size_type, scalar_t>,
-                                     Ds...>;
+                                     element_getter<scalar_t>, Ds...>;
 
 // inverse::hard_coded
-template <typename size_type, typename scalar_t, size_type... Ds>
+template <typename scalar_t, size_type... Ds>
 using hard_coded =
     cmath::matrix::inverse::hard_coded<size_type, matrix_type, scalar_t,
-                                       element_getter<size_type, scalar_t>,
-                                       Ds...>;
+                                       element_getter<scalar_t>, Ds...>;
 
 // preset(s) as standard option(s) for user's convenience
-template <typename size_type, typename scalar_t>
-using preset0 = actor<size_type, scalar_t, cofactor<size_type, scalar_t>,
-                      hard_coded<size_type, scalar_t, 2, 4>>;
+template <typename scalar_t>
+using preset0 = actor<scalar_t, cofactor<scalar_t>, hard_coded<scalar_t, 2, 4>>;
 
 }  // namespace inverse
 
@@ -154,9 +150,8 @@ namespace array {
 /// @{
 
 template <typename T>
-using transform3_actor =
-    matrix::actor<std::size_t, T, matrix::determinant::preset0<std::size_t, T>,
-                  matrix::inverse::preset0<std::size_t, T>>;
+using transform3_actor = matrix::actor<T, matrix::determinant::preset0<T>,
+                                       matrix::inverse::preset0<T>>;
 
 template <typename T>
 using transform3 = cmath::transform3<transform3_actor<T>>;

--- a/frontend/eigen_cmath/include/algebra/eigen_cmath.hpp
+++ b/frontend/eigen_cmath/include/algebra/eigen_cmath.hpp
@@ -70,15 +70,17 @@ using eigen::math::normalize;
 
 namespace matrix {
 
-template <typename T, int N>
+using size_type = int;
+
+template <typename T, size_type N>
 using array_type = eigen::storage_type<T, N>;
-template <typename T, int ROWS, int COLS>
+template <typename T, size_type ROWS, size_type COLS>
 using matrix_type = eigen::matrix_type<T, ROWS, COLS>;
 using element_getter = eigen::math::element_getter;
 using block_getter = eigen::math::block_getter;
 
 // matrix actor
-template <typename size_type, typename scalar_t, typename determinant_actor_t,
+template <typename scalar_t, typename determinant_actor_t,
           typename inverse_actor_t>
 using actor = cmath::matrix::actor<size_type, array_type, matrix_type, scalar_t,
                                    determinant_actor_t, inverse_actor_t,
@@ -87,52 +89,50 @@ using actor = cmath::matrix::actor<size_type, array_type, matrix_type, scalar_t,
 namespace determinant {
 
 // determinant aggregation
-template <typename size_type, typename scalar_t, class... As>
+template <typename scalar_t, class... As>
 using actor =
     cmath::matrix::determinant::actor<size_type, matrix_type, scalar_t, As...>;
 
 // determinant::cofactor
-template <typename size_type, typename scalar_t, size_type... Ds>
+template <typename scalar_t, size_type... Ds>
 using cofactor =
     cmath::matrix::determinant::cofactor<size_type, matrix_type, scalar_t,
                                          element_getter, Ds...>;
 
 // determinant::hard_coded
-template <typename size_type, typename scalar_t, size_type... Ds>
+template <typename scalar_t, size_type... Ds>
 using hard_coded =
     cmath::matrix::determinant::hard_coded<size_type, matrix_type, scalar_t,
                                            element_getter, Ds...>;
 
 // preset(s) as standard option(s) for user's convenience
-template <typename size_type, typename scalar_t>
-using preset0 = actor<size_type, scalar_t, cofactor<size_type, scalar_t>,
-                      hard_coded<size_type, scalar_t, 2, 4>>;
+template <typename scalar_t>
+using preset0 = actor<scalar_t, cofactor<scalar_t>, hard_coded<scalar_t, 2, 4>>;
 
 }  // namespace determinant
 
 namespace inverse {
 
 // inverion aggregation
-template <typename size_type, typename scalar_t, class... As>
+template <typename scalar_t, class... As>
 using actor =
     cmath::matrix::inverse::actor<size_type, matrix_type, scalar_t, As...>;
 
 // inverse::cofactor
-template <typename size_type, typename scalar_t, size_type... Ds>
+template <typename scalar_t, size_type... Ds>
 using cofactor =
     cmath::matrix::inverse::cofactor<size_type, matrix_type, scalar_t,
                                      element_getter, Ds...>;
 
 // inverse::hard_coded
-template <typename size_type, typename scalar_t, size_type... Ds>
+template <typename scalar_t, size_type... Ds>
 using hard_coded =
     cmath::matrix::inverse::hard_coded<size_type, matrix_type, scalar_t,
                                        element_getter, Ds...>;
 
 // preset(s) as standard option(s) for user's convenience
-template <typename size_type, typename scalar_t>
-using preset0 = actor<size_type, scalar_t, cofactor<size_type, scalar_t>,
-                      hard_coded<size_type, scalar_t, 2, 4>>;
+template <typename scalar_t>
+using preset0 = actor<scalar_t, cofactor<scalar_t>, hard_coded<scalar_t, 2, 4>>;
 
 }  // namespace inverse
 
@@ -145,9 +145,8 @@ namespace eigen {
 
 template <typename T>
 using transform3_actor =
-    algebra::matrix::actor<int, T,
-                           algebra::matrix::determinant::preset0<int, T>,
-                           algebra::matrix::inverse::preset0<int, T>>;
+    algebra::matrix::actor<T, algebra::matrix::determinant::preset0<T>,
+                           algebra::matrix::inverse::preset0<T>>;
 
 template <typename T>
 using transform3 = cmath::transform3<transform3_actor<T>>;

--- a/frontend/smatrix_cmath/include/algebra/smatrix_cmath.hpp
+++ b/frontend/smatrix_cmath/include/algebra/smatrix_cmath.hpp
@@ -64,9 +64,11 @@ using smatrix::math::normalize;
 
 namespace matrix {
 
-template <typename T, unsigned int N>
+using size_type = unsigned int;
+
+template <typename T, size_type N>
 using array_type = smatrix::storage_type<T, N>;
-template <typename T, unsigned int ROWS, unsigned int COLS>
+template <typename T, size_type ROWS, size_type COLS>
 using matrix_type = smatrix::matrix_type<T, ROWS, COLS>;
 template <typename scalar_t>
 using element_getter = smatrix::math::element_getter<scalar_t>;
@@ -74,7 +76,7 @@ template <typename scalar_t>
 using block_getter = smatrix::math::block_getter<scalar_t>;
 
 // matrix actor
-template <typename size_type, typename scalar_t, typename determinant_actor_t,
+template <typename scalar_t, typename determinant_actor_t,
           typename inverse_actor_t>
 using actor =
     cmath::matrix::actor<size_type, array_type, matrix_type, scalar_t,
@@ -84,52 +86,50 @@ using actor =
 namespace determinant {
 
 // determinant aggregation
-template <typename size_type, typename scalar_t, class... As>
+template <typename scalar_t, class... As>
 using actor =
     cmath::matrix::determinant::actor<size_type, matrix_type, scalar_t, As...>;
 
 // determinant::cofactor
-template <typename size_type, typename scalar_t, size_type... Ds>
+template <typename scalar_t, size_type... Ds>
 using cofactor =
     cmath::matrix::determinant::cofactor<size_type, matrix_type, scalar_t,
                                          element_getter<scalar_t>, Ds...>;
 
 // determinant::hard_coded
-template <typename size_type, typename scalar_t, size_type... Ds>
+template <typename scalar_t, size_type... Ds>
 using hard_coded =
     cmath::matrix::determinant::hard_coded<size_type, matrix_type, scalar_t,
                                            element_getter<scalar_t>, Ds...>;
 
 // preset(s) as standard option(s) for user's convenience
-template <typename size_type, typename scalar_t>
-using preset0 = actor<size_type, scalar_t, cofactor<size_type, scalar_t>,
-                      hard_coded<size_type, scalar_t, 2, 4>>;
+template <typename scalar_t>
+using preset0 = actor<scalar_t, cofactor<scalar_t>, hard_coded<scalar_t, 2, 4>>;
 
 }  // namespace determinant
 
 namespace inverse {
 
 // inverion aggregation
-template <typename size_type, typename scalar_t, class... As>
+template <typename scalar_t, class... As>
 using actor =
     cmath::matrix::inverse::actor<size_type, matrix_type, scalar_t, As...>;
 
 // inverse::cofactor
-template <typename size_type, typename scalar_t, size_type... Ds>
+template <typename scalar_t, size_type... Ds>
 using cofactor =
     cmath::matrix::inverse::cofactor<size_type, matrix_type, scalar_t,
                                      element_getter<scalar_t>, Ds...>;
 
 // inverse::hard_coded
-template <typename size_type, typename scalar_t, size_type... Ds>
+template <typename scalar_t, size_type... Ds>
 using hard_coded =
     cmath::matrix::inverse::hard_coded<size_type, matrix_type, scalar_t,
                                        element_getter<scalar_t>, Ds...>;
 
 // preset(s) as standard option(s) for user's convenience
-template <typename size_type, typename scalar_t>
-using preset0 = actor<size_type, scalar_t, cofactor<size_type, scalar_t>,
-                      hard_coded<size_type, scalar_t, 2, 4>>;
+template <typename scalar_t>
+using preset0 = actor<scalar_t, cofactor<scalar_t>, hard_coded<scalar_t, 2, 4>>;
 
 }  // namespace inverse
 
@@ -141,9 +141,9 @@ namespace smatrix {
 /// @{
 
 template <typename T>
-using transform3_actor = algebra::matrix::actor<
-    unsigned int, T, algebra::matrix::determinant::preset0<unsigned int, T>,
-    algebra::matrix::inverse::preset0<unsigned int, T>>;
+using transform3_actor =
+    algebra::matrix::actor<T, algebra::matrix::determinant::preset0<T>,
+                           algebra::matrix::inverse::preset0<T>>;
 
 template <typename T>
 using transform3 = cmath::transform3<transform3_actor<T>>;

--- a/frontend/vc_cmath/include/algebra/vc_cmath.hpp
+++ b/frontend/vc_cmath/include/algebra/vc_cmath.hpp
@@ -81,79 +81,75 @@ using vc::math::normalize;
 
 namespace matrix {
 
-template <typename T, std::size_t N>
+using size_type = std::size_t;
+
+template <typename T, size_type N>
 using array_type = Vc::array<T, N>;
 
-template <typename T, std::size_t ROWS, std::size_t COLS>
+template <typename T, size_type ROWS, size_type COLS>
 using matrix_type = vc::matrix_type<T, ROWS, COLS>;
 
-template <typename size_type, typename scalar_t>
+template <typename scalar_t>
 using element_getter = cmath::element_getter<size_type, array_type, scalar_t>;
 
-template <typename size_type, typename scalar_t>
+template <typename scalar_t>
 using block_getter = cmath::block_getter<size_type, array_type, scalar_t>;
 
 // matrix actor
-template <typename size_type, typename scalar_t, typename determinant_actor_t,
+template <typename scalar_t, typename determinant_actor_t,
           typename inverse_actor_t>
-using actor = cmath::matrix::actor<size_type, array_type, matrix_type, scalar_t,
-                                   determinant_actor_t, inverse_actor_t,
-                                   element_getter<size_type, scalar_t>,
-                                   block_getter<size_type, scalar_t>>;
+using actor =
+    cmath::matrix::actor<size_type, array_type, matrix_type, scalar_t,
+                         determinant_actor_t, inverse_actor_t,
+                         element_getter<scalar_t>, block_getter<scalar_t>>;
 
 namespace determinant {
 
 // determinant aggregation
-template <typename size_type, typename scalar_t, class... As>
+template <typename scalar_t, class... As>
 using actor =
     cmath::matrix::determinant::actor<size_type, matrix_type, scalar_t, As...>;
 
 // determinant::cofactor
-template <typename size_type, typename scalar_t, size_type... Ds>
+template <typename scalar_t, size_type... Ds>
 using cofactor =
     cmath::matrix::determinant::cofactor<size_type, matrix_type, scalar_t,
-                                         element_getter<size_type, scalar_t>,
-                                         Ds...>;
+                                         element_getter<scalar_t>, Ds...>;
 
 // determinant::hard_coded
-template <typename size_type, typename scalar_t, size_type... Ds>
+template <typename scalar_t, size_type... Ds>
 using hard_coded =
     cmath::matrix::determinant::hard_coded<size_type, matrix_type, scalar_t,
-                                           element_getter<size_type, scalar_t>,
-                                           Ds...>;
+                                           element_getter<scalar_t>, Ds...>;
 
 // preset(s) as standard option(s) for user's convenience
-template <typename size_type, typename scalar_t>
-using preset0 = actor<size_type, scalar_t, cofactor<size_type, scalar_t>,
-                      hard_coded<size_type, scalar_t, 2, 4>>;
+template <typename scalar_t>
+using preset0 = actor<scalar_t, cofactor<scalar_t>, hard_coded<scalar_t, 2, 4>>;
 
 }  // namespace determinant
 
 namespace inverse {
 
 // inverion aggregation
-template <typename size_type, typename scalar_t, class... As>
+template <typename scalar_t, class... As>
 using actor =
     cmath::matrix::inverse::actor<size_type, matrix_type, scalar_t, As...>;
 
 // inverse::cofactor
-template <typename size_type, typename scalar_t, size_type... Ds>
+template <typename scalar_t, size_type... Ds>
 using cofactor =
     cmath::matrix::inverse::cofactor<size_type, matrix_type, scalar_t,
-                                     element_getter<size_type, scalar_t>,
-                                     Ds...>;
+                                     element_getter<scalar_t>, Ds...>;
 
 // inverse::hard_coded
-template <typename size_type, typename scalar_t, size_type... Ds>
+template <typename scalar_t, size_type... Ds>
 using hard_coded =
     cmath::matrix::inverse::hard_coded<size_type, matrix_type, scalar_t,
-                                       element_getter<size_type, scalar_t>,
-                                       Ds...>;
+                                       element_getter<scalar_t>, Ds...>;
 
 // preset(s) as standard option(s) for user's convenience
-template <typename size_type, typename scalar_t>
-using preset0 = actor<size_type, scalar_t, cofactor<size_type, scalar_t>,
-                      hard_coded<size_type, scalar_t, 2, 4>>;
+template <typename scalar_t>
+using preset0 = actor<scalar_t, cofactor<scalar_t>, hard_coded<scalar_t, 2, 4>>;
 
 }  // namespace inverse
 
@@ -165,9 +161,8 @@ namespace vc {
 /// @{
 
 template <typename T>
-using transform3_actor =
-    matrix::actor<std::size_t, T, matrix::determinant::preset0<std::size_t, T>,
-                  matrix::inverse::preset0<std::size_t, T>>;
+using transform3_actor = matrix::actor<T, matrix::determinant::preset0<T>,
+                                       matrix::inverse::preset0<T>>;
 
 template <typename T>
 using transform3 = cmath::transform3<transform3_actor<T>>;

--- a/frontend/vc_vc/include/algebra/vc_vc.hpp
+++ b/frontend/vc_vc/include/algebra/vc_vc.hpp
@@ -148,79 +148,75 @@ using vc::math::normalize;
 
 namespace matrix {
 
-template <typename T, std::size_t N>
+using size_type = std::size_t;
+
+template <typename T, size_type N>
 using array_type = vc::storage_type<T, N>;
 
-template <typename T, std::size_t ROWS, std::size_t COLS>
+template <typename T, size_type ROWS, size_type COLS>
 using matrix_type = vc::matrix_type<T, ROWS, COLS>;
 
-template <typename size_type, typename scalar_t>
+template <typename scalar_t>
 using element_getter = cmath::element_getter<size_type, Vc::array, scalar_t>;
 
-template <typename size_type, typename scalar_t>
+template <typename scalar_t>
 using block_getter = cmath::block_getter<size_type, Vc::array, scalar_t>;
 
 // matrix actor
-template <typename size_type, typename scalar_t, typename determinant_actor_t,
+template <typename scalar_t, typename determinant_actor_t,
           typename inverse_actor_t>
-using actor = cmath::matrix::actor<size_type, array_type, matrix_type, scalar_t,
-                                   determinant_actor_t, inverse_actor_t,
-                                   element_getter<size_type, scalar_t>,
-                                   block_getter<size_type, scalar_t>>;
+using actor =
+    cmath::matrix::actor<size_type, array_type, matrix_type, scalar_t,
+                         determinant_actor_t, inverse_actor_t,
+                         element_getter<scalar_t>, block_getter<scalar_t>>;
 
 namespace determinant {
 
 // determinant aggregation
-template <typename size_type, typename scalar_t, class... As>
+template <typename scalar_t, class... As>
 using actor =
     cmath::matrix::determinant::actor<size_type, matrix_type, scalar_t, As...>;
 
 // determinant::cofactor
-template <typename size_type, typename scalar_t, size_type... Ds>
+template <typename scalar_t, size_type... Ds>
 using cofactor =
     cmath::matrix::determinant::cofactor<size_type, matrix_type, scalar_t,
-                                         element_getter<size_type, scalar_t>,
-                                         Ds...>;
+                                         element_getter<scalar_t>, Ds...>;
 
 // determinant::hard_coded
-template <typename size_type, typename scalar_t, size_type... Ds>
+template <typename scalar_t, size_type... Ds>
 using hard_coded =
     cmath::matrix::determinant::hard_coded<size_type, matrix_type, scalar_t,
-                                           element_getter<size_type, scalar_t>,
-                                           Ds...>;
+                                           element_getter<scalar_t>, Ds...>;
 
 // preset(s) as standard option(s) for user's convenience
-template <typename size_type, typename scalar_t>
-using preset0 = actor<size_type, scalar_t, cofactor<size_type, scalar_t>,
-                      hard_coded<size_type, scalar_t, 2, 4>>;
+template <typename scalar_t>
+using preset0 = actor<scalar_t, cofactor<scalar_t>, hard_coded<scalar_t, 2, 4>>;
 
 }  // namespace determinant
 
 namespace inverse {
 
 // inverion aggregation
-template <typename size_type, typename scalar_t, class... As>
+template <typename scalar_t, class... As>
 using actor =
     cmath::matrix::inverse::actor<size_type, matrix_type, scalar_t, As...>;
 
 // inverse::cofactor
-template <typename size_type, typename scalar_t, size_type... Ds>
+template <typename scalar_t, size_type... Ds>
 using cofactor =
     cmath::matrix::inverse::cofactor<size_type, matrix_type, scalar_t,
-                                     element_getter<size_type, scalar_t>,
-                                     Ds...>;
+                                     element_getter<scalar_t>, Ds...>;
 
 // inverse::hard_coded
-template <typename size_type, typename scalar_t, size_type... Ds>
+template <typename scalar_t, size_type... Ds>
 using hard_coded =
     cmath::matrix::inverse::hard_coded<size_type, matrix_type, scalar_t,
-                                       element_getter<size_type, scalar_t>,
-                                       Ds...>;
+                                       element_getter<scalar_t>, Ds...>;
 
 // preset(s) as standard option(s) for user's convenience
-template <typename size_type, typename scalar_t>
-using preset0 = actor<size_type, scalar_t, cofactor<size_type, scalar_t>,
-                      hard_coded<size_type, scalar_t, 2, 4>>;
+template <typename scalar_t>
+using preset0 = actor<scalar_t, cofactor<scalar_t>, hard_coded<scalar_t, 2, 4>>;
 
 }  // namespace inverse
 

--- a/frontend/vecmem_cmath/include/algebra/vecmem_cmath.hpp
+++ b/frontend/vecmem_cmath/include/algebra/vecmem_cmath.hpp
@@ -71,78 +71,75 @@ using cmath::normalize;
 
 namespace matrix {
 
-template <typename T, std::size_t N>
+using size_type = std::size_t;
+
+template <typename T, size_type N>
 using array_type = vecmem::storage_type<T, N>;
-template <typename T, std::size_t ROWS, std::size_t COLS>
+
+template <typename T, size_type ROWS, size_type COLS>
 using matrix_type = vecmem::matrix_type<T, ROWS, COLS>;
 
-template <typename size_type, typename scalar_t>
+template <typename scalar_t>
 using element_getter = cmath::element_getter<size_type, array_type, scalar_t>;
 
-template <typename size_type, typename scalar_t>
+template <typename scalar_t>
 using block_getter = cmath::block_getter<size_type, array_type, scalar_t>;
 
 // matrix actor
-template <typename size_type, typename scalar_t, typename determinant_actor_t,
+template <typename scalar_t, typename determinant_actor_t,
           typename inverse_actor_t>
-using actor = cmath::matrix::actor<size_type, array_type, matrix_type, scalar_t,
-                                   determinant_actor_t, inverse_actor_t,
-                                   element_getter<size_type, scalar_t>,
-                                   block_getter<size_type, scalar_t>>;
+using actor =
+    cmath::matrix::actor<size_type, array_type, matrix_type, scalar_t,
+                         determinant_actor_t, inverse_actor_t,
+                         element_getter<scalar_t>, block_getter<scalar_t>>;
 
 namespace determinant {
 
 // determinant aggregation
-template <typename size_type, typename scalar_t, class... As>
+template <typename scalar_t, class... As>
 using actor =
     cmath::matrix::determinant::actor<size_type, matrix_type, scalar_t, As...>;
 
 // determinant::cofactor
-template <typename size_type, typename scalar_t, size_type... Ds>
+template <typename scalar_t, size_type... Ds>
 using cofactor =
     cmath::matrix::determinant::cofactor<size_type, matrix_type, scalar_t,
-                                         element_getter<size_type, scalar_t>,
-                                         Ds...>;
+                                         element_getter<scalar_t>, Ds...>;
 
 // determinant::hard_coded
-template <typename size_type, typename scalar_t, size_type... Ds>
+template <typename scalar_t, size_type... Ds>
 using hard_coded =
     cmath::matrix::determinant::hard_coded<size_type, matrix_type, scalar_t,
-                                           element_getter<size_type, scalar_t>,
-                                           Ds...>;
+                                           element_getter<scalar_t>, Ds...>;
 
 // preset(s) as standard option(s) for user's convenience
-template <typename size_type, typename scalar_t>
-using preset0 = actor<size_type, scalar_t, cofactor<size_type, scalar_t>,
-                      hard_coded<size_type, scalar_t, 2, 4>>;
+template <typename scalar_t>
+using preset0 = actor<scalar_t, cofactor<scalar_t>, hard_coded<scalar_t, 2, 4>>;
 
 }  // namespace determinant
 
 namespace inverse {
 
 // inverion aggregation
-template <typename size_type, typename scalar_t, class... As>
+template <typename scalar_t, class... As>
 using actor =
     cmath::matrix::inverse::actor<size_type, matrix_type, scalar_t, As...>;
 
 // inverse::cofactor
-template <typename size_type, typename scalar_t, size_type... Ds>
+template <typename scalar_t, size_type... Ds>
 using cofactor =
     cmath::matrix::inverse::cofactor<size_type, matrix_type, scalar_t,
-                                     element_getter<size_type, scalar_t>,
-                                     Ds...>;
+                                     element_getter<scalar_t>, Ds...>;
 
 // inverse::hard_coded
-template <typename size_type, typename scalar_t, size_type... Ds>
+template <typename scalar_t, size_type... Ds>
 using hard_coded =
     cmath::matrix::inverse::hard_coded<size_type, matrix_type, scalar_t,
-                                       element_getter<size_type, scalar_t>,
-                                       Ds...>;
+                                       element_getter<scalar_t>, Ds...>;
 
 // preset(s) as standard option(s) for user's convenience
-template <typename size_type, typename scalar_t>
-using preset0 = actor<size_type, scalar_t, cofactor<size_type, scalar_t>,
-                      hard_coded<size_type, scalar_t, 2, 4>>;
+template <typename scalar_t>
+using preset0 = actor<scalar_t, cofactor<scalar_t>, hard_coded<scalar_t, 2, 4>>;
 
 }  // namespace inverse
 
@@ -154,9 +151,8 @@ namespace vecmem {
 /// @{
 
 template <typename T>
-using transform3_actor =
-    matrix::actor<std::size_t, T, matrix::determinant::preset0<std::size_t, T>,
-                  matrix::inverse::preset0<std::size_t, T>>;
+using transform3_actor = matrix::actor<T, matrix::determinant::preset0<T>,
+                                       matrix::inverse::preset0<T>>;
 
 template <typename T>
 using transform3 = cmath::transform3<transform3_actor<T>>;

--- a/tests/accelerator/cuda/array_cmath.cu
+++ b/tests/accelerator/cuda/array_cmath.cu
@@ -40,20 +40,18 @@ typedef testing::Types<
         algebra::array::transform3<float>, algebra::array::cartesian2<float>,
         algebra::array::polar2<float>, algebra::array::cylindrical2<float>,
         std::size_t, algebra::array::matrix_type,
-        algebra::matrix::actor<
-            std::size_t, float,
-            algebra::matrix::determinant::preset0<std::size_t, float>,
-            algebra::matrix::inverse::preset0<std::size_t, float>>>,
+        algebra::matrix::actor<float,
+                               algebra::matrix::determinant::preset0<float>,
+                               algebra::matrix::inverse::preset0<float>>>,
     test_types<
         double, algebra::array::point2<double>, algebra::array::point3<double>,
         algebra::array::vector2<double>, algebra::array::vector3<double>,
         algebra::array::transform3<double>, algebra::array::cartesian2<double>,
         algebra::array::polar2<double>, algebra::array::cylindrical2<double>,
         std::size_t, algebra::array::matrix_type,
-        algebra::matrix::actor<
-            std::size_t, double,
-            algebra::matrix::determinant::preset0<std::size_t, double>,
-            algebra::matrix::inverse::preset0<std::size_t, double>>>>
+        algebra::matrix::actor<double,
+                               algebra::matrix::determinant::preset0<double>,
+                               algebra::matrix::inverse::preset0<double>>>>
     array_cmath_types;
 INSTANTIATE_TYPED_TEST_SUITE_P(algebra_plugins, test_cuda_basics,
                                array_cmath_types, test_specialisation_name);

--- a/tests/accelerator/cuda/eigen_cmath.cu
+++ b/tests/accelerator/cuda/eigen_cmath.cu
@@ -40,18 +40,18 @@ typedef testing::Types<
         algebra::eigen::transform3<float>, algebra::eigen::cartesian2<float>,
         algebra::eigen::polar2<float>, algebra::eigen::cylindrical2<float>, int,
         algebra::eigen::matrix_type,
-        algebra::matrix::actor<
-            int, float, algebra::matrix::determinant::preset0<int, float>,
-            algebra::matrix::inverse::preset0<int, float>>>,
+        algebra::matrix::actor<float,
+                               algebra::matrix::determinant::preset0<float>,
+                               algebra::matrix::inverse::preset0<float>>>,
     test_types<
         double, algebra::eigen::point2<double>, algebra::eigen::point3<double>,
         algebra::eigen::vector2<double>, algebra::eigen::vector3<double>,
         algebra::eigen::transform3<double>, algebra::eigen::cartesian2<double>,
         algebra::eigen::polar2<double>, algebra::eigen::cylindrical2<double>,
         int, algebra::eigen::matrix_type,
-        algebra::matrix::actor<
-            int, double, algebra::matrix::determinant::preset0<int, double>,
-            algebra::matrix::inverse::preset0<int, double>>>>
+        algebra::matrix::actor<double,
+                               algebra::matrix::determinant::preset0<double>,
+                               algebra::matrix::inverse::preset0<double>>>>
     eigen_cmath_types;
 INSTANTIATE_TYPED_TEST_SUITE_P(algebra_plugins, test_cuda_basics,
                                eigen_cmath_types, test_specialisation_name);

--- a/tests/accelerator/cuda/vecmem_cmath.cu
+++ b/tests/accelerator/cuda/vecmem_cmath.cu
@@ -40,10 +40,9 @@ typedef testing::Types<
         algebra::vecmem::transform3<float>, algebra::vecmem::cartesian2<float>,
         algebra::vecmem::polar2<float>, algebra::vecmem::cylindrical2<float>,
         std::size_t, algebra::vecmem::matrix_type,
-        algebra::matrix::actor<
-            std::size_t, float,
-            algebra::matrix::determinant::preset0<std::size_t, float>,
-            algebra::matrix::inverse::preset0<std::size_t, float>>>,
+        algebra::matrix::actor<float,
+                               algebra::matrix::determinant::preset0<float>,
+                               algebra::matrix::inverse::preset0<float>>>,
     test_types<
         double, algebra::vecmem::point2<double>,
         algebra::vecmem::point3<double>, algebra::vecmem::vector2<double>,
@@ -51,10 +50,9 @@ typedef testing::Types<
         algebra::vecmem::cartesian2<double>, algebra::vecmem::polar2<double>,
         algebra::vecmem::cylindrical2<double>, std::size_t,
         algebra::vecmem::matrix_type,
-        algebra::matrix::actor<
-            std::size_t, double,
-            algebra::matrix::determinant::preset0<std::size_t, double>,
-            algebra::matrix::inverse::preset0<std::size_t, double>>>>
+        algebra::matrix::actor<double,
+                               algebra::matrix::determinant::preset0<double>,
+                               algebra::matrix::inverse::preset0<double>>>>
     vecmem_cmath_types;
 INSTANTIATE_TYPED_TEST_SUITE_P(algebra_plugins, test_cuda_basics,
                                vecmem_cmath_types, test_specialisation_name);

--- a/tests/accelerator/sycl/array_cmath.sycl
+++ b/tests/accelerator/sycl/array_cmath.sycl
@@ -40,20 +40,18 @@ typedef testing::Types<
         algebra::array::transform3<float>, algebra::array::cartesian2<float>,
         algebra::array::polar2<float>, algebra::array::cylindrical2<float>,
         std::size_t, algebra::array::matrix_type,
-        algebra::matrix::actor<
-            std::size_t, float,
-            algebra::matrix::determinant::preset0<std::size_t, float>,
-            algebra::matrix::inverse::preset0<std::size_t, float>>>,
+        algebra::matrix::actor<float,
+                               algebra::matrix::determinant::preset0<float>,
+                               algebra::matrix::inverse::preset0<float>>>,
     test_types<
         double, algebra::array::point2<double>, algebra::array::point3<double>,
         algebra::array::vector2<double>, algebra::array::vector3<double>,
         algebra::array::transform3<double>, algebra::array::cartesian2<double>,
         algebra::array::polar2<double>, algebra::array::cylindrical2<double>,
         std::size_t, algebra::array::matrix_type,
-        algebra::matrix::actor<
-            std::size_t, double,
-            algebra::matrix::determinant::preset0<std::size_t, double>,
-            algebra::matrix::inverse::preset0<std::size_t, double>>>>
+        algebra::matrix::actor<double,
+                               algebra::matrix::determinant::preset0<double>,
+                               algebra::matrix::inverse::preset0<double>>>>
     array_cmath_types;
 INSTANTIATE_TYPED_TEST_SUITE_P(algebra_plugins, test_sycl_basics,
                                array_cmath_types, test_specialisation_name);

--- a/tests/accelerator/sycl/vecmem_cmath.sycl
+++ b/tests/accelerator/sycl/vecmem_cmath.sycl
@@ -40,10 +40,9 @@ typedef testing::Types<
         algebra::vecmem::transform3<float>, algebra::vecmem::cartesian2<float>,
         algebra::vecmem::polar2<float>, algebra::vecmem::cylindrical2<float>,
         std::size_t, algebra::vecmem::matrix_type,
-        algebra::matrix::actor<
-            std::size_t, float,
-            algebra::matrix::determinant::preset0<std::size_t, float>,
-            algebra::matrix::inverse::preset0<std::size_t, float>>>,
+        algebra::matrix::actor<float,
+                               algebra::matrix::determinant::preset0<float>,
+                               algebra::matrix::inverse::preset0<float>>>,
     test_types<
         double, algebra::vecmem::point2<double>,
         algebra::vecmem::point3<double>, algebra::vecmem::vector2<double>,
@@ -51,10 +50,9 @@ typedef testing::Types<
         algebra::vecmem::cartesian2<double>, algebra::vecmem::polar2<double>,
         algebra::vecmem::cylindrical2<double>, std::size_t,
         algebra::vecmem::matrix_type,
-        algebra::matrix::actor<
-            std::size_t, double,
-            algebra::matrix::determinant::preset0<std::size_t, double>,
-            algebra::matrix::inverse::preset0<std::size_t, double>>>>
+        algebra::matrix::actor<double,
+                               algebra::matrix::determinant::preset0<double>,
+                               algebra::matrix::inverse::preset0<double>>>>
     vecmem_cmath_types;
 INSTANTIATE_TYPED_TEST_SUITE_P(algebra_plugins, test_sycl_basics,
                                vecmem_cmath_types, test_specialisation_name);

--- a/tests/array/array_cmath.cpp
+++ b/tests/array/array_cmath.cpp
@@ -40,20 +40,18 @@ typedef testing::Types<
         algebra::array::transform3<float>, algebra::array::cartesian2<float>,
         algebra::array::polar2<float>, algebra::array::cylindrical2<float>,
         std::size_t, algebra::array::matrix_type,
-        algebra::matrix::actor<
-            std::size_t, float,
-            algebra::matrix::determinant::preset0<std::size_t, float>,
-            algebra::matrix::inverse::preset0<std::size_t, float>>>,
+        algebra::matrix::actor<float,
+                               algebra::matrix::determinant::preset0<float>,
+                               algebra::matrix::inverse::preset0<float>>>,
     test_types<
         double, algebra::array::point2<double>, algebra::array::point3<double>,
         algebra::array::vector2<double>, algebra::array::vector3<double>,
         algebra::array::transform3<double>, algebra::array::cartesian2<double>,
         algebra::array::polar2<double>, algebra::array::cylindrical2<double>,
         std::size_t, algebra::array::matrix_type,
-        algebra::matrix::actor<
-            std::size_t, double,
-            algebra::matrix::determinant::preset0<std::size_t, double>,
-            algebra::matrix::inverse::preset0<std::size_t, double>>>>
+        algebra::matrix::actor<double,
+                               algebra::matrix::determinant::preset0<double>,
+                               algebra::matrix::inverse::preset0<double>>>>
     array_cmath_types;
 INSTANTIATE_TYPED_TEST_SUITE_P(algebra_plugins, test_host_basics,
                                array_cmath_types, test_specialisation_name);

--- a/tests/eigen/eigen_cmath.cpp
+++ b/tests/eigen/eigen_cmath.cpp
@@ -40,18 +40,18 @@ typedef testing::Types<
         algebra::eigen::transform3<float>, algebra::eigen::cartesian2<float>,
         algebra::eigen::polar2<float>, algebra::eigen::cylindrical2<float>, int,
         algebra::eigen::matrix_type,
-        algebra::matrix::actor<
-            int, float, algebra::matrix::determinant::preset0<int, float>,
-            algebra::matrix::inverse::preset0<int, float>>>,
+        algebra::matrix::actor<float,
+                               algebra::matrix::determinant::preset0<float>,
+                               algebra::matrix::inverse::preset0<float>>>,
     test_types<
         double, algebra::eigen::point2<double>, algebra::eigen::point3<double>,
         algebra::eigen::vector2<double>, algebra::eigen::vector3<double>,
         algebra::eigen::transform3<double>, algebra::eigen::cartesian2<double>,
         algebra::eigen::polar2<double>, algebra::eigen::cylindrical2<double>,
         int, algebra::eigen::matrix_type,
-        algebra::matrix::actor<
-            int, double, algebra::matrix::determinant::preset0<int, double>,
-            algebra::matrix::inverse::preset0<int, double>>>>
+        algebra::matrix::actor<double,
+                               algebra::matrix::determinant::preset0<double>,
+                               algebra::matrix::inverse::preset0<double>>>>
     eigen_cmath_types;
 INSTANTIATE_TYPED_TEST_SUITE_P(algebra_plugins, test_host_basics,
                                eigen_cmath_types, test_specialisation_name);

--- a/tests/smatrix/smatrix_cmath.cpp
+++ b/tests/smatrix/smatrix_cmath.cpp
@@ -41,10 +41,9 @@ typedef testing::Types<
         algebra::smatrix::cartesian2<float>, algebra::smatrix::polar2<float>,
         algebra::smatrix::cylindrical2<float>, unsigned int,
         algebra::smatrix::matrix_type,
-        algebra::matrix::actor<
-            unsigned int, float,
-            algebra::matrix::determinant::preset0<unsigned int, float>,
-            algebra::matrix::inverse::preset0<unsigned int, float>>>,
+        algebra::matrix::actor<float,
+                               algebra::matrix::determinant::preset0<float>,
+                               algebra::matrix::inverse::preset0<float>>>,
     test_types<
         double, algebra::smatrix::point2<double>,
         algebra::smatrix::point3<double>, algebra::smatrix::vector2<double>,
@@ -52,10 +51,9 @@ typedef testing::Types<
         algebra::smatrix::cartesian2<double>, algebra::smatrix::polar2<double>,
         algebra::smatrix::cylindrical2<double>, unsigned int,
         algebra::smatrix::matrix_type,
-        algebra::matrix::actor<
-            unsigned int, double,
-            algebra::matrix::determinant::preset0<unsigned int, double>,
-            algebra::matrix::inverse::preset0<unsigned int, double>>>>
+        algebra::matrix::actor<double,
+                               algebra::matrix::determinant::preset0<double>,
+                               algebra::matrix::inverse::preset0<double>>>>
     smatrix_cmath_types;
 INSTANTIATE_TYPED_TEST_SUITE_P(algebra_plugins, test_host_basics,
                                smatrix_cmath_types, test_specialisation_name);

--- a/tests/vc/vc_cmath.cpp
+++ b/tests/vc/vc_cmath.cpp
@@ -40,18 +40,16 @@ typedef testing::Types<
                algebra::vc::polar2<float>, algebra::vc::cylindrical2<float>,
                std::size_t, algebra::vc::matrix_type,
                algebra::matrix::actor<
-                   std::size_t, float,
-                   algebra::matrix::determinant::preset0<std::size_t, float>,
-                   algebra::matrix::inverse::preset0<std::size_t, float>>>,
+                   float, algebra::matrix::determinant::preset0<float>,
+                   algebra::matrix::inverse::preset0<float>>>,
     test_types<double, Vc::array<double, 2>, Vc::array<double, 3>,
                Vc::array<double, 2>, Vc::array<double, 3>,
                algebra::vc::transform3<double>, algebra::vc::cartesian2<double>,
                algebra::vc::polar2<double>, algebra::vc::cylindrical2<double>,
                std::size_t, algebra::vc::matrix_type,
                algebra::matrix::actor<
-                   std::size_t, double,
-                   algebra::matrix::determinant::preset0<std::size_t, double>,
-                   algebra::matrix::inverse::preset0<std::size_t, double>>>>
+                   double, algebra::matrix::determinant::preset0<double>,
+                   algebra::matrix::inverse::preset0<double>>>>
     vc_cmath_types;
 INSTANTIATE_TYPED_TEST_SUITE_P(algebra_plugins, test_host_basics,
                                vc_cmath_types, test_specialisation_name);

--- a/tests/vc/vc_vc.cpp
+++ b/tests/vc/vc_vc.cpp
@@ -40,18 +40,16 @@ typedef testing::Types<
                algebra::vc::polar2<float>, algebra::vc::cylindrical2<float>,
                std::size_t, algebra::vc::matrix_type,
                algebra::matrix::actor<
-                   std::size_t, float,
-                   algebra::matrix::determinant::preset0<std::size_t, float>,
-                   algebra::matrix::inverse::preset0<std::size_t, float>>>,
+                   float, algebra::matrix::determinant::preset0<float>,
+                   algebra::matrix::inverse::preset0<float>>>,
     test_types<double, algebra::vc::point2<double>, algebra::vc::point3<double>,
                algebra::vc::vector2<double>, algebra::vc::vector3<double>,
                algebra::vc::transform3<double>, algebra::vc::cartesian2<double>,
                algebra::vc::polar2<double>, algebra::vc::cylindrical2<double>,
                std::size_t, algebra::vc::matrix_type,
                algebra::matrix::actor<
-                   std::size_t, double,
-                   algebra::matrix::determinant::preset0<std::size_t, double>,
-                   algebra::matrix::inverse::preset0<std::size_t, double>>>>
+                   double, algebra::matrix::determinant::preset0<double>,
+                   algebra::matrix::inverse::preset0<double>>>>
     vc_vc_types;
 INSTANTIATE_TYPED_TEST_SUITE_P(algebra_plugins, test_host_basics, vc_vc_types,
                                test_specialisation_name);

--- a/tests/vecmem/vecmem_cmath.cpp
+++ b/tests/vecmem/vecmem_cmath.cpp
@@ -40,10 +40,9 @@ typedef testing::Types<
         algebra::vecmem::transform3<float>, algebra::vecmem::cartesian2<float>,
         algebra::vecmem::polar2<float>, algebra::vecmem::cylindrical2<float>,
         std::size_t, algebra::vecmem::matrix_type,
-        algebra::matrix::actor<
-            std::size_t, float,
-            algebra::matrix::determinant::preset0<std::size_t, float>,
-            algebra::matrix::inverse::preset0<std::size_t, float>>>,
+        algebra::matrix::actor<float,
+                               algebra::matrix::determinant::preset0<float>,
+                               algebra::matrix::inverse::preset0<float>>>,
     test_types<
         double, algebra::vecmem::point2<double>,
         algebra::vecmem::point3<double>, algebra::vecmem::vector2<double>,
@@ -51,10 +50,9 @@ typedef testing::Types<
         algebra::vecmem::cartesian2<double>, algebra::vecmem::polar2<double>,
         algebra::vecmem::cylindrical2<double>, std::size_t,
         algebra::vecmem::matrix_type,
-        algebra::matrix::actor<
-            std::size_t, double,
-            algebra::matrix::determinant::preset0<std::size_t, double>,
-            algebra::matrix::inverse::preset0<std::size_t, double>>>>
+        algebra::matrix::actor<double,
+                               algebra::matrix::determinant::preset0<double>,
+                               algebra::matrix::inverse::preset0<double>>>>
     vecmem_cmath_types;
 INSTANTIATE_TYPED_TEST_SUITE_P(algebra_plugins, test_host_basics,
                                vecmem_cmath_types, test_specialisation_name);


### PR DESCRIPTION
Matrix actors in frontends don't have to take `size_type` as a template parameter obviously...