### PR TITLE
VecMem Update, main branch (2023.02.03.)

### DIFF
--- a/extern/vecmem/CMakeLists.txt
+++ b/extern/vecmem/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Algebra plugins library, part of the ACTS project (R&D line)
 #
-# (c) 2021-2022 CERN for the benefit of the ACTS project
+# (c) 2021-2023 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -13,7 +13,7 @@ message( STATUS "Building VecMem as part of the Algebra Plugins project" )
 
 # Declare where to get VecMem from.
 set( ALGEBRA_PLUGINS_VECMEM_SOURCE
-   "URL;https://github.com/acts-project/vecmem/archive/refs/tags/v0.10.0.tar.gz;URL_MD5;712888e704d2e4c915ac1f25f28da467"
+   "URL;https://github.com/acts-project/vecmem/archive/refs/tags/v0.22.0.tar.gz;URL_MD5;f074994adb7f9b13c67485df73e6c971"
    CACHE STRING "Source for VecMem, when built as part of this project" )
 mark_as_advanced( ALGEBRA_PLUGINS_VECMEM_SOURCE )
 FetchContent_Declare( VecMem ${ALGEBRA_PLUGINS_VECMEM_SOURCE} )


### PR DESCRIPTION
Switched to using [VecMem 0.22.0](https://github.com/acts-project/vecmem/releases/tag/v0.22.0) by default.

While testing #90 I was using a recent nightly of [intel/llvm](https://github.com/intel/llvm), which the old version of VecMem is just not compatible with anymore. While having the old VecMem version in the CI was a fairly good test for API stability in that project, making it easier to build this project with the newest compilers is more important. :wink: