### PR TITLE
Silence Eigen Warnings From CUDA on Windows, main branch (2023.10.09.)

### DIFF
--- a/math/eigen/include/algebra/math/impl/eigen_getter.hpp
+++ b/math/eigen/include/algebra/math/impl/eigen_getter.hpp
@@ -15,10 +15,17 @@
 #ifdef _MSC_VER
 #pragma warning(push, 0)
 #endif  // MSVC
+#ifdef __NVCC_DIAG_PRAGMA_SUPPORT__
+#pragma nv_diagnostic push
+#pragma nv_diag_suppress 20012
+#endif  // __NVCC_DIAG_PRAGMA_SUPPORT__
 #include <Eigen/Core>
 #ifdef _MSC_VER
 #pragma warning(pop)
 #endif  // MSVC
+#ifdef __NVCC_DIAG_PRAGMA_SUPPORT__
+#pragma nv_diagnostic pop
+#endif  // __NVCC_DIAG_PRAGMA_SUPPORT__
 
 // System include(s).
 #include <type_traits>

--- a/math/eigen/include/algebra/math/impl/eigen_matrix.hpp
+++ b/math/eigen/include/algebra/math/impl/eigen_matrix.hpp
@@ -15,10 +15,17 @@
 #ifdef _MSC_VER
 #pragma warning(push, 0)
 #endif  // MSVC
+#ifdef __NVCC_DIAG_PRAGMA_SUPPORT__
+#pragma nv_diagnostic push
+#pragma nv_diag_suppress 20012
+#endif  // __NVCC_DIAG_PRAGMA_SUPPORT__
 #include <Eigen/Core>
 #ifdef _MSC_VER
 #pragma warning(pop)
 #endif  // MSVC
+#ifdef __NVCC_DIAG_PRAGMA_SUPPORT__
+#pragma nv_diagnostic pop
+#endif  // __NVCC_DIAG_PRAGMA_SUPPORT__
 
 namespace algebra::eigen::matrix {
 

--- a/math/eigen/include/algebra/math/impl/eigen_transform3.hpp
+++ b/math/eigen/include/algebra/math/impl/eigen_transform3.hpp
@@ -1,6 +1,6 @@
 /** Algebra plugins library, part of the ACTS project
  *
- * (c) 2020-2022 CERN for the benefit of the ACTS project
+ * (c) 2020-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -14,11 +14,20 @@
 #ifdef _MSC_VER
 #pragma warning(push, 0)
 #endif  // MSVC
+#ifdef __NVCC_DIAG_PRAGMA_SUPPORT__
+#pragma nv_diagnostic push
+#pragma nv_diag_suppress 20011
+#pragma nv_diag_suppress 20012
+#pragma nv_diag_suppress 20014
+#endif  // __NVCC_DIAG_PRAGMA_SUPPORT__
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 #ifdef _MSC_VER
 #pragma warning(pop)
 #endif  // MSVC
+#ifdef __NVCC_DIAG_PRAGMA_SUPPORT__
+#pragma nv_diagnostic pop
+#endif  // __NVCC_DIAG_PRAGMA_SUPPORT__
 
 // System include(s).
 #include <type_traits>

--- a/math/eigen/include/algebra/math/impl/eigen_vector.hpp
+++ b/math/eigen/include/algebra/math/impl/eigen_vector.hpp
@@ -1,6 +1,6 @@
 /** Algebra plugins library, part of the ACTS project
  *
- * (c) 2020-2022 CERN for the benefit of the ACTS project
+ * (c) 2020-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -14,10 +14,17 @@
 #ifdef _MSC_VER
 #pragma warning(push, 0)
 #endif  // MSVC
+#ifdef __NVCC_DIAG_PRAGMA_SUPPORT__
+#pragma nv_diagnostic push
+#pragma nv_diag_suppress 20012
+#endif  // __NVCC_DIAG_PRAGMA_SUPPORT__
 #include <Eigen/Core>
 #ifdef _MSC_VER
 #pragma warning(pop)
 #endif  // MSVC
+#ifdef __NVCC_DIAG_PRAGMA_SUPPORT__
+#pragma nv_diagnostic pop
+#endif  // __NVCC_DIAG_PRAGMA_SUPPORT__
 
 namespace algebra::eigen::math {
 

--- a/storage/eigen/include/algebra/storage/impl/eigen_array.hpp
+++ b/storage/eigen/include/algebra/storage/impl/eigen_array.hpp
@@ -1,6 +1,6 @@
 /** Algebra plugins library, part of the ACTS project
  *
- * (c) 2020-2022 CERN for the benefit of the ACTS project
+ * (c) 2020-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -11,10 +11,17 @@
 #ifdef _MSC_VER
 #pragma warning(push, 0)
 #endif  // MSVC
+#ifdef __NVCC_DIAG_PRAGMA_SUPPORT__
+#pragma nv_diagnostic push
+#pragma nv_diag_suppress 20012
+#endif  // __NVCC_DIAG_PRAGMA_SUPPORT__
 #include <Eigen/Core>
 #ifdef _MSC_VER
 #pragma warning(pop)
 #endif  // MSVC
+#ifdef __NVCC_DIAG_PRAGMA_SUPPORT__
+#pragma nv_diagnostic pop
+#endif  // __NVCC_DIAG_PRAGMA_SUPPORT__
 
 // System include(s).
 #include <cstddef>


### PR DESCRIPTION
Turned off specific CUDA warnings for the Eigen headers.

This is only needed with MSVC, since "system include directories" as a concept doesn't quite work with that compiler. 😦 (On Linux we are shielded from these warnings by: https://github.com/acts-project/algebra-plugins/blob/main/extern/eigen3/CMakeLists.txt#L39-L44) So we need to explicitly turn off the checking for some warnings in the code like this.

@niermann999, you mentioned in https://github.com/acts-project/algebra-plugins/pull/95#issuecomment-1752741760 that you observe warnings yourself as well. Could you elaborate? Since I only know at this point why there would be warnings on Windows. But on Linux there should not have been any to begin with. 🤔

P.S. Note that the `master` branch of Eigen doesn't produce any warnings/errors with our code. But it's not clear when we should expect new releases out of those guys. 😦 See:
  - https://gitlab.com/libeigen/eigen/-/issues/2699
  - https://gitlab.com/libeigen/eigen/-/issues/2724
  - etc.