### PR TITLE
Benchmarks Fix, main branch (2023.03.29.)

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -111,7 +111,7 @@ jobs:
     - name: Configure
       run: |
         source ${GITHUB_WORKSPACE}/.github/ci_setup.sh ${{ matrix.PLATFORM.NAME }}
-        cmake -DCMAKE_BUILD_TYPE=${{ matrix.BUILD_TYPE }} ${{ matrix.PLATFORM.OPTIONS }} -S ${GITHUB_WORKSPACE} -B build
+        cmake -DCMAKE_BUILD_TYPE=${{ matrix.BUILD_TYPE }} ${{ matrix.PLATFORM.OPTIONS }} -DALGEBRA_PLUGINS_BUILD_BENCHMARKS=TRUE -S ${GITHUB_WORKSPACE} -B build
     # Perform the build.
     - name: Build
       run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,10 +173,5 @@ if( BUILD_TESTING AND ALGEBRA_PLUGINS_BUILD_TESTING )
   add_subdirectory( tests )
 endif()
 
-# Set up the benchmarks.
-if( ALGEBRA_PLUGINS_BUILD_BENCHMARKS )
-  add_subdirectory( benchmarks )
-endif()
-
 # Set up the packaging of the project.
 include( algebra-plugins-packaging )


### PR DESCRIPTION
Removed the reference to the non-existent `benchmarks/` directory. This was introduced in #69, which I just really don't see the point in now that I look back. :frowning: (One would only add Google Benchmark in the PR in which it is first needed. And touching all those files without a need is just pretty bad... :frowning:)

At the same time enabled the "build of benchmarks" in the CI. In case we ever add some to the project...