### PR TITLE
Removed `ALGEBRA_PLUGINS_CUSTOM_SCALARTYPE` option from the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,6 @@ cmake --build algebra-plugins-build
 
 Available options:
 
-- `ALGEBRA_PLUGINS_CUSTOM_SCALARTYPE`: Scalar value type
-  (`float` or `double`, `double` by default)
 - `ALGEBRA_PLUGINS_INCLUDE_<XXX>`: Boolean to turn on/off the build of one of
   the following plugins:
   * `EIGEN`: Plugin using [Eigen](https://eigen.tuxfamily.org)


### PR DESCRIPTION
I removed it because it looks like the current `CMakeLists.txt` does not use this option. It appears to have been removed in f4701ab13bd578eb5a486b65d1c461497573ece0 as a part of #44.