### PR TITLE
VecMem (and CMake) Update, main branch (2024.04.11.)

### DIFF
--- a/cmake/algebra-plugins-compiler-options-sycl.cmake
+++ b/cmake/algebra-plugins-compiler-options-sycl.cmake
@@ -1,6 +1,6 @@
 # Algebra plugins library, part of the ACTS project (R&D line)
 #
-# (c) 2021-2023 CERN for the benefit of the ACTS project
+# (c) 2021-2024 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -8,30 +8,22 @@
 include( algebra-plugins-functions )
 
 # Basic flags for all build modes.
-foreach( mode RELEASE RELWITHDEBINFO MINSIZEREL DEBUG )
-   algebra_add_flag( CMAKE_SYCL_FLAGS_${mode} "-Wall" )
-   algebra_add_flag( CMAKE_SYCL_FLAGS_${mode} "-Wextra" )
-   algebra_add_flag( CMAKE_SYCL_FLAGS_${mode} "-Wno-unknown-cuda-version" )
-   algebra_add_flag( CMAKE_SYCL_FLAGS_${mode} "-Wshadow" )
-   algebra_add_flag( CMAKE_SYCL_FLAGS_${mode} "-Wunused-local-typedefs" )
-endforeach()
+algebra_add_flag( CMAKE_SYCL_FLAGS "-Wall" )
+algebra_add_flag( CMAKE_SYCL_FLAGS "-Wextra" )
+algebra_add_flag( CMAKE_SYCL_FLAGS "-Wno-unknown-cuda-version" )
+algebra_add_flag( CMAKE_SYCL_FLAGS "-Wshadow" )
+algebra_add_flag( CMAKE_SYCL_FLAGS "-Wunused-local-typedefs" )
 if( NOT WIN32 )
-   foreach( mode RELEASE RELWITHDEBINFO MINSIZEREL DEBUG )
-      algebra_add_flag( CMAKE_SYCL_FLAGS_${mode} "-pedantic" )
-   endforeach()
+   algebra_add_flag( CMAKE_SYCL_FLAGS "-pedantic" )
 endif()
 
 # Avoid issues coming from MSVC<->DPC++ argument differences.
 if( "${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC" )
-   foreach( mode RELEASE RELWITHDEBINFO MINSIZEREL DEBUG )
-      algebra_add_flag( CMAKE_SYCL_FLAGS_${mode}
-         "-Wno-unused-command-line-argument" )
-   endforeach()
+   algebra_add_flag( CMAKE_SYCL_FLAGS
+      "-Wno-unused-command-line-argument" )
 endif()
 
 # Fail on warnings, if asked for that behaviour.
 if( ALGEBRA_PLUGINS_FAIL_ON_WARNINGS )
-   foreach( mode RELEASE RELWITHDEBINFO MINSIZEREL DEBUG )
-      algebra_add_flag( CMAKE_SYCL_FLAGS_${mode} "-Werror" )
-   endforeach()
+   algebra_add_flag( CMAKE_SYCL_FLAGS "-Werror" )
 endif()

--- a/extern/vecmem/CMakeLists.txt
+++ b/extern/vecmem/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Algebra plugins library, part of the ACTS project (R&D line)
 #
-# (c) 2021-2023 CERN for the benefit of the ACTS project
+# (c) 2021-2024 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -13,7 +13,7 @@ message( STATUS "Building VecMem as part of the Algebra Plugins project" )
 
 # Declare where to get VecMem from.
 set( ALGEBRA_PLUGINS_VECMEM_SOURCE
-   "URL;https://github.com/acts-project/vecmem/archive/refs/tags/v0.27.0.tar.gz;URL_MD5;cd1520efbd46d5d09ac5727452939ede"
+   "URL;https://github.com/acts-project/vecmem/archive/refs/tags/v1.5.0.tar.gz;URL_MD5;3cc5a3bb14b93f611513535173a6be28"
    CACHE STRING "Source for VecMem, when built as part of this project" )
 mark_as_advanced( ALGEBRA_PLUGINS_VECMEM_SOURCE )
 FetchContent_Declare( VecMem ${ALGEBRA_PLUGINS_VECMEM_SOURCE} )


### PR DESCRIPTION
Updated the project to [VecMem 1.4.0](https://github.com/acts-project/vecmem/releases/tag/v1.4.0).

At the same time simplified the SYCL build flag configuration of the project a bit, which the new VecMem version allows to do. :wink: