### PR TITLE
CMake Updates, main branch (2023.03.29.)

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -53,6 +53,8 @@ jobs:
                  -DALGEBRA_PLUGINS_INCLUDE_FASTOR=TRUE
                  -DALGEBRA_PLUGINS_SETUP_FASTOR=TRUE
                  -DALGEBRA_PLUGINS_USE_SYSTEM_FASTOR=FALSE
+                 -DALGEBRA_PLUGINS_BUILD_BENCHMARKS=TRUE
+                 -DALGEBRA_PLUGINS_FAIL_ON_WARNINGS=TRUE
                  -S ${{ github.workspace }} -B build
                  -G "${{ matrix.PLATFORM.GENERATOR }}"
     # Perform the build.
@@ -111,7 +113,7 @@ jobs:
     - name: Configure
       run: |
         source ${GITHUB_WORKSPACE}/.github/ci_setup.sh ${{ matrix.PLATFORM.NAME }}
-        cmake -DCMAKE_BUILD_TYPE=${{ matrix.BUILD_TYPE }} ${{ matrix.PLATFORM.OPTIONS }} -DALGEBRA_PLUGINS_BUILD_BENCHMARKS=TRUE -S ${GITHUB_WORKSPACE} -B build
+        cmake -DCMAKE_BUILD_TYPE=${{ matrix.BUILD_TYPE }} ${{ matrix.PLATFORM.OPTIONS }} -DALGEBRA_PLUGINS_BUILD_BENCHMARKS=TRUE -DALGEBRA_PLUGINS_FAIL_ON_WARNINGS=TRUE -S ${GITHUB_WORKSPACE} -B build
     # Perform the build.
     - name: Build
       run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,8 @@ option( ALGEBRA_PLUGINS_BUILD_TESTING "Build the unit tests of Algebra Plugins"
    TRUE )
 option( ALGEBRA_PLUGINS_BUILD_BENCHMARKS "Build the benchmark suite of Algebra Plugins"
 	FALSE )
+option( ALGEBRA_PLUGINS_FAIL_ON_WARNINGS
+   "Make the build fail on compiler/linker warnings" FALSE )
 
 # Include the Algebra Plugins CMake code.
 list( APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake" )

--- a/cmake/algebra-plugins-compiler-options-cpp.cmake
+++ b/cmake/algebra-plugins-compiler-options-cpp.cmake
@@ -1,17 +1,11 @@
 # Algebra plugins library, part of the ACTS project (R&D line)
 #
-# (c) 2021-2022 CERN for the benefit of the ACTS project
+# (c) 2021-2023 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
 # Include the helper function(s).
 include( algebra-plugins-functions )
-
-# Turn on the correct setting for the __cplusplus macro with MSVC.
-if( "${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC" )
-   algebra_add_flag( CMAKE_CXX_FLAGS "/Zc:__cplusplus" )
-   algebra_add_flag( CMAKE_CUDA_FLAGS "-Xcompiler /Zc:__cplusplus" )
-endif()
 
 # Turn on a number of warnings for the "known compilers".
 if( ( "${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU" ) OR
@@ -22,10 +16,12 @@ if( ( "${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU" ) OR
    algebra_add_flag( CMAKE_CXX_FLAGS "-Wextra" )
    algebra_add_flag( CMAKE_CXX_FLAGS "-Wshadow" )
    algebra_add_flag( CMAKE_CXX_FLAGS "-Wunused-local-typedefs" )
+   algebra_add_flag( CMAKE_CXX_FLAGS "-pedantic" )
 
-   # More rigorous tests for the Debug builds.
-   algebra_add_flag( CMAKE_CXX_FLAGS_DEBUG "-Werror" )
-   algebra_add_flag( CMAKE_CXX_FLAGS_DEBUG "-pedantic" )
+   # Fail on warnings, if asked for that behaviour.
+   if( ALGEBRA_PLUGINS_FAIL_ON_WARNINGS )
+      algebra_add_flag( CMAKE_CXX_FLAGS "-Werror" )
+   endif()
 
 elseif( "${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC" )
 
@@ -34,7 +30,12 @@ elseif( "${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC" )
       "${CMAKE_CXX_FLAGS}" )
    algebra_add_flag( CMAKE_CXX_FLAGS "/W4" )
 
-   # More rigorous tests for the Debug builds.
-   algebra_add_flag( CMAKE_CXX_FLAGS_DEBUG "/WX" )
+   # Fail on warnings, if asked for that behaviour.
+   if( ALGEBRA_PLUGINS_FAIL_ON_WARNINGS )
+      algebra_add_flag( CMAKE_CXX_FLAGS "/WX" )
+   endif()
+
+   # Turn on the correct setting for the __cplusplus macro with MSVC.
+   algebra_add_flag( CMAKE_CXX_FLAGS "/Zc:__cplusplus" )
 
 endif()

--- a/cmake/algebra-plugins-compiler-options-cuda.cmake
+++ b/cmake/algebra-plugins-compiler-options-cuda.cmake
@@ -1,6 +1,6 @@
 # Algebra plugins library, part of the ACTS project (R&D line)
 #
-# (c) 2021-2022 CERN for the benefit of the ACTS project
+# (c) 2021-2023 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -17,11 +17,23 @@ find_package( CUDAToolkit REQUIRED )
 set( CMAKE_CUDA_ARCHITECTURES "52" CACHE STRING
    "CUDA architectures to build device code for" )
 
+# Turn on the correct setting for the __cplusplus macro with MSVC.
+if( "${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC" )
+   algebra_add_flag( CMAKE_CUDA_FLAGS "-Xcompiler /Zc:__cplusplus" )
+endif()
+
 # Make CUDA generate debug symbols for the device code as well in a debug
 # build.
-algebra_add_flag( CMAKE_CUDA_FLAGS_DEBUG "-G" )
+if( "${CMAKE_CUDA_COMPILER_ID}" MATCHES "NVIDIA" )
+   algebra_add_flag( CMAKE_CUDA_FLAGS_DEBUG "-G" )
+endif()
 
-# More rigorous tests for the Debug builds.
-if( "${CUDAToolkit_VERSION}" VERSION_GREATER_EQUAL "10.2" )
-   algebra_add_flag( CMAKE_CUDA_FLAGS_DEBUG "-Werror all-warnings" )
+# Fail on warnings, if asked for that behaviour.
+if( ALGEBRA_PLUGINS_FAIL_ON_WARNINGS )
+   if( ( "${CUDAToolkit_VERSION}" VERSION_GREATER_EQUAL "10.2" ) AND
+       ( "${CMAKE_CUDA_COMPILER_ID}" MATCHES "NVIDIA" ) )
+      algebra_add_flag( CMAKE_CUDA_FLAGS "-Werror all-warnings" )
+   elseif( "${CMAKE_CUDA_COMPILER_ID}" MATCHES "Clang" )
+      algebra_add_flag( CMAKE_CUDA_FLAGS "-Werror" )
+   endif()
 endif()

--- a/cmake/algebra-plugins-compiler-options-sycl.cmake
+++ b/cmake/algebra-plugins-compiler-options-sycl.cmake
@@ -1,6 +1,6 @@
 # Algebra plugins library, part of the ACTS project (R&D line)
 #
-# (c) 2021-2022 CERN for the benefit of the ACTS project
+# (c) 2021-2023 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -15,10 +15,10 @@ foreach( mode RELEASE RELWITHDEBINFO MINSIZEREL DEBUG )
    algebra_add_flag( CMAKE_SYCL_FLAGS_${mode} "-Wshadow" )
    algebra_add_flag( CMAKE_SYCL_FLAGS_${mode} "-Wunused-local-typedefs" )
 endforeach()
-
-# More rigorous tests for the Debug builds.
 if( NOT WIN32 )
-   algebra_add_flag( CMAKE_SYCL_FLAGS_DEBUG "-pedantic" )
+   foreach( mode RELEASE RELWITHDEBINFO MINSIZEREL DEBUG )
+      algebra_add_flag( CMAKE_SYCL_FLAGS_${mode} "-pedantic" )
+   endforeach()
 endif()
 
 # Avoid issues coming from MSVC<->DPC++ argument differences.
@@ -26,5 +26,12 @@ if( "${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC" )
    foreach( mode RELEASE RELWITHDEBINFO MINSIZEREL DEBUG )
       algebra_add_flag( CMAKE_SYCL_FLAGS_${mode}
          "-Wno-unused-command-line-argument" )
+   endforeach()
+endif()
+
+# Fail on warnings, if asked for that behaviour.
+if( ALGEBRA_PLUGINS_FAIL_ON_WARNINGS )
+   foreach( mode RELEASE RELWITHDEBINFO MINSIZEREL DEBUG )
+      algebra_add_flag( CMAKE_SYCL_FLAGS_${mode} "-Werror" )
    endforeach()
 endif()


### PR DESCRIPTION
Introduced `ALGEBRA_PLUGINS_FAIL_ON_WARNINGS`. Instead of only using `-Werror` (and similar flags) for debug builds, it is now possible to add `-Werror` to the build in any build mode. This is following the same sort of setup as in https://github.com/acts-project/vecmem/pull/210 and https://github.com/acts-project/traccc/pull/334.

Updated the CI to set `ALGEBRA_PLUGINS_FAIL_ON_WARNINGS` to `TRUE` in all tests.

Note that I was intending to add `-Wconversion` as a warning as well, but that triggered on a gazillion of floating point literals in the unit tests. (Complaining that double precision literals are converted into single precision values.) That just not seemed reasonable to do. As the readability of the unit tests would've been seriously hurt.

Also note that I realized, while updating the `builds.yml` configuration, that I forgot to add `-DALGEBRA_PLUGINS_BUILD_BENCHMARKS=TRUE` for the "native builds" in #99. So I'm sneaking in that fix here...