### PR TITLE
External Build Re-Design, main branch (2023.05.25.)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,9 +19,6 @@ set( CMAKE_SYCL_STANDARD 17 CACHE STRING "The (SYCL) C++ standard to use" )
 include( CTest )
 include( GNUInstallDirs )
 
-# Flags controlling the meta-build system.
-option( ALGEBRA_PLUGINS_USE_SYSTEM_LIBS "Use system libraries be default" FALSE )
-
 # Explicitly set the output directory for the binaries. Such that if this
 # project is included by another project, the main project's configuration would
 # win out.
@@ -57,83 +54,21 @@ option( ALGEBRA_PLUGINS_FAIL_ON_WARNINGS
 list( APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake" )
 include( algebra-plugins-functions )
 
-# Suppress developer warnings for all of the externals by default.
-# Unless the user explicitly requested otherwise.
-if( NOT DEFINED CMAKE_SUPPRESS_DEVELOPER_WARNINGS )
-   set( CMAKE_SUPPRESS_DEVELOPER_WARNINGS TRUE )
-   set( _unsetDevWarningFlag TRUE )
+# Set up all "buildable" externals.
+if( ALGEBRA_PLUGINS_BUILD_BENCHMARKS )
+   add_subdirectory( extern/benchmark )
 endif()
-
-# Set up VecMem.
-option( ALGEBRA_PLUGINS_SETUP_VECMEM
-   "Set up the VecMem target(s) explicitly" TRUE )
-option( ALGEBRA_PLUGINS_USE_SYSTEM_VECMEM
-   "Pick up an existing installation of VecMem from the build environment"
-   ${ALGEBRA_PLUGINS_USE_SYSTEM_LIBS} )
-if( ALGEBRA_PLUGINS_SETUP_VECMEM )
-   if( ALGEBRA_PLUGINS_USE_SYSTEM_VECMEM )
-      find_package( vecmem 0.7.0 REQUIRED COMPONENTS LANGUAGE )
-   else()
-      add_subdirectory( extern/vecmem )
-      # Make the "VecMem language code" available for the whole project.
-      include( "${VECMEM_LANGUAGE_DIR}/vecmem-check-language.cmake" )
-   endif()
+if( BUILD_TESTING AND ALGEBRA_PLUGINS_BUILD_TESTING )
+   add_subdirectory( extern/googletest )
 endif()
-
-# Set up GoogleTest.
-option( ALGEBRA_PLUGINS_SETUP_GOOGLETEST
-   "Set up the GoogleTest target(s) explicitly" TRUE )
-option( ALGEBRA_PLUGINS_USE_SYSTEM_GOOGLETEST
-   "Pick up an existing installation of GoogleTest from the build environment"
-   ${ALGEBRA_PLUGINS_USE_SYSTEM_LIBS} )
-if( ALGEBRA_PLUGINS_SETUP_GOOGLETEST )
-   if( ALGEBRA_PLUGINS_USE_SYSTEM_GOOGLETEST )
-      find_package( GTest REQUIRED )
-   else()
-      add_subdirectory( extern/googletest )
-   endif()
+if( ALGEBRA_PLUGINS_INCLUDE_EIGEN )
+   add_subdirectory( extern/eigen3 )
 endif()
-
-# Set up Google Benchmark
-option( ALGEBRA_PLUGINS_SETUP_BENCHMARK
-   "Set up the Google Benchmark target(s) explicitly" TRUE )
-option( ALGEBRA_PLUGINS_USE_SYSTEM_BENCHMARK
-   "Pick up an existing installation of Google Benchmark from the build environment"
-   ${ALGEBRA_PLUGINS_USE_SYSTEM_LIBS} )
-if( ALGEBRA_PLUGINS_SETUP_BENCHMARK )
-   if( ALGEBRA_PLUGINS_USE_SYSTEM_BENCHMARK )
-      find_package( benchmark REQUIRED )
-   else()
-      add_subdirectory( extern/benchmark )
-   endif()
+if( ALGEBRA_PLUGINS_INCLUDE_FASTOR )
+   add_subdirectory( extern/fastor )
 endif()
-
-# Set up Eigen3.
-option( ALGEBRA_PLUGINS_SETUP_EIGEN3
-   "Set up the Eigen3 target(s) explicitly" FALSE )
-option( ALGEBRA_PLUGINS_USE_SYSTEM_EIGEN3
-   "Pick up an existing installation of Eigen3 from the build environment"
-   ${ALGEBRA_PLUGINS_USE_SYSTEM_LIBS} )
-if( ALGEBRA_PLUGINS_SETUP_EIGEN3 )
-   if( ALGEBRA_PLUGINS_USE_SYSTEM_EIGEN3 )
-      find_package( Eigen3 REQUIRED )
-   else()
-      add_subdirectory( extern/eigen3 )
-   endif()
-endif()
-
-# Set up Vc.
-option( ALGEBRA_PLUGINS_SETUP_VC
-   "Set up the Vc target(s) explicitly" FALSE )
-option( ALGEBRA_PLUGINS_USE_SYSTEM_VC
-   "Pick up an existing installation of Vc from the build environment"
-   ${ALGEBRA_PLUGINS_USE_SYSTEM_LIBS} )
-if( ALGEBRA_PLUGINS_SETUP_VC )
-   if( ALGEBRA_PLUGINS_USE_SYSTEM_VC )
-      find_package( Vc 1.4.2 REQUIRED )
-   else()
-      add_subdirectory( extern/vc )
-   endif()
+if( ALGEBRA_PLUGINS_INCLUDE_VC )
+   add_subdirectory( extern/vc )
    if( NOT "${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC" )
       # Use the preferred compiler flags from Vc for the entire project. Do not
       # set them on the libraries individually, as the clients of the libraries
@@ -143,26 +78,7 @@ if( ALGEBRA_PLUGINS_SETUP_VC )
       add_compile_options( ${Vc_COMPILE_FLAGS} ${Vc_ARCHITECTURE_FLAGS} )
    endif()
 endif()
-
-# Set up Fastor.
-option( ALGEBRA_PLUGINS_SETUP_FASTOR
-   "Set up the Fastor target(s) explicitly" FALSE )
-option( ALGEBRA_PLUGINS_USE_SYSTEM_FASTOR
-   "Pick up an existing installation of Fastor from the build environment"
-   ${ALGEBRA_PLUGINS_USE_SYSTEM_LIBS} )
-if( ALGEBRA_PLUGINS_SETUP_FASTOR )
-   if( ALGEBRA_PLUGINS_USE_SYSTEM_FASTOR )
-      find_package( Fastor 0.6.3 REQUIRED )
-   else()
-      add_subdirectory( extern/fastor )
-   endif()
-endif()
-
-# Undo the developer flag suppression.
-if( _unsetDevWarningFlag )
-   unset( CMAKE_SUPPRESS_DEVELOPER_WARNINGS )
-   unset( _unsetDevWarningFlag )
-endif()
+add_subdirectory( extern/vecmem ) # VecMem is always needed.
 
 # Set up the Algebra Plugin libraries.
 add_subdirectory( common )

--- a/extern/benchmark/CMakeLists.txt
+++ b/extern/benchmark/CMakeLists.txt
@@ -1,32 +1,33 @@
 # Algebra plugins library, part of the ACTS project (R&D line)
 #
-# (c) 2022 CERN for the benefit of the ACTS project
+# (c) 2022-2023 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
 # CMake include(s).
-cmake_minimum_required( VERSION 3.11 )
+cmake_minimum_required( VERSION 3.24 )
 include( FetchContent )
 
-# Tell the user what's happening.
-message( STATUS "Building Google Benchmark as part of the Algebra Plugins project" )
-
-# Declare where to get GoogleTest from.
+# Declare where to get GoogleTest from, in case it is not found with
+# find_package.
 set( ALGEBRA_PLUGINS_BENCHMARK_SOURCE
    "URL;https://github.com/google/benchmark/archive/refs/tags/v1.6.1.tar.gz;URL_MD5;8c33c51f9b7154e6c290df3750081c87"
    CACHE STRING "Source for Google Benchmark, when built as part of this project" )
 mark_as_advanced( ALGEBRA_PLUGINS_BENCHMARK_SOURCE )
-FetchContent_Declare( benchmark ${ALGEBRA_PLUGINS_BENCHMARK_SOURCE} )
+FetchContent_Declare( benchmark ${ALGEBRA_PLUGINS_BENCHMARK_SOURCE}
+   FIND_PACKAGE_ARGS )
 
 # Options used in the build of Google Benchmark.
-set(BENCHMARK_ENABLE_TESTING OFF CACHE BOOL "Don't build the Google Benchmark tests")
-set(BENCHMARK_ENABLE_INSTALL OFF CACHE BOOL "Turn off the installation of Google Benchmark")
-set(BENCHMARK_INSTALL_DOCS OFF CACHE BOOL "Don't install the Google Benchmark docs")
-set(BENCHMARK_ENABLE_GTEST_TESTS OFF CACHE BOOL "Don't build the unit tests which depend on gtest")
-set(BENCHMARK_ENABLE_WERROR OFF CACHE BOOL "Enable/disable using -Werror in the build of Google Benchmark")
+set( BENCHMARK_ENABLE_TESTING OFF CACHE BOOL
+   "Don't build the Google Benchmark tests" )
+set( BENCHMARK_ENABLE_INSTALL OFF CACHE BOOL
+   "Turn off the installation of Google Benchmark" )
+set( BENCHMARK_INSTALL_DOCS OFF CACHE BOOL
+   "Don't install the Google Benchmark docs" )
+set( BENCHMARK_ENABLE_GTEST_TESTS OFF CACHE BOOL
+   "Don't build the unit tests which depend on gtest" )
+set( BENCHMARK_ENABLE_WERROR OFF CACHE BOOL
+   "Enable/disable using -Werror in the build of Google Benchmark" )
 
-# Get it into the current directory.
-FetchContent_Populate( benchmark )
-add_subdirectory( "${benchmark_SOURCE_DIR}" "${benchmark_BINARY_DIR}"
-   EXCLUDE_FROM_ALL )
-
+# Set it up.
+FetchContent_MakeAvailable( benchmark )

--- a/extern/eigen3/CMakeLists.txt
+++ b/extern/eigen3/CMakeLists.txt
@@ -1,22 +1,20 @@
 # Algebra plugins library, part of the ACTS project (R&D line)
 #
-# (c) 2021-2022 CERN for the benefit of the ACTS project
+# (c) 2021-2023 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
 # CMake include(s).
-cmake_minimum_required( VERSION 3.14 )
+cmake_minimum_required( VERSION 3.24 )
 include( FetchContent )
 
-# Tell the user what's happening.
-message( STATUS "Building Eigen3 as part of the Algebra Plugins project" )
-
-# Declare where to get Eigen3 from.
+# Declare where to get Eigen3 from, in case it is not found with find_package.
 set( ALGEBRA_PLUGINS_EIGEN_SOURCE
    "URL;https://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-3.4.0.tar.bz2;URL_MD5;132dde48fe2b563211675626d29f1707"
    CACHE STRING "Source for Eigen, when built as part of this project" )
 mark_as_advanced( ALGEBRA_PLUGINS_EIGEN_SOURCE )
-FetchContent_Declare( Eigen3 ${ALGEBRA_PLUGINS_EIGEN_SOURCE} )
+FetchContent_Declare( Eigen3 ${ALGEBRA_PLUGINS_EIGEN_SOURCE}
+   FIND_PACKAGE_ARGS )
 
 # Turn off the unit tests for Eigen3.
 if( DEFINED CACHE{BUILD_TESTING} )
@@ -24,7 +22,7 @@ if( DEFINED CACHE{BUILD_TESTING} )
 endif()
 set( BUILD_TESTING FALSE CACHE INTERNAL "Forceful setting of BUILD_TESTING" )
 
-# Get it into the current directory.
+# Set it up.
 FetchContent_MakeAvailable( Eigen3 )
 
 # Reset the BUILD_TESTING variable.
@@ -37,8 +35,10 @@ else()
 endif()
 
 # Treat the Eigen headers as "system headers", to avoid getting warnings from
-# them.
-get_target_property( _incDirs eigen INTERFACE_INCLUDE_DIRECTORIES )
-target_include_directories( eigen
-   SYSTEM INTERFACE ${_incDirs} )
-unset( _incDirs )
+# them. But only bother about this when building Eigen as part of this project.
+if( TARGET eigen )
+   get_target_property( _incDirs eigen INTERFACE_INCLUDE_DIRECTORIES )
+   target_include_directories( eigen
+      SYSTEM INTERFACE ${_incDirs} )
+   unset( _incDirs )
+endif()

--- a/extern/fastor/CMakeLists.txt
+++ b/extern/fastor/CMakeLists.txt
@@ -1,24 +1,22 @@
 # Algebra plugins library, part of the ACTS project (R&D line)
 #
-# (c) 2022 CERN for the benefit of the ACTS project
+# (c) 2022-2023 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
 # CMake include(s).
-cmake_minimum_required( VERSION 3.11 )
+cmake_minimum_required( VERSION 3.24 )
 include( FetchContent )
 
-# Tell the user what's happening.
-message( STATUS "Building Fastor as part of the Algebra Plugins project" )
-
-# Declare where to get Fastor from.
+# Declare where to get Fastor from, in case it is not found with find_package.
 # We need to use this alternative syntax for FetchContent_Declare because the
 # latest release for Fastor does not have a CMakeLists.txt file.
 set( ALGEBRA_PLUGINS_FASTOR_SOURCE
    "fastor;GIT_REPOSITORY;https://github.com/romeric/Fastor.git;GIT_TAG;e96e63fe8a05898d732d0b9faba3667d9a25a38f"
    CACHE STRING "Source for Fastor, when built as part of this project" )
 mark_as_advanced( ALGEBRA_PLUGINS_FASTOR_SOURCE )
-FetchContent_Declare( fastor ${ALGEBRA_PLUGINS_FASTOR_SOURCE} )
+FetchContent_Declare( Fastor ${ALGEBRA_PLUGINS_FASTOR_SOURCE}
+   FIND_PACKAGE_ARGS 0.6.3 )
 
 # Turn off the unit tests for Fastor.
 if( DEFINED CACHE{BUILD_TESTING} )
@@ -26,8 +24,8 @@ if( DEFINED CACHE{BUILD_TESTING} )
 endif()
 set( BUILD_TESTING FALSE CACHE INTERNAL "Forceful setting of BUILD_TESTING" )
 
-# Get it into the current directory.
-FetchContent_MakeAvailable( fastor )
+# Set it up.
+FetchContent_MakeAvailable( Fastor )
 
 # Reset the BUILD_TESTING variable.
 if( DEFINED _buildTestingValue )
@@ -40,11 +38,15 @@ endif()
 
 # Treat the Fastor headers as "system headers", to avoid getting warnings from
 # them.
-get_target_property( _incDirs Fastor INTERFACE_INCLUDE_DIRECTORIES ) 
-target_include_directories( Fastor  
-   SYSTEM INTERFACE ${_incDirs} )
-unset( _incDirs )
+if( TARGET Fastor )
+   get_target_property( _incDirs Fastor INTERFACE_INCLUDE_DIRECTORIES )
+   target_include_directories( Fastor
+      SYSTEM INTERFACE ${_incDirs} )
+   unset( _incDirs )
+endif()
 
 # Set up an alias for the Fastor target, with the same name that it will have
 # when "finding it".
-add_library( Fastor::Fastor ALIAS Fastor )
+if( NOT TARGET Fastor::Fastor )
+   add_library( Fastor::Fastor ALIAS Fastor )
+endif()

--- a/extern/googletest/CMakeLists.txt
+++ b/extern/googletest/CMakeLists.txt
@@ -1,25 +1,23 @@
 # Algebra plugins library, part of the ACTS project (R&D line)
 #
-# (c) 2021-2022 CERN for the benefit of the ACTS project
+# (c) 2021-2023 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
 # CMake include(s).
-cmake_minimum_required( VERSION 3.11 )
+cmake_minimum_required( VERSION 3.24 )
 include( FetchContent )
-
-# Tell the user what's happening.
-message( STATUS "Building GoogleTest as part of the Algebra Plugins project" )
 
 # Declare where to get GoogleTest from.
 set( ALGEBRA_PLUGINS_GOOGLETEST_SOURCE
    "URL;https://github.com/google/googletest/archive/release-1.11.0.tar.gz;URL_MD5;e8a8df240b6938bb6384155d4c37d937"
    CACHE STRING "Source for GoogleTest, when built as part of this project" )
 mark_as_advanced( ALGEBRA_PLUGINS_GOOGLETEST_SOURCE )
-FetchContent_Declare( GoogleTest ${ALGEBRA_PLUGINS_GOOGLETEST_SOURCE} )
+FetchContent_Declare( GTest ${ALGEBRA_PLUGINS_GOOGLETEST_SOURCE}
+   FIND_PACKAGE_ARGS )
 
 # Options used in the build of GoogleTest.
-set( BUILD_GMOCK TRUE CACHE BOOL "Turn off the build of GMock" )
+set( BUILD_GMOCK FALSE CACHE BOOL "Turn off the build of GMock" )
 set( INSTALL_GTEST FALSE CACHE BOOL "Turn off the installation of GoogleTest" )
 if( WIN32 )
    set( gtest_force_shared_crt TRUE CACHE BOOL
@@ -29,12 +27,14 @@ endif()
 # Silence some warnings with modern versions of CMake on macOS.
 set( CMAKE_MACOSX_RPATH TRUE )
 
-# Get it into the current directory.
-FetchContent_Populate( GoogleTest )
-add_subdirectory( "${googletest_SOURCE_DIR}" "${googletest_BINARY_DIR}"
-   EXCLUDE_FROM_ALL )
+# Set it up.
+FetchContent_MakeAvailable( GTest )
 
 # Set up aliases for the GTest targets with the same name that they have
 # when we find GTest pre-installed.
-add_library( GTest::gtest ALIAS gtest )
-add_library( GTest::gtest_main ALIAS gtest_main )
+if( NOT TARGET GTest::gtest )
+   add_library( GTest::gtest ALIAS gtest )
+endif()
+if( NOT TARGET GTest::gtest_main )
+   add_library( GTest::gtest_main ALIAS gtest_main )
+endif()

--- a/extern/vc/CMakeLists.txt
+++ b/extern/vc/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Algebra plugins library, part of the ACTS project (R&D line)
 #
-# (c) 2021-2022 CERN for the benefit of the ACTS project
+# (c) 2021-2023 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -8,15 +8,19 @@
 cmake_minimum_required( VERSION 3.14 )
 include( FetchContent )
 
-# Tell the user what's happening.
-message( STATUS "Building Vc as part of the Algebra Plugins project" )
+# Suppress developer warnings for Vc by default.
+# Unless the user explicitly requested otherwise.
+if( NOT DEFINED CMAKE_SUPPRESS_DEVELOPER_WARNINGS )
+   set( CMAKE_SUPPRESS_DEVELOPER_WARNINGS TRUE )
+endif()
 
-# Declare where to get Vc from.
+# Declare where to get Vc from, in case it is not found with find_package.
 set( ALGEBRA_PLUGINS_VC_SOURCE
    "URL;https://github.com/VcDevel/Vc/archive/b84dcd0a65d8dc5de6a2bd4d367882b3748f812c.tar.gz;URL_MD5;ae1e8317352df53113ee28ba3f0d490a"
    CACHE STRING "Source for Vc, when built as part of this project" )
 mark_as_advanced( ALGEBRA_PLUGINS_VC_SOURCE )
-FetchContent_Declare( Vc ${ALGEBRA_PLUGINS_VC_SOURCE} )
+FetchContent_Declare( Vc ${ALGEBRA_PLUGINS_VC_SOURCE}
+   FIND_PACKAGE_ARGS 1.4.2 )
 
 # Turn off the unit tests for Vc.
 if( DEFINED CACHE{BUILD_TESTING} )
@@ -24,7 +28,7 @@ if( DEFINED CACHE{BUILD_TESTING} )
 endif()
 set( BUILD_TESTING FALSE CACHE INTERNAL "Forceful setting of BUILD_TESTING" )
 
-# Get it into the current directory.
+# Set it up.
 FetchContent_MakeAvailable( Vc )
 
 # Reset the BUILD_TESTING variable.
@@ -37,15 +41,19 @@ else()
 endif()
 
 # Treat the Vc headers as "system headers", to avoid getting warnings from them.
-target_include_directories( Vc
-   SYSTEM INTERFACE $<TARGET_PROPERTY:Vc,INCLUDE_DIRECTORIES> )
+if( TARGET Vc )
+   target_include_directories( Vc
+      SYSTEM INTERFACE $<TARGET_PROPERTY:Vc,INCLUDE_DIRECTORIES> )
+endif()
 
 # Disable a warning for GCC which the Vc build turns on explicitly for that
 # compiler, just to then go and trigger it... :-/
-if( "${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU" )
+if( ( "${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU" ) AND ( TARGET Vc ) )
    target_compile_options( Vc PRIVATE "-Wno-old-style-cast" )
 endif()
 
 # Set up an alias for the Vc target, with the same name that it will have
 # when "finding it".
-add_library( Vc::Vc ALIAS Vc )
+if( NOT TARGET Vc::Vc )
+   add_library( Vc::Vc ALIAS Vc )
+endif()

--- a/extern/vecmem/CMakeLists.txt
+++ b/extern/vecmem/CMakeLists.txt
@@ -5,22 +5,20 @@
 # Mozilla Public License Version 2.0
 
 # CMake include(s).
-cmake_minimum_required( VERSION 3.14 )
+cmake_minimum_required( VERSION 3.24 )
 include( FetchContent )
 
-# Tell the user what's happening.
-message( STATUS "Building VecMem as part of the Algebra Plugins project" )
-
-# Declare where to get VecMem from.
+# Declare where to get VecMem from, in case it is not found with find_package.
 set( ALGEBRA_PLUGINS_VECMEM_SOURCE
    "URL;https://github.com/acts-project/vecmem/archive/refs/tags/v0.24.0.tar.gz;URL_MD5;f6936ea57921d7e5110606c7a9e9a371"
    CACHE STRING "Source for VecMem, when built as part of this project" )
 mark_as_advanced( ALGEBRA_PLUGINS_VECMEM_SOURCE )
-FetchContent_Declare( VecMem ${ALGEBRA_PLUGINS_VECMEM_SOURCE} )
+FetchContent_Declare( vecmem ${ALGEBRA_PLUGINS_VECMEM_SOURCE}
+   FIND_PACKAGE_ARGS )
 
 # Options used in the build of VecMem.
 set( VECMEM_BUILD_TESTING FALSE CACHE BOOL
    "Turn off the build of the VecMem unit tests" )
 
-# Get it into the current directory.
-FetchContent_MakeAvailable( VecMem )
+# Set it up.
+FetchContent_MakeAvailable( vecmem )

--- a/frontend/eigen_cmath/CMakeLists.txt
+++ b/frontend/eigen_cmath/CMakeLists.txt
@@ -4,6 +4,9 @@
 #
 # Mozilla Public License Version 2.0
 
+# Find the required dependencies.
+find_package( Eigen3 REQUIRED )
+
 # Set up the library.
 algebra_add_library( algebra_eigen_cmath eigen_cmath
    "include/algebra/eigen_cmath.hpp" )

--- a/frontend/eigen_eigen/CMakeLists.txt
+++ b/frontend/eigen_eigen/CMakeLists.txt
@@ -4,6 +4,9 @@
 #
 # Mozilla Public License Version 2.0
 
+# Find the required dependencies.
+find_package( Eigen3 REQUIRED )
+
 # Set up the library.
 algebra_add_library( algebra_eigen_eigen eigen_eigen
    "include/algebra/eigen_eigen.hpp" )

--- a/frontend/vecmem_cmath/CMakeLists.txt
+++ b/frontend/vecmem_cmath/CMakeLists.txt
@@ -4,6 +4,9 @@
 #
 # Mozilla Public License Version 2.0
 
+# Find the required dependencies.
+find_package( vecmem REQUIRED )
+
 # Set up the library.
 algebra_add_library( algebra_vecmem_cmath vecmem_cmath
    "include/algebra/vecmem_cmath.hpp" )

--- a/math/eigen/CMakeLists.txt
+++ b/math/eigen/CMakeLists.txt
@@ -4,6 +4,9 @@
 #
 # Mozilla Public License Version 2.0
 
+# Find the required dependencies.
+find_package( Eigen3 REQUIRED )
+
 # Set up the library.
 algebra_add_library(algebra_eigen_math eigen_math
    "include/algebra/math/eigen.hpp"

--- a/math/fastor/CMakeLists.txt
+++ b/math/fastor/CMakeLists.txt
@@ -4,6 +4,9 @@
 #
 # Mozilla Public License Version 2.0
 
+# Find the required dependencies.
+find_package( Fastor REQUIRED )
+
 # Set up the library.
 algebra_add_library(algebra_fastor_math fastor_math
    "include/algebra/math/fastor.hpp"

--- a/math/vc/CMakeLists.txt
+++ b/math/vc/CMakeLists.txt
@@ -4,6 +4,9 @@
 #
 # Mozilla Public License Version 2.0
 
+# Find the required dependencies.
+find_package( Vc REQUIRED )
+
 # Set up the library.
 algebra_add_library( algebra_vc_math vc_math
    "include/algebra/math/vc.hpp"

--- a/storage/eigen/CMakeLists.txt
+++ b/storage/eigen/CMakeLists.txt
@@ -4,6 +4,9 @@
 #
 # Mozilla Public License Version 2.0
 
+# Find the required dependencies.
+find_package( Eigen3 REQUIRED )
+
 # Set up the library.
 algebra_add_library( algebra_eigen_storage eigen_storage
    "include/algebra/storage/eigen.hpp"

--- a/storage/fastor/CMakeLists.txt
+++ b/storage/fastor/CMakeLists.txt
@@ -4,6 +4,9 @@
 #
 # Mozilla Public License Version 2.0
 
+# Find the required dependencies.
+find_package( Fastor REQUIRED )
+
 # Set up the library.
 algebra_add_library( algebra_fastor_storage fastor_storage
    "include/algebra/storage/fastor.hpp"

--- a/storage/vc/CMakeLists.txt
+++ b/storage/vc/CMakeLists.txt
@@ -4,6 +4,9 @@
 #
 # Mozilla Public License Version 2.0
 
+# Find the required dependencies.
+find_package( Vc REQUIRED )
+
 # Set up the library.
 algebra_add_library( algebra_vc_storage vc_storage
    "include/algebra/storage/vc.hpp"

--- a/storage/vecmem/CMakeLists.txt
+++ b/storage/vecmem/CMakeLists.txt
@@ -4,6 +4,9 @@
 #
 # Mozilla Public License Version 2.0
 
+# Find the required dependencies.
+find_package( vecmem REQUIRED )
+
 # Set up the library.
 algebra_add_library( algebra_vecmem_storage vecmem_storage
    "include/algebra/storage/vecmem.hpp" )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,8 +1,11 @@
 # Algebra plugins library, part of the ACTS project (R&D line)
 #
-# (c) 2021-2022 CERN for the benefit of the ACTS project
+# (c) 2021-2023 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
+
+# Find the required dependencies.
+find_package( GTest REQUIRED )
 
 # Set the default C++ compiler flags.
 include( algebra-plugins-compiler-options-cpp )
@@ -45,7 +48,7 @@ if( ALGEBRA_PLUGINS_INCLUDE_VC )
 endif()
 
 if( ALGEBRA_PLUGINS_INCLUDE_FASTOR )
-   algebra_add_test( fastor 
+   algebra_add_test( fastor
       "fastor/fastor_fastor.cpp"
       LINK_LIBRARIES GTest::gtest_main algebra::tests_common
                      algebra::fastor_fastor )

--- a/tests/accelerator/CMakeLists.txt
+++ b/tests/accelerator/CMakeLists.txt
@@ -4,6 +4,12 @@
 #
 # Mozilla Public License Version 2.0
 
+# Find the required dependencies.
+find_package( vecmem REQUIRED COMPONENTS LANGUAGE )
+
+# Make the "VecMem language code" available.
+include( "${VECMEM_LANGUAGE_DIR}/vecmem-check-language.cmake" )
+
 # Set up a "common library" for the device tests.
 add_library( algebra_tests_accel_common INTERFACE )
 target_include_directories( algebra_tests_accel_common INTERFACE


### PR DESCRIPTION
I'm absolutely opening a can of worms with this one, but let's see where it goes...

With [CMake 3.24](https://cmake.org/cmake/help/latest/release/3.24.html) a new behaviour was introduced for [FetchContent](https://cmake.org/cmake/help/latest/module/FetchContent.html) and [find_package](https://cmake.org/cmake/help/latest/command/find_package.html). They now implement a very similar logic for building or finding a needed external to what we implemented in these R&D projects. (And in [Acts](https://github.com/acts-project/acts) itself.)

Basically, [FetchContent](https://cmake.org/cmake/help/latest/module/FetchContent.html) can either build an external dependency as it did before, or it can look for it with [find_package](https://cmake.org/cmake/help/latest/command/find_package.html). The default behaviour of the code is to silently look for the package first, and if it's found in the user's build environment, the found version is used. While if it's not found, it is built instead. But one can also force the build to either always look for an existing external, or to always build it. See: [FETCHCONTENT_TRY_FIND_PACKAGE_MODE](https://cmake.org/cmake/help/latest/module/FetchContent.html#variable:FETCHCONTENT_TRY_FIND_PACKAGE_MODE)

The behaviour of the code is not really changed with all these modifications. The reasons that doing these modifications could be a good idea are the following:
  - I like that in this setup we need to put [find_package](https://cmake.org/cmake/help/latest/command/find_package.html) calls explicitly in all places in the code where we want to use an external dependency. Our current setup of only declaring those dependencies on the project level is not all too great...
  - Instead of using our own custom cache variables for controlling how externals would be used, we switch to using "CMake standard" variables for the same thing.
  - We don't have to worry about only a single project using [FetchContent](https://cmake.org/cmake/help/latest/module/FetchContent.html) on let's say [Eigen](https://eigen.tuxfamily.org/) when building [traccc](https://github.com/acts-project/traccc). The resolution between "whose version wins out" is sort of well defined, so we don't need the logic implemented through variables like `ALGEBRA_PLUGINS_SETUP_EIGEN3` anymore.

But one of the main things that sold this for me is how one would be able to work on multiple projects at the same time in the new setup. With our current setup one needs to for instance:
  - Set up [vecmem](https://github.com/acts-project/vecmem) in its own directory. Set up its build in a separate directory, and install it into some directory.
  - With this project point to that installation location, and build against that location.
  - When modifying something in [vecmem](https://github.com/acts-project/vecmem), go through a full "build vecmem" -> "install vecmem" -> "reconfigure algebra-plugins" -> "build algebra-plugins" cycle.

In this new setup one can instead clone [vecmem](https://github.com/acts-project/vecmem) and this project side-by-side, and when setting up the build of this project, use `-DFETCHCONTENT_SOURCE_DIR_VECMEM=<foo>` to tell the build to pick up [vecmem](https://github.com/acts-project/vecmem) from that location. So all of a sudden one can modify both projects freely, and just issue `make` commands in a single build directory.

**But...** Because there is a big but... :frowning: We don't use CMake 3.24+ in our Docker images at the moment. :frowning: So to make all this work, we would need to put in a fair amount of effort... :thinking: So we may want to think it through properly before committing to it. Even if I think this could be helpful in the long term.