### PR TITLE
Add a constructor for transform3

### DIFF
--- a/math/cmath/include/algebra/math/impl/cmath_transform3.hpp
+++ b/math/cmath/include/algebra/math/impl/cmath_transform3.hpp
@@ -60,8 +60,8 @@ struct transform3 {
   /// @name Data objects
   /// @{
 
-  matrix44 _data;
-  matrix44 _data_inv;
+  matrix44 _data = matrix_actor().template identity<4, 4>();
+  matrix44 _data_inv = matrix_actor().template identity<4, 4>();
 
   /// @}
 

--- a/math/cmath/include/algebra/math/impl/cmath_transform3.hpp
+++ b/math/cmath/include/algebra/math/impl/cmath_transform3.hpp
@@ -65,19 +65,17 @@ struct transform3 {
 
   /// @}
 
-  /** Contructor with arguments: t, z, x
+  /** Contructor with arguments: t, x, y, z
    *
    * @param t the translation (or origin of the new frame)
-   * @param z the z axis of the new frame, normal vector for planes
    * @param x the x axis of the new frame
-   *
-   * @note y will be constructed by cross product
+   * @param y the y axis of the new frame
+   * @param z the z axis of the new frame, normal vector for planes
    *
    **/
   ALGEBRA_HOST_DEVICE
-  transform3(const vector3 &t, const vector3 &z, const vector3 &x) {
-
-    auto y = cross(z, x);
+  transform3(const vector3 &t, const vector3 &x, const vector3 &y,
+             const vector3 &z, bool get_inverse = true) {
 
     matrix_actor().element(_data, 0, 0) = x[0];
     matrix_actor().element(_data, 1, 0) = x[1];
@@ -96,8 +94,24 @@ struct transform3 {
     matrix_actor().element(_data, 2, 3) = t[2];
     matrix_actor().element(_data, 3, 3) = 1.;
 
-    _data_inv = matrix_actor().inverse(_data);
+    if (get_inverse) {
+      _data_inv = matrix_actor().inverse(_data);
+    }
   }
+
+  /** Contructor with arguments: t, z, x
+   *
+   * @param t the translation (or origin of the new frame)
+   * @param z the z axis of the new frame, normal vector for planes
+   * @param x the x axis of the new frame
+   *
+   * @note y will be constructed by cross product
+   *
+   **/
+  ALGEBRA_HOST_DEVICE
+  transform3(const vector3 &t, const vector3 &z, const vector3 &x,
+             bool get_inverse = true)
+      : transform3(t, x, cross(z, x), z, get_inverse) {}
 
   /** Constructor with arguments: translation
    *

--- a/math/eigen/include/algebra/math/impl/eigen_transform3.hpp
+++ b/math/eigen/include/algebra/math/impl/eigen_transform3.hpp
@@ -57,9 +57,10 @@ struct transform3 {
   /// @name Data objects
   /// @{
 
-  Eigen::Transform<scalar_type, 3, Eigen::Affine> _data;
-
-  Eigen::Transform<scalar_type, 3, Eigen::Affine> _data_inv;
+  Eigen::Transform<scalar_type, 3, Eigen::Affine> _data =
+      Eigen::Transform<scalar_type, 3, Eigen::Affine>::Identity();
+  Eigen::Transform<scalar_type, 3, Eigen::Affine> _data_inv =
+      Eigen::Transform<scalar_type, 3, Eigen::Affine>::Identity();
 
   /// @}
 

--- a/math/eigen/include/algebra/math/impl/eigen_transform3.hpp
+++ b/math/eigen/include/algebra/math/impl/eigen_transform3.hpp
@@ -63,6 +63,28 @@ struct transform3 {
 
   /// @}
 
+  /** Contructor with arguments: t, x, y, z
+   *
+   * @param t the translation (or origin of the new frame)
+   * @param x the x axis of the new frame
+   * @param y the y axis of the new frame
+   * @param z the z axis of the new frame, normal vector for planes
+   *
+   **/
+  ALGEBRA_HOST_DEVICE
+  transform3(const vector3 &t, const vector3 &x, const vector3 &y,
+             const vector3 &z, bool get_inverse = true) {
+    auto &matrix = _data.matrix();
+    matrix.template block<3, 1>(0, 0) = x;
+    matrix.template block<3, 1>(0, 1) = y;
+    matrix.template block<3, 1>(0, 2) = z;
+    matrix.template block<3, 1>(0, 3) = t;
+
+    if (get_inverse) {
+      _data_inv = _data.inverse();
+    }
+  }
+
   /** Contructor with arguments: t, z, x
    *
    * @param t the translation (or origin of the new frame)
@@ -71,18 +93,9 @@ struct transform3 {
    *
    **/
   ALGEBRA_HOST_DEVICE
-  transform3(const vector3 &t, const vector3 &z, const vector3 &x) {
-
-    auto y = z.cross(x);
-
-    auto &matrix = _data.matrix();
-    matrix.template block<3, 1>(0, 0) = x;
-    matrix.template block<3, 1>(0, 1) = y;
-    matrix.template block<3, 1>(0, 2) = z;
-    matrix.template block<3, 1>(0, 3) = t;
-
-    _data_inv = _data.inverse();
-  }
+  transform3(const vector3 &t, const vector3 &z, const vector3 &x,
+             bool get_inverse = true)
+      : transform3(t, x, z.cross(x), z, get_inverse) {}
 
   /** Constructor with arguments: translation
    *

--- a/math/smatrix/include/algebra/math/impl/smatrix_transform3.hpp
+++ b/math/smatrix/include/algebra/math/impl/smatrix_transform3.hpp
@@ -55,18 +55,17 @@ struct transform3 {
 
   /// @}
 
-  /** Contructor with arguments: t, z, x
+  /** Contructor with arguments: t, x, y, z
    *
    * @param t the translation (or origin of the new frame)
-   * @param z the z axis of the new frame, normal vector for planes
    * @param x the x axis of the new frame
+   * @param y the y axis of the new frame
+   * @param z the z axis of the new frame, normal vector for planes
    *
    **/
-  ALGEBRA_HOST
-  transform3(const vector3 &t, const vector3 &z, const vector3 &x) {
-
-    auto y = ROOT::Math::Cross(z, x);
-
+  ALGEBRA_HOST_DEVICE
+  transform3(const vector3 &t, const vector3 &x, const vector3 &y,
+             const vector3 &z, bool get_inverse = true) {
     _data(0, 0) = x[0];
     _data(1, 0) = x[1];
     _data(2, 0) = x[2];
@@ -80,10 +79,24 @@ struct transform3 {
     _data(1, 3) = t[1];
     _data(2, 3) = t[2];
 
-    int ifail = 0;
-    _data_inv = _data.Inverse(ifail);
-    SMATRIX_CHECK(ifail);
+    if (get_inverse) {
+      int ifail = 0;
+      _data_inv = _data.Inverse(ifail);
+      SMATRIX_CHECK(ifail);
+    }
   }
+
+  /** Contructor with arguments: t, z, x
+   *
+   * @param t the translation (or origin of the new frame)
+   * @param z the z axis of the new frame, normal vector for planes
+   * @param x the x axis of the new frame
+   *
+   **/
+  ALGEBRA_HOST
+  transform3(const vector3 &t, const vector3 &z, const vector3 &x,
+             bool get_inverse = true)
+      : transform3(t, x, ROOT::Math::Cross(z, x), z, get_inverse) {}
 
   /** Constructor with arguments: translation
    *

--- a/math/vc/include/algebra/math/impl/vc_transform3.hpp
+++ b/math/vc/include/algebra/math/impl/vc_transform3.hpp
@@ -129,6 +129,27 @@ struct transform3 {
 
   /// @}
 
+  /** Contructor with arguments: t, x, y, z
+   *
+   * @param t the translation (or origin of the new frame)
+   * @param x the x axis of the new frame
+   * @param y the y axis of the new frame
+   * @param z the z axis of the new frame, normal vector for planes
+   *
+   **/
+  ALGEBRA_HOST_DEVICE
+  transform3(const vector3 &t, const vector3 &x, const vector3 &y,
+             const vector3 &z, bool get_inverse = true) {
+    _data.x = {x[0], x[1], x[2], 0.};
+    _data.y = {y[0], y[1], y[2], 0.};
+    _data.z = {z[0], z[1], z[2], 0.};
+    _data.t = {t[0], t[1], t[2], 1.};
+
+    if (get_inverse) {
+      _data_inv = invert(_data);
+    }
+  }
+
   /** Contructor with arguments: t, z, x
    *
    * @param t the translation (or origin of the new frame)
@@ -139,16 +160,9 @@ struct transform3 {
    *
    **/
   ALGEBRA_HOST_DEVICE
-  transform3(const vector3 &t, const vector3 &z, const vector3 &x) {
-
-    vector3 y = cross(z, x);
-    _data.x = {x[0], x[1], x[2], 0.};
-    _data.y = {y[0], y[1], y[2], 0.};
-    _data.z = {z[0], z[1], z[2], 0.};
-    _data.t = {t[0], t[1], t[2], 1.};
-
-    _data_inv = invert(_data);
-  }
+  transform3(const vector3 &t, const vector3 &z, const vector3 &x,
+             bool get_inverse = true)
+      : transform3(t, x, cross(z, x), z, get_inverse) {}
 
   /** Constructor with arguments: translation
    *


### PR DESCRIPTION
This PR adds a constructor of `transform3` which takes `t`,`x`,`y`,`z` and `get_inverse` as inputs. The last argument is to decide whether to calculate inverse or not. (I have a use case for creating tf3 object without inverse)
The old constructor also utilizes the new constructor to avoid code repetition.