### PR TITLE
CMake Presets, main branch (2023.10.06.)

### DIFF
--- a/.github/ci_setup.sh
+++ b/.github/ci_setup.sh
@@ -1,6 +1,6 @@
 # Algebra plugins library, part of the ACTS project (R&D line)
 #
-# (c) 2021-2022 CERN for the benefit of the ACTS project
+# (c) 2021-2023 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 #
@@ -15,8 +15,11 @@ PLATFORM_NAME=$1
 
 # Set up the correct environment for the SYCL tests.
 if [ "${PLATFORM_NAME}" = "SYCL" ]; then
-   source /opt/intel/oneapi/setvars.sh
+   source /opt/intel/oneapi/setvars.sh --include-intel-llvm
+   # Use clang/clang++ instead of icx/icpx, to avoid some aggressive math
+   # optimizations that break some tests.
+   export CC=`which clang`
    export CXX=`which clang++`
-   export SYCLCXX=`which dpcpp`
+   export SYCLCXX="${CXX} -fsycl"
    export SYCL_DEVICE_FILTER=host
 fi

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -40,21 +40,7 @@ jobs:
     - uses: actions/checkout@v2
     # Run the CMake configuration.
     - name: Configure
-      run: cmake -DCMAKE_BUILD_TYPE=${{ matrix.BUILD_TYPE }}
-                 -DALGEBRA_PLUGINS_INCLUDE_EIGEN=TRUE
-                 -DALGEBRA_PLUGINS_SETUP_EIGEN3=TRUE
-                 -DALGEBRA_PLUGINS_USE_SYSTEM_EIGEN3=FALSE
-                 -DALGEBRA_PLUGINS_INCLUDE_VC=TRUE
-                 -DALGEBRA_PLUGINS_SETUP_VC=TRUE
-                 -DALGEBRA_PLUGINS_USE_SYSTEM_VC=FALSE
-                 -DALGEBRA_PLUGINS_INCLUDE_VECMEM=TRUE
-                 -DALGEBRA_PLUGINS_SETUP_VECMEM=TRUE
-                 -DALGEBRA_PLUGINS_USE_SYSTEM_VECMEM=FALSE
-                 -DALGEBRA_PLUGINS_INCLUDE_FASTOR=TRUE
-                 -DALGEBRA_PLUGINS_SETUP_FASTOR=TRUE
-                 -DALGEBRA_PLUGINS_USE_SYSTEM_FASTOR=FALSE
-                 -DALGEBRA_PLUGINS_BUILD_BENCHMARKS=TRUE
-                 -DALGEBRA_PLUGINS_FAIL_ON_WARNINGS=TRUE
+      run: cmake --preset default
                  -S ${{ github.workspace }} -B build
                  -G "${{ matrix.PLATFORM.GENERATOR }}"
     # Perform the build.
@@ -75,26 +61,29 @@ jobs:
         BUILD_TYPE: ["Release", "Debug"]
         PLATFORM:
           - NAME: "HOST"
-            CONTAINER: "ghcr.io/acts-project/ubuntu2004:v13"
-            OPTIONS: -DALGEBRA_PLUGINS_INCLUDE_EIGEN=TRUE -DALGEBRA_PLUGINS_SETUP_EIGEN3=TRUE -DALGEBRA_PLUGINS_USE_SYSTEM_EIGEN3=TRUE
+            CONTAINER: "ghcr.io/acts-project/ubuntu2004:v43"
+            OPTIONS: --preset eigen -DALGEBRA_PLUGINS_USE_SYSTEM_EIGEN3=TRUE
           - NAME: "HOST"
-            CONTAINER: "ghcr.io/acts-project/ubuntu2004:v13"
-            OPTIONS: -DALGEBRA_PLUGINS_INCLUDE_EIGEN=TRUE -DALGEBRA_PLUGINS_SETUP_EIGEN3=TRUE -DALGEBRA_PLUGINS_USE_SYSTEM_EIGEN3=FALSE
+            CONTAINER: "ghcr.io/acts-project/ubuntu2004:v43"
+            OPTIONS: --preset eigen
           - NAME: "HOST"
-            CONTAINER: "ghcr.io/acts-project/ubuntu2004:v13"
+            CONTAINER: "ghcr.io/acts-project/ubuntu2004:v43"
             OPTIONS: -DALGEBRA_PLUGINS_INCLUDE_SMATRIX=TRUE
           - NAME: "HOST"
-            CONTAINER: "ghcr.io/acts-project/ubuntu2004:v13"
-            OPTIONS: -DALGEBRA_PLUGINS_INCLUDE_VC=TRUE -DALGEBRA_PLUGINS_SETUP_VC=TRUE -DALGEBRA_PLUGINS_USE_SYSTEM_VC=FALSE
+            CONTAINER: "ghcr.io/acts-project/ubuntu2004:v43"
+            OPTIONS: --preset vc
           - NAME: "HOST"
-            CONTAINER: "ghcr.io/acts-project/ubuntu2004:v13"
-            OPTIONS: -DALGEBRA_PLUGINS_INCLUDE_VECMEM=TRUE -DALGEBRA_PLUGINS_SETUP_VECMEM=TRUE -DALGEBRA_PLUGINS_USE_SYSTEM_VECMEM=FALSE
+            CONTAINER: "ghcr.io/acts-project/ubuntu2004:v43"
+            OPTIONS: --preset vecmem
+          - NAME: "HOST"
+            CONTAINER: "ghcr.io/acts-project/ubuntu2004:v43"
+            OPTIONS: --preset fastor
           - NAME: "CUDA"
-            CONTAINER: "ghcr.io/acts-project/ubuntu2004_cuda:v13"
-            OPTIONS: -DALGEBRA_PLUGINS_TEST_CUDA=TRUE -DALGEBRA_PLUGINS_INCLUDE_EIGEN=TRUE -DALGEBRA_PLUGINS_SETUP_EIGEN3=TRUE -DALGEBRA_PLUGINS_USE_SYSTEM_EIGEN3=FALSE -DALGEBRA_PLUGINS_INCLUDE_VECMEM=TRUE -DALGEBRA_PLUGINS_SETUP_VECMEM=TRUE -DALGEBRA_PLUGINS_USE_SYSTEM_VECMEM=FALSE
+            CONTAINER: "ghcr.io/acts-project/ubuntu2004_cuda:v43"
+            OPTIONS: --preset cuda
           - NAME: "SYCL"
-            CONTAINER: "ghcr.io/acts-project/ubuntu2004_oneapi:v13"
-            OPTIONS: -DALGEBRA_PLUGINS_TEST_SYCL=TRUE -DALGEBRA_PLUGINS_INCLUDE_EIGEN=TRUE -DALGEBRA_PLUGINS_SETUP_EIGEN3=TRUE -DALGEBRA_PLUGINS_USE_SYSTEM_EIGEN3=FALSE -DALGEBRA_PLUGINS_INCLUDE_VECMEM=TRUE -DALGEBRA_PLUGINS_SETUP_VECMEM=TRUE -DALGEBRA_PLUGINS_USE_SYSTEM_VECMEM=FALSE
+            CONTAINER: "ghcr.io/acts-project/ubuntu2004_oneapi:v43"
+            OPTIONS: --preset sycl
 
     # The system to run on.
     runs-on: ubuntu-latest
@@ -113,7 +102,7 @@ jobs:
     - name: Configure
       run: |
         source ${GITHUB_WORKSPACE}/.github/ci_setup.sh ${{ matrix.PLATFORM.NAME }}
-        cmake -DCMAKE_BUILD_TYPE=${{ matrix.BUILD_TYPE }} ${{ matrix.PLATFORM.OPTIONS }} -DALGEBRA_PLUGINS_BUILD_BENCHMARKS=TRUE -DALGEBRA_PLUGINS_FAIL_ON_WARNINGS=TRUE -S ${GITHUB_WORKSPACE} -B build
+        cmake ${{ matrix.PLATFORM.OPTIONS }} -DCMAKE_BUILD_TYPE=${{ matrix.BUILD_TYPE }} -S ${GITHUB_WORKSPACE} -B build
     # Perform the build.
     - name: Build
       run: |

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,76 @@
+{
+   "version" : 3,
+   "configurePresets": [
+      {
+         "name" : "base",
+         "displayName" : "Base Configuration",
+         "warnings": {
+            "deprecated": true
+         },
+         "cacheVariables": {
+            "CMAKE_BUILD_TYPE"                 : "RelWithDebInfo",
+            "ALGEBRA_PLUGINS_BUILD_TESTING"    : "TRUE",
+            "ALGEBRA_PLUGINS_BUILD_BENCHMARKS" : "TRUE",
+            "ALGEBRA_PLUGINS_FAIL_ON_WARNINGS" : "TRUE",
+            "ALGEBRA_PLUGINS_USE_SYSTEM_LIBS"  : "FALSE"
+         }
+      },
+      {
+         "name" : "vecmem",
+         "displayName" : "VecMem Enabled Configuration",
+         "inherits" : [ "base" ],
+         "cacheVariables": {
+            "ALGEBRA_PLUGINS_SETUP_VECMEM"   : "TRUE",
+            "ALGEBRA_PLUGINS_INCLUDE_VECMEM" : "TRUE"
+         }
+      },
+      {
+         "name" : "eigen",
+         "displayName" : "Eigen Enabled Configuration",
+         "inherits" : [ "base" ],
+         "cacheVariables": {
+            "ALGEBRA_PLUGINS_SETUP_EIGEN3"  : "TRUE",
+            "ALGEBRA_PLUGINS_INCLUDE_EIGEN" : "TRUE"
+         }
+      },
+      {
+         "name" : "vc",
+         "displayName" : "Vc Enabled Configuration",
+         "inherits" : [ "base" ],
+         "cacheVariables": {
+            "ALGEBRA_PLUGINS_SETUP_VC"   : "TRUE",
+            "ALGEBRA_PLUGINS_INCLUDE_VC" : "TRUE"
+         }
+      },
+      {
+         "name" : "fastor",
+         "displayName" : "Fastor Enabled Configuration",
+         "inherits" : [ "base" ],
+         "cacheVariables": {
+            "ALGEBRA_PLUGINS_SETUP_FASTOR"   : "TRUE",
+            "ALGEBRA_PLUGINS_INCLUDE_FASTOR" : "TRUE"
+         }
+      },
+      {
+         "name" : "default",
+         "displayName" : "Default Developer Configuration",
+         "inherits" : [ "vecmem", "eigen", "vc", "fastor" ]
+      },
+      {
+         "name" : "cuda",
+         "displayName" : "CUDA Developer Configuration",
+         "inherits" : [ "vecmem", "eigen" ],
+         "cacheVariables" : {
+            "ALGEBRA_PLUGINS_TEST_CUDA" : "TRUE"
+         }
+      },
+      {
+         "name" : "sycl",
+         "displayName" : "SYCL Developer Configuration",
+         "inherits" : [ "vecmem", "eigen" ],
+         "cacheVariables" : {
+            "ALGEBRA_PLUGINS_TEST_SYCL" : "TRUE"
+         }
+      }
+   ]
+}


### PR DESCRIPTION
Add a `CMakePresets.json` file to the repository. And also updated the CI to make use of it, simplifying the latter a little.

Presets are described here:

https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html

I've been thinking for a long time about adopting them in our projects to simplify builds a little bit. Since especially in this project (as @niermann999 has also rightfully complained in the past) we need to use an unreasonable number of CMake CACHE variables to specify exactly what type of build we want. With this setup the idea is that we could do:

```
cmake --preset default ../algebra-plugins/
```

Or:

```
cmake --preset cuda ../algebra-plugins/
```

Etc.

Note that it's very possible to use CACHE variable declarations together with the presets. Like:

```
cmake --preset default -DALGEBRA_PLUGINS_INCLUDE_SMATRIX=TRUE ../algebra-plugins/
```

I had to update the CI's Docker image versions, as the ones currently in use do not have a new enough version of CMake for this functionality. But as you can see, the new SYCL image triggers a numerical difference in some tests. :confused: So that will need to be sorted out before this could be merged in. :thinking:

P.S. I also added a previously missing "separate" Fastor test.