### PR TITLE
Add CMake Preset for ARM64, main branch (2023.10.14.)

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -40,7 +40,7 @@ jobs:
     - uses: actions/checkout@v2
     # Run the CMake configuration.
     - name: Configure
-      run: cmake --preset default
+      run: cmake --preset default-x86-64
                  -S ${{ github.workspace }} -B build
                  -G "${{ matrix.PLATFORM.GENERATOR }}"
     # Perform the build.

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -52,9 +52,14 @@
          }
       },
       {
-         "name" : "default",
-         "displayName" : "Default Developer Configuration",
+         "name" : "default-x86-64",
+         "displayName" : "Default Developer Configuration for x86_64",
          "inherits" : [ "vecmem", "eigen", "vc", "fastor" ]
+      },
+      {
+         "name" : "default-aarch64",
+         "displayName" : "Default Developer Configuration for ARM64",
+         "inherits" : [ "vecmem", "eigen", "vc" ]
       },
       {
          "name" : "cuda",

--- a/extern/fastor/CMakeLists.txt
+++ b/extern/fastor/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Algebra plugins library, part of the ACTS project (R&D line)
 #
-# (c) 2022 CERN for the benefit of the ACTS project
+# (c) 2022-2023 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -10,6 +10,11 @@ include( FetchContent )
 
 # Tell the user what's happening.
 message( STATUS "Building Fastor as part of the Algebra Plugins project" )
+
+# Warn the user, if they are not on an x86 platform.
+if( NOT "${CMAKE_SYSTEM_PROCESSOR}" MATCHES "x86_64" )
+   message( WARNING "Fastor is only supported on the x86 platforms" )
+endif()
 
 # Declare where to get Fastor from.
 # We need to use this alternative syntax for FetchContent_Declare because the
@@ -40,8 +45,8 @@ endif()
 
 # Treat the Fastor headers as "system headers", to avoid getting warnings from
 # them.
-get_target_property( _incDirs Fastor INTERFACE_INCLUDE_DIRECTORIES ) 
-target_include_directories( Fastor  
+get_target_property( _incDirs Fastor INTERFACE_INCLUDE_DIRECTORIES )
+target_include_directories( Fastor
    SYSTEM INTERFACE ${_incDirs} )
 unset( _incDirs )
 


### PR DESCRIPTION
Added a separate default configuration for the `aarch64` platform. Since as it turns out, Fastor does not work on non-x86 platforms. (Like my M1 Mac.) So provided a configuration preset without Fastor for `aarch64`.

Note that interestingly the GitHub runners seem to **not** use ARM Mac-s. 😕 Since those build succeeded so far, and I also don't see

```
-- Building Vc as part of the Algebra Plugins project
-- Detected Compiler: Clang 15.0.0
CMake Warning at /Users/krasznaa/ATLAS/projects/algebra/build/_deps/vc-src/CMakeLists.txt:34 (message):
  No optimized implementation of the Vc types available for arm64
```

in their configuration logs. 🤔

Also note that I'm very much getting the feeling that the CPU architecture may have something to do with your Mac troubles in #95 @niermann999, but I'll elaborate in that PR about that.