### PR TITLE
GitHub SYCL Highlighting, main branch (2023.02.03.)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# Algebra plugins library, part of the ACTS project (R&D line)
+#
+# (c) 2021-2023 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
+
+# Consider .sycl files as C++.
+*.sycl linguist-language=C++


### PR DESCRIPTION
Taught GitHub how to highlight code in `.sycl` files. Exactly how it is done in [vecmem](https://github.com/acts-project/vecmem) and [traccc](https://github.com/acts-project/traccc) as well.