### PR TITLE
Stability improvement

### DIFF
--- a/math/cmath/include/algebra/math/impl/cmath_transform3.hpp
+++ b/math/cmath/include/algebra/math/impl/cmath_transform3.hpp
@@ -252,6 +252,10 @@ struct transform3 {
   ALGEBRA_HOST_DEVICE
   inline const matrix44 &matrix() const { return _data; }
 
+  /** This method retrieves the 4x4 matrix of an inverse transform */
+  ALGEBRA_HOST_DEVICE
+  inline const matrix44 &matrix_inverse() const { return _data_inv; }
+
   /** This method transform from a point from the local 3D cartesian frame to
    * the global 3D cartesian frame */
   ALGEBRA_HOST_DEVICE inline point3 point_to_global(const point3 &v) const {

--- a/math/eigen/include/algebra/math/impl/eigen_matrix.hpp
+++ b/math/eigen/include/algebra/math/impl/eigen_matrix.hpp
@@ -9,6 +9,7 @@
 
 // Project include(s).
 #include "algebra/qualifiers.hpp"
+#include "algebra/storage/eigen.hpp"
 
 // Eigen include(s).
 #ifdef _MSC_VER
@@ -27,7 +28,7 @@ struct actor {
 
   /// 2D matrix type
   template <int ROWS, int COLS>
-  using matrix_type = Eigen::Matrix<scalar_t, ROWS, COLS, 0, ROWS, COLS>;
+  using matrix_type = algebra::eigen::matrix_type<scalar_t, ROWS, COLS>;
 
   /// Operator getting a reference to one element of a non-const matrix
   template <int ROWS, int COLS>

--- a/math/eigen/include/algebra/math/impl/eigen_transform3.hpp
+++ b/math/eigen/include/algebra/math/impl/eigen_transform3.hpp
@@ -46,8 +46,7 @@ struct transform3 {
   using point2 = array_type<2>;
 
   /// 4x4 matrix type
-  using matrix44 =
-      typename Eigen::Transform<scalar_type, 3, Eigen::Affine>::MatrixType;
+  using matrix44 = typename Eigen::Matrix<scalar_t, 4, 4, 0, 4, 4>;
 
   /// Function (object) used for accessing a matrix element
   using element_getter = algebra::eigen::math::element_getter;

--- a/math/eigen/include/algebra/math/impl/eigen_transform3.hpp
+++ b/math/eigen/include/algebra/math/impl/eigen_transform3.hpp
@@ -46,7 +46,8 @@ struct transform3 {
   using point2 = array_type<2>;
 
   /// 4x4 matrix type
-  using matrix44 = typename Eigen::Matrix<scalar_t, 4, 4, 0, 4, 4>;
+  using matrix44 =
+      typename Eigen::Transform<scalar_type, 3, Eigen::Affine>::MatrixType;
 
   /// Function (object) used for accessing a matrix element
   using element_getter = algebra::eigen::math::element_getter;

--- a/math/eigen/include/algebra/math/impl/eigen_transform3.hpp
+++ b/math/eigen/include/algebra/math/impl/eigen_transform3.hpp
@@ -177,6 +177,10 @@ struct transform3 {
   ALGEBRA_HOST_DEVICE
   inline const matrix44 &matrix() const { return _data.matrix(); }
 
+  /** This method retrieves the 4x4 matrix of an inverse transform */
+  ALGEBRA_HOST_DEVICE
+  inline const matrix44 &matrix_inverse() const { return _data_inv.matrix(); }
+
   /** This method transform from a point from the local 3D cartesian frame to
    * the global 3D cartesian frame */
   template <

--- a/math/smatrix/include/algebra/math/impl/smatrix_transform3.hpp
+++ b/math/smatrix/include/algebra/math/impl/smatrix_transform3.hpp
@@ -174,6 +174,10 @@ struct transform3 {
   ALGEBRA_HOST
   inline matrix44 matrix() const { return _data; }
 
+  /** This method retrieves the 4x4 matrix of an inverse transform */
+  ALGEBRA_HOST
+  inline matrix44 matrix() const { return _data_inv; }
+
   /** This method transform from a point from the local 3D cartesian frame to
    * the global 3D cartesian frame */
   ALGEBRA_HOST

--- a/math/smatrix/include/algebra/math/impl/smatrix_transform3.hpp
+++ b/math/smatrix/include/algebra/math/impl/smatrix_transform3.hpp
@@ -176,7 +176,7 @@ struct transform3 {
 
   /** This method retrieves the 4x4 matrix of an inverse transform */
   ALGEBRA_HOST
-  inline matrix44 matrix() const { return _data_inv; }
+  inline matrix44 matrix_inverse() const { return _data_inv; }
 
   /** This method transform from a point from the local 3D cartesian frame to
    * the global 3D cartesian frame */

--- a/math/smatrix/include/algebra/math/impl/smatrix_vector.hpp
+++ b/math/smatrix/include/algebra/math/impl/smatrix_vector.hpp
@@ -86,10 +86,50 @@ ALGEBRA_HOST inline scalar_t dot(const ROOT::Math::VecExpr<A, scalar_t, N> &a,
  * @return the scalar dot product value
  **/
 template <typename scalar_t, class A, auto N>
-ALGEBRA_HOST inline scalar_t dot(const ROOT::Math::VecExpr<A, scalar_t, N> &a,
+ALGEBRA_HOST inline scalar_t dot(const ROOT::Math::SMatrix<scalar_t, N, 1> &a,
                                  const ROOT::Math::VecExpr<A, scalar_t, N> &b) {
 
-  return ROOT::Math::Dot(a, b);
+  return ROOT::Math::Dot(a.Col(0), b);
+}
+
+/** Dot product between two input vectors
+ *
+ * @param a the first input vector
+ * @param b the second input vector
+ *
+ * @return the scalar dot product value
+ **/
+template <typename scalar_t, class A, auto N>
+ALGEBRA_HOST inline scalar_t dot(const ROOT::Math::VecExpr<A, scalar_t, N> &a,
+                                 const ROOT::Math::SMatrix<scalar_t, N, 1> &b) {
+  return dot(b, a);
+}
+
+/** Dot product between two input vectors
+ *
+ * @param a the first input vector
+ * @param b the second input vector
+ *
+ * @return the scalar dot product value
+ **/
+template <typename scalar_t, auto N>
+ALGEBRA_HOST inline scalar_t dot(const ROOT::Math::SMatrix<scalar_t, N, 1> &a,
+                                 const ROOT::Math::SVector<scalar_t, N> &b) {
+
+  return ROOT::Math::Dot(a.Col(0), b);
+}
+
+/** Dot product between two input vectors
+ *
+ * @param a the first input vector
+ * @param b the second input vector
+ *
+ * @return the scalar dot product value
+ **/
+template <typename scalar_t, auto N>
+ALGEBRA_HOST inline scalar_t dot(const ROOT::Math::SVector<scalar_t, N> &a,
+                                 const ROOT::Math::SMatrix<scalar_t, N, 1> &b) {
+  return dot(b, a);
 }
 
 /** Cross product between two input vectors

--- a/math/vc/include/algebra/math/impl/vc_transform3.hpp
+++ b/math/vc/include/algebra/math/impl/vc_transform3.hpp
@@ -350,6 +350,10 @@ struct transform3 {
   ALGEBRA_HOST_DEVICE
   inline const matrix44 &matrix() const { return _data; }
 
+  /** This method retrieves the 4x4 matrix of an inverse transform */
+  ALGEBRA_HOST_DEVICE
+  inline const matrix44 &matrix_inverse() const { return _data_inv; }
+
   /** This method transform from a point from the local 3D cartesian frame
    *  to the global 3D cartesian frame
    *

--- a/storage/eigen/include/algebra/storage/eigen.hpp
+++ b/storage/eigen/include/algebra/storage/eigen.hpp
@@ -21,14 +21,9 @@ using size_type = int;
 template <typename T, size_type N>
 using storage_type = array<T, N>;
 /// Matrix type used in the Eigen storage model
-
-#ifdef _MSC_VER
+/// If the number of rows is 1, make it RowMajor
 template <typename T, size_type ROWS, size_type COLS>
-using matrix_type = Eigen::Matrix<T, ROWS, COLS, 0, ROWS, COLS>;
-#else
-template <typename T, size_type ROWS, size_type COLS>
-using matrix_type = Eigen::Matrix<T, ROWS, COLS>;
-#endif  // MSVC
+using matrix_type = Eigen::Matrix<T, ROWS, COLS, (ROWS == 1), ROWS, COLS>;
 
 /// 3-element "vector" type, using @c algebra::eigen::array
 template <typename T>

--- a/storage/eigen/include/algebra/storage/eigen.hpp
+++ b/storage/eigen/include/algebra/storage/eigen.hpp
@@ -21,8 +21,14 @@ using size_type = int;
 template <typename T, size_type N>
 using storage_type = array<T, N>;
 /// Matrix type used in the Eigen storage model
+
+#ifdef _MSC_VER
 template <typename T, size_type ROWS, size_type COLS>
 using matrix_type = Eigen::Matrix<T, ROWS, COLS, 0, ROWS, COLS>;
+#else
+template <typename T, size_type ROWS, size_type COLS>
+using matrix_type = Eigen::Matrix<T, ROWS, COLS>;
+#endif  // MSVC
 
 /// 3-element "vector" type, using @c algebra::eigen::array
 template <typename T>

--- a/tests/common/test_device_basics.hpp
+++ b/tests/common/test_device_basics.hpp
@@ -115,6 +115,13 @@ class test_device_basics : public test_base<T> {
     }
 
     // Test block operations
+    auto b13 = matrix_actor().template block<1, 3>(m2, 0, 0);
+    auto b13_tp = matrix_actor().transpose(b13);
+    algebra::getter::element(b13_tp, 0, 0) = 1;
+    algebra::getter::element(b13_tp, 1, 0) = 2;
+    algebra::getter::element(b13_tp, 2, 0) = 3;
+    matrix_actor().set_block(m2, b13_tp, 0, 0);
+
     auto b32 = matrix_actor().template block<3, 2>(m2, 2, 2);
     algebra::getter::element(b32, 0, 0) = 4;
     algebra::getter::element(b32, 0, 1) = 3;

--- a/tests/common/test_host_basics.hpp
+++ b/tests/common/test_host_basics.hpp
@@ -193,6 +193,11 @@ TYPED_TEST_P(test_host_basics, matrix64) {
   ASSERT_NEAR(algebra::getter::element(b13, 0, 1), 0., this->m_epsilon);
   ASSERT_NEAR(algebra::getter::element(b13, 0, 2), 0., this->m_epsilon);
 
+  auto b13_tp = typename TypeParam::matrix_actor().transpose(b13);
+  ASSERT_NEAR(algebra::getter::element(b13_tp, 0, 0), 1., this->m_epsilon);
+  ASSERT_NEAR(algebra::getter::element(b13_tp, 1, 0), 0., this->m_epsilon);
+  ASSERT_NEAR(algebra::getter::element(b13_tp, 2, 0), 0., this->m_epsilon);
+
   auto b32 = typename TypeParam::matrix_actor().template block<3, 2>(m, 2, 2);
   ASSERT_NEAR(algebra::getter::element(b32, 0, 0), 1., this->m_epsilon);
   ASSERT_NEAR(algebra::getter::element(b32, 0, 1), 0., this->m_epsilon);

--- a/tests/common/test_host_basics.hpp
+++ b/tests/common/test_host_basics.hpp
@@ -123,16 +123,20 @@ TYPED_TEST_P(test_host_basics, vector3) {
   ASSERT_NEAR(v2[0], 14, this->m_epsilon);
   ASSERT_NEAR(v2[1], 32, this->m_epsilon);
 
-  // Cross product on vector3 - matrix<3,1>
+  // Cross product on vector3 and matrix<3,1>
   typename TypeParam::template matrix<3, 1> vF;
   algebra::getter::element(vF, 0, 0) = 5;
   algebra::getter::element(vF, 1, 0) = 6;
   algebra::getter::element(vF, 2, 0) = 13;
 
-  auto vG = algebra::vector::cross(vD, vF);
+  typename TypeParam::vector3 vG = algebra::vector::cross(vD, vF);
   ASSERT_NEAR(vG[0], 7, this->m_epsilon);
   ASSERT_NEAR(vG[1], -8, this->m_epsilon);
   ASSERT_NEAR(vG[2], 1, this->m_epsilon);
+
+  // Dot product on vector3 and matrix<3,1>
+  auto dot = algebra::vector::dot(vG, vF);
+  ASSERT_NEAR(dot, 0, this->m_epsilon);
 }
 
 // Test generic access to a 6x4 matrix

--- a/tests/common/test_host_basics.hpp
+++ b/tests/common/test_host_basics.hpp
@@ -188,6 +188,11 @@ TYPED_TEST_P(test_host_basics, matrix64) {
   }
 
   // Test block operations
+  auto b13 = typename TypeParam::matrix_actor().template block<1, 3>(m, 0, 0);
+  ASSERT_NEAR(algebra::getter::element(b13, 0, 0), 1., this->m_epsilon);
+  ASSERT_NEAR(algebra::getter::element(b13, 0, 1), 0., this->m_epsilon);
+  ASSERT_NEAR(algebra::getter::element(b13, 0, 2), 0., this->m_epsilon);
+
   auto b32 = typename TypeParam::matrix_actor().template block<3, 2>(m, 2, 2);
   ASSERT_NEAR(algebra::getter::element(b32, 0, 0), 1., this->m_epsilon);
   ASSERT_NEAR(algebra::getter::element(b32, 0, 1), 0., this->m_epsilon);

--- a/tests/common/test_host_basics.hpp
+++ b/tests/common/test_host_basics.hpp
@@ -390,7 +390,6 @@ TYPED_TEST_P(test_host_basics, transform3) {
 
   // Test constructor from inverse matrix
   auto m44_inv = trf2.matrix_inverse();
-  typename TypeParam::transform3 trfm(m44_inv);
 
   // Make sure that algebra::getter:vector can be called.
   (void)algebra::getter::vector<3>(m44_inv, 0, 0);

--- a/tests/common/test_host_basics.hpp
+++ b/tests/common/test_host_basics.hpp
@@ -388,6 +388,15 @@ TYPED_TEST_P(test_host_basics, transform3) {
   (void)algebra::getter::vector<3>(m44, 0, 1);
   (void)algebra::getter::vector<3>(m44, 0, 2);
 
+  // Test constructor from inverse matrix
+  auto m44_inv = trf2.matrix_inverse();
+  typename TypeParam::transform3 trfm(m44_inv);
+
+  // Make sure that algebra::getter:vector can be called.
+  (void)algebra::getter::vector<3>(m44_inv, 0, 0);
+  (void)algebra::getter::vector<3>(m44_inv, 0, 1);
+  (void)algebra::getter::vector<3>(m44_inv, 0, 2);
+
   // Re-evaluate rot and trn
   auto rotm = trfm.rotation();
   ASSERT_NEAR(element_getter(rotm, 0, 0), x[0], this->m_epsilon);


### PR DESCRIPTION
There are three updates in this PR:

- Add `matrix_inverse` method in `transform3` classes
- Allow dot product between `SVector` and `SMatrix<N,1>`
- Define Eigen matrix as `Row major` when the number of rows is one (Otherwise, compiler spits error message with invalid template parameter)