### PR TITLE
CMake Export Fix, main branch (2023.03.24.)

### DIFF
--- a/cmake/algebra-plugins-config.cmake.in
+++ b/cmake/algebra-plugins-config.cmake.in
@@ -1,6 +1,6 @@
 # Algebra plugins library, part of the ACTS project (R&D line)
 #
-# (c) 2021-2022 CERN for the benefit of the ACTS project
+# (c) 2021-2023 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -13,6 +13,12 @@ set( ALGEBRA_PLUGINS_INCLUDE_EIGEN @ALGEBRA_PLUGINS_INCLUDE_EIGEN@ )
 set( ALGEBRA_PLUGINS_INCLUDE_SMATRIX @ALGEBRA_PLUGINS_INCLUDE_SMATRIX@ )
 set( ALGEBRA_PLUGINS_INCLUDE_VC @ALGEBRA_PLUGINS_INCLUDE_VC@ )
 set( ALGEBRA_PLUGINS_INCLUDE_VECMEM @ALGEBRA_PLUGINS_INCLUDE_VECMEM@ )
+
+# Set up some simple variables for using the package.
+set( algebra_plugins_VERSION "@PROJECT_VERSION@" )
+set_and_check( algebra_plugins_INCLUDE_DIR
+   "@PACKAGE_CMAKE_INSTALL_INCLUDEDIR@" )
+set_and_check( algebra_plugins_CMAKE_DIR "@PACKAGE_CMAKE_INSTALL_CMAKEDIR@" )
 
 # Find all packages that Algebra Plugins needs to function.
 include( CMakeFindDependencyMacro )
@@ -28,12 +34,6 @@ endif()
 if( ALGEBRA_PLUGINS_INCLUDE_VECMEM )
    find_dependency( vecmem )
 endif()
-
-# Set up some simple variables for using the package.
-set( algebra_plugins_VERSION "@PROJECT_VERSION@" )
-set_and_check( algebra_plugins_INCLUDE_DIR
-   "@PACKAGE_CMAKE_INSTALL_INCLUDEDIR@" )
-set_and_check( algebra_plugins_CMAKE_DIR "@PACKAGE_CMAKE_INSTALL_CMAKEDIR@" )
 
 # Print a standard information message about the package being found.
 include( FindPackageHandleStandardArgs )


### PR DESCRIPTION
Moved the use of "magic variables" before the first use of find_dependency to fix #36. (This of course also very much relates to https://github.com/acts-project/traccc/pull/364.)

The way that the variables provided by [configure_package_config_file(...)](https://cmake.org/cmake/help/latest/module/CMakePackageConfigHelpers.html#command:configure_package_config_file) work is that a "`PACKAGE_PREFIX_DIR`" variable is created behind the scenes, and all other variables are declared relative to this "hidden" variable.

The problem is that if a package "found" by [find_dependency(...)](https://cmake.org/cmake/help/latest/module/CMakeFindDependencyMacro.html) uses the same CMake mechanism in its own exported CMake configuration (like [Vc](https://github.com/VcDevel/Vc) does for instance), then this "hidden" `PACKAGE_PREFIX_DIR` variable gets re-defined after the `find_dependency(...)` calls. And all of a sudden the rest of the lines that try to set paths using the mechanism provided by `configure_package_config_file(...)` become broken in a fairly confusing way.

This is something that will need to be fixed in the rest of our projects as well, Algebra Plugins is just the first in line to be fixed...