### PR TITLE
Add `size_type` to plugin namespace

### DIFF
--- a/frontend/array_cmath/include/algebra/array_cmath.hpp
+++ b/frontend/array_cmath/include/algebra/array_cmath.hpp
@@ -70,7 +70,7 @@ using cmath::normalize;
 
 namespace matrix {
 
-using size_type = std::size_t;
+using size_type = array::size_type;
 
 template <typename T, size_type N>
 using array_type = array::storage_type<T, N>;

--- a/frontend/eigen_cmath/include/algebra/eigen_cmath.hpp
+++ b/frontend/eigen_cmath/include/algebra/eigen_cmath.hpp
@@ -70,8 +70,7 @@ using eigen::math::normalize;
 
 namespace matrix {
 
-using size_type = int;
-
+using size_type = eigen::size_type;
 template <typename T, size_type N>
 using array_type = eigen::storage_type<T, N>;
 template <typename T, size_type ROWS, size_type COLS>

--- a/frontend/smatrix_cmath/include/algebra/smatrix_cmath.hpp
+++ b/frontend/smatrix_cmath/include/algebra/smatrix_cmath.hpp
@@ -64,8 +64,7 @@ using smatrix::math::normalize;
 
 namespace matrix {
 
-using size_type = unsigned int;
-
+using size_type = smatrix::size_type;
 template <typename T, size_type N>
 using array_type = smatrix::storage_type<T, N>;
 template <typename T, size_type ROWS, size_type COLS>

--- a/frontend/vc_cmath/include/algebra/vc_cmath.hpp
+++ b/frontend/vc_cmath/include/algebra/vc_cmath.hpp
@@ -81,7 +81,7 @@ using vc::math::normalize;
 
 namespace matrix {
 
-using size_type = std::size_t;
+using size_type = vc::size_type;
 
 template <typename T, size_type N>
 using array_type = Vc::array<T, N>;

--- a/frontend/vc_vc/include/algebra/vc_vc.hpp
+++ b/frontend/vc_vc/include/algebra/vc_vc.hpp
@@ -148,7 +148,7 @@ using vc::math::normalize;
 
 namespace matrix {
 
-using size_type = std::size_t;
+using size_type = vc::size_type;
 
 template <typename T, size_type N>
 using array_type = vc::storage_type<T, N>;

--- a/storage/array/include/algebra/storage/array.hpp
+++ b/storage/array/include/algebra/storage/array.hpp
@@ -13,11 +13,13 @@
 
 namespace algebra::array {
 
+/// size type for Array storage model
+using size_type = std::size_t;
 /// Array type used in the Array storage model
-template <typename T, std::size_t N>
+template <typename T, size_type N>
 using storage_type = std::array<T, N>;
 /// Matrix type used in the Array storage model
-template <typename T, std::size_t ROWS, std::size_t COLS>
+template <typename T, size_type ROWS, size_type COLS>
 using matrix_type = storage_type<storage_type<T, ROWS>, COLS>;
 
 /// 3-element "vector" type, using @c std::array

--- a/storage/eigen/include/algebra/storage/eigen.hpp
+++ b/storage/eigen/include/algebra/storage/eigen.hpp
@@ -15,11 +15,13 @@
 
 namespace algebra::eigen {
 
+/// size type for Eigen storage model
+using size_type = int;
 /// Array type used in the Eigen storage model
-template <typename T, int N>
+template <typename T, size_type N>
 using storage_type = array<T, N>;
 /// Matrix type used in the Eigen storage model
-template <typename T, int ROWS, int COLS>
+template <typename T, size_type ROWS, size_type COLS>
 using matrix_type = Eigen::Matrix<T, ROWS, COLS, 0, ROWS, COLS>;
 
 /// 3-element "vector" type, using @c algebra::eigen::array

--- a/storage/smatrix/include/algebra/storage/smatrix.hpp
+++ b/storage/smatrix/include/algebra/storage/smatrix.hpp
@@ -16,11 +16,13 @@
 
 namespace algebra::smatrix {
 
+/// size type for SMatrix storage model
+using size_type = unsigned int;
 /// Array type used in the SMatrix storage model
-template <typename T, unsigned int N>
+template <typename T, size_type N>
 using storage_type = ROOT::Math::SVector<T, N>;
 /// Matrix type used in the SMatrix storage model
-template <typename T, unsigned int ROWS, unsigned int COLS>
+template <typename T, size_type ROWS, size_type COLS>
 using matrix_type = ROOT::Math::SMatrix<T, ROWS, COLS>;
 
 /// 3-element "vector" type, using @c ROOT::Math::SVector

--- a/storage/vc/include/algebra/storage/vc.hpp
+++ b/storage/vc/include/algebra/storage/vc.hpp
@@ -25,11 +25,13 @@
 
 namespace algebra::vc {
 
+/// size type for Vc storage model
+using size_type = std::size_t;
 /// Array type used in the Vc storage model
-template <typename T, std::size_t N>
+template <typename T, size_type N>
 using storage_type = Vc::SimdArray<T, N>;
 /// Matrix type used in the Vc storage model
-template <typename T, std::size_t ROWS, std::size_t COLS>
+template <typename T, size_type ROWS, size_type COLS>
 using matrix_type = Vc::array<Vc::array<T, ROWS>, COLS>;
 
 /// 3-element "vector" type, using @c algebra::vc::array4


### PR DESCRIPTION
With the change in the PR we can define `size_type` for matrix in external projects:

```
using size_type = __plugin::size_type
```
