### PR TITLE
Replaced casts to `void` with the `[[maybe_unused]]` attribute.

### DIFF
--- a/math/cmath/include/algebra/math/algorithms/utils/algorithm_finder.hpp
+++ b/math/cmath/include/algebra/math/algorithms/utils/algorithm_finder.hpp
@@ -13,9 +13,8 @@
 namespace algebra::cmath {
 
 template <typename size_type, size_type... Is>
-constexpr bool is_in(size_type i, std::integer_sequence<size_type, Is...>) {
-  // suppress unused parameter warning
-  (void)i;
+constexpr bool is_in([[maybe_unused]] size_type i,
+                     std::integer_sequence<size_type, Is...>) {
   return ((i == Is) || ...);
 }
 

--- a/math/smatrix/include/algebra/math/impl/smatrix_matrix.hpp
+++ b/math/smatrix/include/algebra/math/impl/smatrix_matrix.hpp
@@ -133,10 +133,7 @@ struct actor {
   template <unsigned int N>
   ALGEBRA_HOST_DEVICE inline scalar_t determinant(const matrix_type<N, N> &m) {
     scalar_t det;
-    bool success = m.Det2(det);
-
-    // suppress unused parameter warning
-    (void)success;
+    [[maybe_unused]] bool success = m.Det2(det);
 
     return det;
   }

--- a/tests/common/test_host_basics.hpp
+++ b/tests/common/test_host_basics.hpp
@@ -531,17 +531,21 @@ TYPED_TEST_P(test_host_basics, transform3) {
   typename TypeParam::transform3 trfm(m44);
 
   // Make sure that algebra::getter:vector can be called.
-  (void)algebra::getter::vector<3>(m44, 0, 0);
-  (void)algebra::getter::vector<3>(m44, 0, 1);
-  (void)algebra::getter::vector<3>(m44, 0, 2);
+  [[maybe_unused]] typename TypeParam::vector3
+      test_vector;  // we need to declare a variable in order to use the
+                    // [[maybe_unused]] attribute here
+
+  test_vector = algebra::getter::vector<3>(m44, 0, 0);
+  test_vector = algebra::getter::vector<3>(m44, 0, 1);
+  test_vector = algebra::getter::vector<3>(m44, 0, 2);
 
   // Test constructor from inverse matrix
   auto m44_inv = trf2.matrix_inverse();
 
   // Make sure that algebra::getter:vector can be called.
-  (void)algebra::getter::vector<3>(m44_inv, 0, 0);
-  (void)algebra::getter::vector<3>(m44_inv, 0, 1);
-  (void)algebra::getter::vector<3>(m44_inv, 0, 2);
+  test_vector = algebra::getter::vector<3>(m44_inv, 0, 0);
+  test_vector = algebra::getter::vector<3>(m44_inv, 0, 1);
+  test_vector = algebra::getter::vector<3>(m44_inv, 0, 2);
 
   // Re-evaluate rot and trn
   auto rotm = trfm.rotation();
@@ -595,8 +599,7 @@ TYPED_TEST_P(test_host_basics, global_transformations) {
       algebra::vector::normalize(typename TypeParam::vector3{3., 2., 1.});
   typename TypeParam::vector3 x =
       algebra::vector::normalize(typename TypeParam::vector3{2., -3., 0.});
-  typename TypeParam::vector3 y = algebra::vector::cross(z, x);
-  (void)y;
+  [[maybe_unused]] typename TypeParam::vector3 y = algebra::vector::cross(z, x);
   typename TypeParam::point3 t = {2., 3., 4.};
   typename TypeParam::transform3 trf(t, z, x);
 


### PR DESCRIPTION
Casts to `void` (to suppress unused variable warnings) look like black boxes to unsuspecting readers of the code. `[[maybe_unused]]` is a much better way to convey intent.

Moreover, since we are using C++17, there is no reason not to use `[[maybe_unused]]` as it available in any C++17-standard compliant compiler.