### PR TITLE
(Better) VSCode Build Support, main branch (2024.04.11.)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
+# Algebra plugins library, part of the ACTS project (R&D line)
+#
+# (c) 2021-2024 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
+
 # Prerequisites
 *.d
 
@@ -30,3 +36,6 @@
 *.exe
 *.out
 *.app
+
+# VSCode build directory.
+out/


### PR DESCRIPTION
Made git ignore the directory created by VSCode during its build (`out/`).

For some reason I forgot to add this back in #109 and #111. :confused: