### PR TITLE
Public Header Tests, main branch (2023.03.29.)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ set( CMAKE_CUDA_EXTENSIONS FALSE CACHE BOOL "Disable (CUDA) C++ extensions" )
 set( CMAKE_SYCL_STANDARD 17 CACHE STRING "The (SYCL) C++ standard to use" )
 
 # Standard CMake include(s).
+include( CTest )
 include( GNUInstallDirs )
 
 # Flags controlling the meta-build system.
@@ -34,10 +35,6 @@ set( CMAKE_ARCHIVE_OUTPUT_DIRECTORY
    "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}" CACHE PATH
    "Directory for the built static libraries" )
 
-# Include the Algebra Plugins CMake code.
-list( APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake" )
-include( algebra-plugins-functions )
-
 # Flags controlling how the Algebra Plugins code should behave.
 option( ALGEBRA_PLUGINS_INCLUDE_EIGEN
    "Include Eigen types in Algebra Plugins" FALSE )
@@ -53,6 +50,10 @@ option( ALGEBRA_PLUGINS_BUILD_TESTING "Build the unit tests of Algebra Plugins"
    TRUE )
 option( ALGEBRA_PLUGINS_BUILD_BENCHMARKS "Build the benchmark suite of Algebra Plugins"
 	FALSE )
+
+# Include the Algebra Plugins CMake code.
+list( APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake" )
+include( algebra-plugins-functions )
 
 # Suppress developer warnings for all of the externals by default.
 # Unless the user explicitly requested otherwise.
@@ -168,7 +169,6 @@ add_subdirectory( math )
 add_subdirectory( frontend )
 
 # Set up the test(s).
-include( CTest )
 if( BUILD_TESTING AND ALGEBRA_PLUGINS_BUILD_TESTING )
   add_subdirectory( tests )
 endif()

--- a/cmake/algebra-plugins-functions.cmake
+++ b/cmake/algebra-plugins-functions.cmake
@@ -1,6 +1,6 @@
 # Algebra plugins library, part of the ACTS project (R&D line)
 #
-# (c) 2021-2022 CERN for the benefit of the ACTS project
+# (c) 2021-2023 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -39,6 +39,50 @@ function( algebra_add_library fullname basename )
       DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}" )
 
 endfunction( algebra_add_library )
+
+# Helper function testing the algebra plugins public headers.
+#
+# It can be used to test that public headers would include everything
+# that they need to work, and that the CMake library targets would take
+# care of declaring all of their dependencies correctly for the public
+# headers to work.
+#
+# Usage: algebra_test_public_headers( algebra_array_cmath
+#                                     include/header1.hpp ... )
+#
+function( algebra_test_public_headers library )
+
+   # If testing is not turned on, don't do anything.
+   if( ( NOT BUILD_TESTING ) OR ( NOT ALGEBRA_PLUGINS_BUILD_TESTING ) )
+      return()
+   endif()
+
+   # All arguments are treated as header file names.
+   foreach( _headerName ${ARGN} )
+
+      # Make the header filename into a "string".
+      string( REPLACE "/" "_" _headerNormName "${_headerName}" )
+      string( REPLACE "." "_" _headerNormName "${_headerNormName}" )
+
+      # Write a small source file that would test that the public
+      # header can be used as-is.
+      set( _testFileName
+         "${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/test_${_headerNormName}.cpp" )
+      file( WRITE "${_testFileName}"
+         "#include \"${_headerName}\"\n"
+         "int main() { return 0; }" )
+
+      # Set up an executable that would build it. But hide it, don't put it
+      # into ${CMAKE_BINARY_DIR}/bin.
+      add_executable( "test_${_headerNormName}" "${_testFileName}" )
+      target_link_libraries( "test_${_headerNormName}" PRIVATE ${library} )
+      set_target_properties( "test_${_headerNormName}" PROPERTIES
+         RUNTIME_OUTPUT_DIRECTORY
+         "${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}" )
+
+   endforeach()
+
+endfunction( algebra_test_public_headers )
 
 # Helper function for setting up the algebra plugin tests.
 #

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -1,9 +1,11 @@
 # Algebra plugins library, part of the ACTS project (R&D line)
 #
-# (c) 2021-2022 CERN for the benefit of the ACTS project
+# (c) 2021-2023 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
 # Set up the library.
 algebra_add_library( algebra_common common
    "include/algebra/qualifiers.hpp" )
+algebra_test_public_headers( algebra_common
+   "algebra/qualifiers.hpp" )

--- a/frontend/array_cmath/CMakeLists.txt
+++ b/frontend/array_cmath/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Algebra plugins library, part of the ACTS project (R&D line)
 #
-# (c) 2021-2022 CERN for the benefit of the ACTS project
+# (c) 2021-2023 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -9,3 +9,5 @@ algebra_add_library( algebra_array_cmath array_cmath
    "include/algebra/array_cmath.hpp" )
 target_link_libraries( algebra_array_cmath
    INTERFACE algebra::common algebra::array_storage algebra::cmath_math )
+algebra_test_public_headers( algebra_array_cmath
+   "algebra/array_cmath.hpp" )

--- a/frontend/eigen_cmath/CMakeLists.txt
+++ b/frontend/eigen_cmath/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Algebra plugins library, part of the ACTS project (R&D line)
 #
-# (c) 2021-2022 CERN for the benefit of the ACTS project
+# (c) 2021-2023 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -10,3 +10,5 @@ algebra_add_library( algebra_eigen_cmath eigen_cmath
 target_link_libraries( algebra_eigen_cmath
    INTERFACE algebra::common algebra::eigen_storage algebra::cmath_math
              algebra::eigen_math Eigen3::Eigen )
+algebra_test_public_headers( algebra_eigen_cmath
+   "algebra/eigen_cmath.hpp" )

--- a/frontend/eigen_eigen/CMakeLists.txt
+++ b/frontend/eigen_eigen/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Algebra plugins library, part of the ACTS project (R&D line)
 #
-# (c) 2021-2022 CERN for the benefit of the ACTS project
+# (c) 2021-2023 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -10,3 +10,5 @@ algebra_add_library( algebra_eigen_eigen eigen_eigen
 target_link_libraries( algebra_eigen_eigen
    INTERFACE algebra::common algebra::eigen_storage algebra::cmath_math
              algebra::eigen_math Eigen3::Eigen )
+algebra_test_public_headers( algebra_eigen_eigen
+   "algebra/eigen_eigen.hpp" )

--- a/frontend/fastor_fastor/CMakeLists.txt
+++ b/frontend/fastor_fastor/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Algebra plugins library, part of the ACTS project (R&D line)
 #
-# (c) 2022 CERN for the benefit of the ACTS project
+# (c) 2022-2023 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -10,3 +10,5 @@ algebra_add_library( algebra_fastor_fastor fastor_fastor
 target_link_libraries( algebra_fastor_fastor
    INTERFACE algebra::common algebra::fastor_storage algebra::cmath_math
    			 algebra::fastor_math )
+algebra_test_public_headers( algebra_fastor_fastor
+   "algebra/fastor_fastor.hpp" )

--- a/frontend/smatrix_cmath/CMakeLists.txt
+++ b/frontend/smatrix_cmath/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Algebra plugins library, part of the ACTS project (R&D line)
 #
-# (c) 2021-2022 CERN for the benefit of the ACTS project
+# (c) 2021-2023 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -13,3 +13,5 @@ algebra_add_library( algebra_smatrix_cmath smatrix_cmath
 target_link_libraries( algebra_smatrix_cmath
    INTERFACE algebra::common algebra::smatrix_storage algebra::cmath_math
              algebra::smatrix_math ROOT::Smatrix )
+algebra_test_public_headers( algebra_smatrix_cmath
+   "algebra/smatrix_cmath.hpp" )

--- a/frontend/smatrix_smatrix/CMakeLists.txt
+++ b/frontend/smatrix_smatrix/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Algebra plugins library, part of the ACTS project (R&D line)
 #
-# (c) 2021-2022 CERN for the benefit of the ACTS project
+# (c) 2021-2023 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -9,3 +9,5 @@ algebra_add_library( algebra_smatrix_smatrix smatrix_smatrix
    "include/algebra/smatrix_smatrix.hpp" )
 target_link_libraries( algebra_smatrix_smatrix
    INTERFACE algebra::common algebra::smatrix_storage algebra::smatrix_math )
+algebra_test_public_headers( algebra_smatrix_smatrix
+   "algebra/smatrix_smatrix.hpp" )

--- a/frontend/vc_cmath/CMakeLists.txt
+++ b/frontend/vc_cmath/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Algebra plugins library, part of the ACTS project (R&D line)
 #
-# (c) 2021-2022 CERN for the benefit of the ACTS project
+# (c) 2021-2023 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -10,3 +10,5 @@ algebra_add_library( algebra_vc_cmath vc_cmath
 target_link_libraries( algebra_vc_cmath
    INTERFACE algebra::common algebra::vc_storage algebra::cmath_math
              algebra::vc_math )
+algebra_test_public_headers( algebra_vc_cmath
+   "algebra/vc_cmath.hpp" )

--- a/frontend/vc_vc/CMakeLists.txt
+++ b/frontend/vc_vc/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Algebra plugins library, part of the ACTS project (R&D line)
 #
-# (c) 2021-2022 CERN for the benefit of the ACTS project
+# (c) 2021-2023 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -10,3 +10,5 @@ algebra_add_library( algebra_vc_vc vc_vc
 target_link_libraries( algebra_vc_vc
    INTERFACE algebra::common algebra::vc_storage algebra::cmath_math
              algebra::vc_math )
+algebra_test_public_headers( algebra_vc_vc
+   "algebra/vc_vc.hpp" )

--- a/frontend/vecmem_cmath/CMakeLists.txt
+++ b/frontend/vecmem_cmath/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Algebra plugins library, part of the ACTS project (R&D line)
 #
-# (c) 2021-2022 CERN for the benefit of the ACTS project
+# (c) 2021-2023 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -9,3 +9,5 @@ algebra_add_library( algebra_vecmem_cmath vecmem_cmath
    "include/algebra/vecmem_cmath.hpp" )
 target_link_libraries( algebra_vecmem_cmath
    INTERFACE algebra::common algebra::vecmem_storage algebra::cmath_math )
+algebra_test_public_headers( algebra_vecmem_cmath
+   "algebra/vecmem_cmath.hpp" )

--- a/math/cmath/CMakeLists.txt
+++ b/math/cmath/CMakeLists.txt
@@ -1,13 +1,12 @@
 # Algebra plugins library, part of the ACTS project (R&D line)
 #
-# (c) 2021-2022 CERN for the benefit of the ACTS project
+# (c) 2021-2023 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
 # Set up the library.
 algebra_add_library(algebra_cmath_math cmath_math
    # impl include
-   "include/algebra/math/cmath_operators.hpp"
    "include/algebra/math/cmath.hpp"
    "include/algebra/math/impl/cmath_getter.hpp"
    "include/algebra/math/impl/cmath_matrix.hpp"
@@ -25,3 +24,5 @@ algebra_add_library(algebra_cmath_math cmath_math
    "include/algebra/math/algorithms/utils/algorithm_finder.hpp")
 target_link_libraries(algebra_cmath_math
    INTERFACE algebra::common algebra::common_math)
+algebra_test_public_headers( algebra_cmath_math
+   "algebra/math/cmath.hpp" )

--- a/math/common/CMakeLists.txt
+++ b/math/common/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Algebra plugins library, part of the ACTS project (R&D line)
 #
-# (c) 2022 CERN for the benefit of the ACTS project
+# (c) 2022-2023 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -10,3 +10,5 @@ algebra_add_library(algebra_common_math common_math
    "include/algebra/math/common.hpp")
 target_link_libraries(algebra_common_math
    INTERFACE algebra::common)
+algebra_test_public_headers( algebra_common_math
+   "algebra/math/common.hpp" )

--- a/math/eigen/CMakeLists.txt
+++ b/math/eigen/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Algebra plugins library, part of the ACTS project (R&D line)
 #
-# (c) 2021-2022 CERN for the benefit of the ACTS project
+# (c) 2021-2023 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -12,4 +12,7 @@ algebra_add_library(algebra_eigen_math eigen_math
    "include/algebra/math/impl/eigen_transform3.hpp"
    "include/algebra/math/impl/eigen_vector.hpp")
 target_link_libraries(algebra_eigen_math
-   INTERFACE algebra::common algebra::common_math Eigen3::Eigen)
+   INTERFACE Eigen3::Eigen algebra::common algebra::common_math
+             algebra::eigen_storage)
+algebra_test_public_headers( algebra_eigen_math
+   "algebra/math/eigen.hpp" )

--- a/math/fastor/CMakeLists.txt
+++ b/math/fastor/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Algebra plugins library, part of the ACTS project (R&D line)
 #
-# (c) 2022 CERN for the benefit of the ACTS project
+# (c) 2022-2023 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -11,7 +11,8 @@ algebra_add_library(algebra_fastor_math fastor_math
    "include/algebra/math/impl/fastor_matrix.hpp"
    "include/algebra/math/impl/fastor_transform3.hpp"
    "include/algebra/math/impl/fastor_vector.hpp")
-
 target_link_libraries(algebra_fastor_math
-   INTERFACE algebra::common algebra::common_math Fastor::Fastor )
-   
+   INTERFACE Fastor::Fastor algebra::common algebra::common_math
+             algebra::fastor_storage)
+algebra_test_public_headers( algebra_fastor_math
+   "algebra/math/fastor.hpp" )

--- a/math/smatrix/CMakeLists.txt
+++ b/math/smatrix/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Algebra plugins library, part of the ACTS project (R&D line)
 #
-# (c) 2021-2022 CERN for the benefit of the ACTS project
+# (c) 2021-2023 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -17,3 +17,5 @@ algebra_add_library(algebra_smatrix_math smatrix_math
    "include/algebra/math/impl/smatrix_vector.hpp")
 target_link_libraries(algebra_smatrix_math
    INTERFACE algebra::common ROOT::Core ROOT::MathCore ROOT::Smatrix)
+algebra_test_public_headers( algebra_smatrix_math
+   "algebra/math/smatrix.hpp" )

--- a/math/vc/CMakeLists.txt
+++ b/math/vc/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Algebra plugins library, part of the ACTS project (R&D line)
 #
-# (c) 2021-2022 CERN for the benefit of the ACTS project
+# (c) 2021-2023 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -11,4 +11,7 @@ algebra_add_library( algebra_vc_math vc_math
    "include/algebra/math/impl/vc_transform3.hpp"
    "include/algebra/math/impl/vc_vector.hpp" )
 target_link_libraries( algebra_vc_math
-   INTERFACE algebra::common algebra::common_math Vc::Vc )
+   INTERFACE Vc::Vc algebra::common algebra::common_math
+             algebra::cmath_math )
+algebra_test_public_headers( algebra_vc_math
+   "algebra/math/vc.hpp" )

--- a/storage/array/CMakeLists.txt
+++ b/storage/array/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Algebra plugins library, part of the ACTS project (R&D line)
 #
-# (c) 2021-2022 CERN for the benefit of the ACTS project
+# (c) 2021-2023 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -9,3 +9,5 @@ algebra_add_library( algebra_array_storage array_storage
    "include/algebra/storage/array.hpp" )
 target_link_libraries( algebra_array_storage
    INTERFACE algebra::common )
+algebra_test_public_headers( algebra_array_storage
+   "algebra/storage/array.hpp" )

--- a/storage/eigen/CMakeLists.txt
+++ b/storage/eigen/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Algebra plugins library, part of the ACTS project (R&D line)
 #
-# (c) 2021-2022 CERN for the benefit of the ACTS project
+# (c) 2021-2023 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -10,3 +10,5 @@ algebra_add_library( algebra_eigen_storage eigen_storage
    "include/algebra/storage/impl/eigen_array.hpp" )
 target_link_libraries( algebra_eigen_storage
    INTERFACE algebra::common Eigen3::Eigen )
+algebra_test_public_headers( algebra_eigen_storage
+   "algebra/storage/eigen.hpp" )

--- a/storage/fastor/CMakeLists.txt
+++ b/storage/fastor/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Algebra plugins library, part of the ACTS project (R&D line)
 #
-# (c) 2022 CERN for the benefit of the ACTS project
+# (c) 2022-2023 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -9,4 +9,6 @@ algebra_add_library( algebra_fastor_storage fastor_storage
    "include/algebra/storage/fastor.hpp"
    "include/algebra/storage/impl/fastor_matrix.hpp" )
 target_link_libraries( algebra_fastor_storage
-	INTERFACE algebra::common )
+	INTERFACE Fastor::Fastor algebra::common )
+algebra_test_public_headers( algebra_fastor_storage
+   "algebra/storage/fastor.hpp" )

--- a/storage/smatrix/CMakeLists.txt
+++ b/storage/smatrix/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Algebra plugins library, part of the ACTS project (R&D line)
 #
-# (c) 2021-2022 CERN for the benefit of the ACTS project
+# (c) 2021-2023 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -12,3 +12,5 @@ algebra_add_library( algebra_smatrix_storage smatrix_storage
    "include/algebra/storage/smatrix.hpp" )
 target_link_libraries( algebra_smatrix_storage
    INTERFACE algebra::common ROOT::Smatrix )
+algebra_test_public_headers( algebra_smatrix_storage
+   "algebra/storage/smatrix.hpp" )

--- a/storage/vc/CMakeLists.txt
+++ b/storage/vc/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Algebra plugins library, part of the ACTS project (R&D line)
 #
-# (c) 2021-2022 CERN for the benefit of the ACTS project
+# (c) 2021-2023 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -10,3 +10,5 @@ algebra_add_library( algebra_vc_storage vc_storage
    "include/algebra/storage/impl/vc_array4_wrapper.hpp" )
 target_link_libraries( algebra_vc_storage
    INTERFACE algebra::common Vc::Vc )
+algebra_test_public_headers( algebra_vc_storage
+   "algebra/storage/vc.hpp" )

--- a/storage/vecmem/CMakeLists.txt
+++ b/storage/vecmem/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Algebra plugins library, part of the ACTS project (R&D line)
 #
-# (c) 2021-2022 CERN for the benefit of the ACTS project
+# (c) 2021-2023 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -9,3 +9,5 @@ algebra_add_library( algebra_vecmem_storage vecmem_storage
    "include/algebra/storage/vecmem.hpp" )
 target_link_libraries( algebra_vecmem_storage
    INTERFACE algebra::common vecmem::core )
+algebra_test_public_headers( algebra_vecmem_storage
+   "algebra/storage/vecmem.hpp" )


### PR DESCRIPTION
This is a sibling of https://github.com/acts-project/vecmem/pull/222.

I added a function called `algebra_test_public_headers(...)` that can be used to make sure that:
  - public header files include everything that they need to be usable;
  - the CMake library targets are set up correctly to make the public headers usable after only linking against the library target that the public header is sitting in.

All this was necessitated because I noticed in [traccc](https://github.com/acts-project/traccc) that some [detray](https://github.com/acts-project/detray) targets are not set up correctly. :frowning: But introducing rigorous tests revealed some problems already in [vecmem](https://github.com/acts-project/vecmem), and now in this project as well. (The `algebra::eigen_math`, `algebra::fastor_math`, `algebra::fastor_storage` and `algebra::vc_math` targets have some problems currently.)

Note that here I just made sure that the CMake configuration would correctly reflect what the code is doing. But for instance I'm not convinced that `algebra::vc_math` is indeed meant to rely on `algebra::cmath_math`. :confused:

https://github.com/acts-project/algebra-plugins/blob/main/math/vc/include/algebra/math/impl/vc_transform3.hpp#L11

Could you check Beomki and Joana?