### PR TITLE
External Updates, main branch (2023.10.06.)

### DIFF
--- a/extern/googletest/CMakeLists.txt
+++ b/extern/googletest/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Algebra plugins library, part of the ACTS project (R&D line)
 #
-# (c) 2021-2022 CERN for the benefit of the ACTS project
+# (c) 2021-2023 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -13,7 +13,7 @@ message( STATUS "Building GoogleTest as part of the Algebra Plugins project" )
 
 # Declare where to get GoogleTest from.
 set( ALGEBRA_PLUGINS_GOOGLETEST_SOURCE
-   "URL;https://github.com/google/googletest/archive/release-1.11.0.tar.gz;URL_MD5;e8a8df240b6938bb6384155d4c37d937"
+   "URL;https://github.com/google/googletest/archive/refs/tags/v1.14.0.tar.gz;URL_MD5;c8340a482851ef6a3fe618a082304cfc"
    CACHE STRING "Source for GoogleTest, when built as part of this project" )
 mark_as_advanced( ALGEBRA_PLUGINS_GOOGLETEST_SOURCE )
 FetchContent_Declare( GoogleTest ${ALGEBRA_PLUGINS_GOOGLETEST_SOURCE} )

--- a/extern/vecmem/CMakeLists.txt
+++ b/extern/vecmem/CMakeLists.txt
@@ -13,7 +13,7 @@ message( STATUS "Building VecMem as part of the Algebra Plugins project" )
 
 # Declare where to get VecMem from.
 set( ALGEBRA_PLUGINS_VECMEM_SOURCE
-   "URL;https://github.com/acts-project/vecmem/archive/refs/tags/v0.24.0.tar.gz;URL_MD5;f6936ea57921d7e5110606c7a9e9a371"
+   "URL;https://github.com/acts-project/vecmem/archive/refs/tags/v0.27.0.tar.gz;URL_MD5;cd1520efbd46d5d09ac5727452939ede"
    CACHE STRING "Source for VecMem, when built as part of this project" )
 mark_as_advanced( ALGEBRA_PLUGINS_VECMEM_SOURCE )
 FetchContent_Declare( VecMem ${ALGEBRA_PLUGINS_VECMEM_SOURCE} )


### PR DESCRIPTION
Updated the versions of GoogleTest and VecMem. The new version of GoogleTest provides better support for recent CMake versions, while the new VecMem version provides better support for recent oneAPI versions on Windows. Neither should change anything important with the project. :wink: