### PR TITLE
`actor` member functions marked as `const`

### DIFF
--- a/math/cmath/include/algebra/math/impl/cmath_matrix.hpp
+++ b/math/cmath/include/algebra/math/impl/cmath_matrix.hpp
@@ -60,7 +60,7 @@ struct actor {
   template <size_type ROWS, size_type COLS, class input_matrix_type>
   ALGEBRA_HOST_DEVICE matrix_type<ROWS, COLS> block(const input_matrix_type &m,
                                                     size_type row,
-                                                    size_type col) {
+                                                    size_type col) const {
     return block_getter().template operator()<ROWS, COLS>(m, row, col);
   }
 
@@ -68,7 +68,7 @@ struct actor {
   template <size_type ROWS, size_type COLS, class input_matrix_type>
   ALGEBRA_HOST_DEVICE void set_block(input_matrix_type &m,
                                      const matrix_type<ROWS, COLS> &b,
-                                     size_type row, size_type col) {
+                                     size_type row, size_type col) const {
     for (size_type i = 0; i < ROWS; ++i) {
       for (size_type j = 0; j < COLS; ++j) {
         element_getter()(m, i + row, j + col) = element_getter()(b, i, j);
@@ -81,7 +81,7 @@ struct actor {
             class input_matrix_type>
   ALGEBRA_HOST_DEVICE void set_block(input_matrix_type &m,
                                      const vector_t<scalar_t, ROWS> &b,
-                                     size_type row, size_type col) {
+                                     size_type row, size_type col) const {
     for (size_type i = 0; i < ROWS; ++i) {
       element_getter()(m, i + row, col) = b[i];
     }

--- a/math/eigen/include/algebra/math/impl/eigen_matrix.hpp
+++ b/math/eigen/include/algebra/math/impl/eigen_matrix.hpp
@@ -76,7 +76,7 @@ struct actor {
                 bool> = true>
   ALGEBRA_HOST_DEVICE matrix_type<ROWS, COLS> block(const input_matrix_type &m,
                                                     size_type_1 row,
-                                                    size_type_2 col) {
+                                                    size_type_2 col) const {
     return m.template block<ROWS, COLS>(static_cast<Eigen::Index>(row),
                                         static_cast<Eigen::Index>(col));
   }
@@ -90,20 +90,20 @@ struct actor {
                 bool> = true>
   ALGEBRA_HOST_DEVICE void set_block(input_matrix_type &m,
                                      const matrix_type<ROWS, COLS> &b,
-                                     size_type_1 row, size_type_2 col) {
+                                     size_type_1 row, size_type_2 col) const {
     m.template block<ROWS, COLS>(static_cast<Eigen::Index>(row),
                                  static_cast<Eigen::Index>(col)) = b;
   }
 
   // Create zero matrix
   template <int ROWS, int COLS>
-  ALGEBRA_HOST_DEVICE inline matrix_type<ROWS, COLS> zero() {
+  ALGEBRA_HOST_DEVICE inline matrix_type<ROWS, COLS> zero() const {
     return matrix_type<ROWS, COLS>::Zero();
   }
 
   // Create identity matrix
   template <int ROWS, int COLS>
-  ALGEBRA_HOST_DEVICE inline matrix_type<ROWS, COLS> identity() {
+  ALGEBRA_HOST_DEVICE inline matrix_type<ROWS, COLS> identity() const {
     return matrix_type<ROWS, COLS>::Identity();
   }
 
@@ -123,20 +123,20 @@ struct actor {
   // Create transpose matrix
   template <int ROWS, int COLS>
   ALGEBRA_HOST_DEVICE inline matrix_type<COLS, ROWS> transpose(
-      const matrix_type<ROWS, COLS> &m) {
+      const matrix_type<ROWS, COLS> &m) const {
     return m.transpose();
   }
 
   // Get determinant
   template <int N>
-  ALGEBRA_HOST_DEVICE inline scalar_t determinant(const matrix_type<N, N> &m) {
+  ALGEBRA_HOST_DEVICE inline scalar_t determinant(const matrix_type<N, N> &m) const {
     return m.determinant();
   }
 
   // Create inverse matrix
   template <int N>
   ALGEBRA_HOST_DEVICE inline matrix_type<N, N> inverse(
-      const matrix_type<N, N> &m) {
+      const matrix_type<N, N> &m) const {
     return m.inverse();
   }
 };

--- a/math/eigen/include/algebra/math/impl/eigen_matrix.hpp
+++ b/math/eigen/include/algebra/math/impl/eigen_matrix.hpp
@@ -129,7 +129,8 @@ struct actor {
 
   // Get determinant
   template <int N>
-  ALGEBRA_HOST_DEVICE inline scalar_t determinant(const matrix_type<N, N> &m) const {
+  ALGEBRA_HOST_DEVICE inline scalar_t determinant(
+      const matrix_type<N, N> &m) const {
     return m.determinant();
   }
 

--- a/math/smatrix/include/algebra/math/impl/smatrix_matrix.hpp
+++ b/math/smatrix/include/algebra/math/impl/smatrix_matrix.hpp
@@ -57,7 +57,7 @@ struct actor {
   template <unsigned int ROWS, unsigned int COLS, class input_matrix_type>
   ALGEBRA_HOST_DEVICE matrix_type<ROWS, COLS> block(const input_matrix_type &m,
                                                     unsigned int row,
-                                                    unsigned int col) {
+                                                    unsigned int col) const {
     return m.template Sub<matrix_type<ROWS, COLS> >(row, col);
   }
 
@@ -65,7 +65,7 @@ struct actor {
   template <unsigned int ROWS, unsigned int COLS, class input_matrix_type>
   ALGEBRA_HOST_DEVICE void set_block(input_matrix_type &m,
                                      const matrix_type<ROWS, COLS> &b,
-                                     unsigned int row, unsigned int col) {
+                                     unsigned int row, unsigned int col) const {
     for (unsigned int i = 0; i < ROWS; ++i) {
       for (unsigned int j = 0; j < COLS; ++j) {
         m(i + row, j + col) = b(i, j);
@@ -77,7 +77,7 @@ struct actor {
   template <unsigned int ROWS, class input_matrix_type>
   ALGEBRA_HOST_DEVICE void set_block(input_matrix_type &m,
                                      const vector_type<ROWS> &b,
-                                     unsigned int row, unsigned int col) {
+                                     unsigned int row, unsigned int col) const {
     for (unsigned int i = 0; i < ROWS; ++i) {
       m(i + row, col) = b[i];
     }
@@ -85,13 +85,13 @@ struct actor {
 
   // Create zero matrix
   template <unsigned int ROWS, unsigned int COLS>
-  ALGEBRA_HOST_DEVICE inline matrix_type<ROWS, COLS> zero() {
+  ALGEBRA_HOST_DEVICE inline matrix_type<ROWS, COLS> zero() const {
     return matrix_type<ROWS, COLS>();
   }
 
   // Create identity matrix
   template <unsigned int ROWS, unsigned int COLS>
-  ALGEBRA_HOST_DEVICE inline matrix_type<ROWS, COLS> identity() {
+  ALGEBRA_HOST_DEVICE inline matrix_type<ROWS, COLS> identity() const {
     return matrix_type<ROWS, COLS>(ROOT::Math::SMatrixIdentity());
   }
 
@@ -125,13 +125,13 @@ struct actor {
   // Create transpose matrix
   template <unsigned int ROWS, unsigned int COLS>
   ALGEBRA_HOST_DEVICE inline matrix_type<COLS, ROWS> transpose(
-      const matrix_type<ROWS, COLS> &m) {
+      const matrix_type<ROWS, COLS> &m) const {
     return ROOT::Math::Transpose(m);
   }
 
   // Get determinant
   template <unsigned int N>
-  ALGEBRA_HOST_DEVICE inline scalar_t determinant(const matrix_type<N, N> &m) {
+  ALGEBRA_HOST_DEVICE inline scalar_t determinant(const matrix_type<N, N> &m) const {
     scalar_t det;
     bool success = m.Det2(det);
 
@@ -144,7 +144,7 @@ struct actor {
   // Create inverse matrix
   template <unsigned int N>
   ALGEBRA_HOST_DEVICE inline matrix_type<N, N> inverse(
-      const matrix_type<N, N> &m) {
+      const matrix_type<N, N> &m) const {
     int ifail = 0;
     return m.Inverse(ifail);
   }

--- a/math/smatrix/include/algebra/math/impl/smatrix_matrix.hpp
+++ b/math/smatrix/include/algebra/math/impl/smatrix_matrix.hpp
@@ -131,7 +131,8 @@ struct actor {
 
   // Get determinant
   template <unsigned int N>
-  ALGEBRA_HOST_DEVICE inline scalar_t determinant(const matrix_type<N, N> &m) const {
+  ALGEBRA_HOST_DEVICE inline scalar_t determinant(
+      const matrix_type<N, N> &m) const {
     scalar_t det;
     bool success = m.Det2(det);
 


### PR DESCRIPTION
I marked the all the `actor` member functions as `const` to improve `const`-correctness. They can all be marked as `const` because none of them change the internal state of the `actor` struct.