### PR TITLE
oneAPI 2024.1.0 Support, main branch (2024.04.11.)

### DIFF
--- a/math/cmath/include/algebra/math/algorithms/matrix/decomposition/partial_pivot_lud.hpp
+++ b/math/cmath/include/algebra/math/algorithms/matrix/decomposition/partial_pivot_lud.hpp
@@ -1,6 +1,6 @@
 /** Algebra plugins library, part of the ACTS project
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -8,6 +8,7 @@
 #pragma once
 
 // Project include(s).
+#include "algebra/math/common.hpp"
 #include "algebra/qualifiers.hpp"
 
 // System include(s).
@@ -74,7 +75,7 @@ struct partial_pivot_lud {
       max_idx = i;
 
       for (size_type k = i; k < N; k++) {
-        abs_val = std::abs(element_getter()(lu, k, i));
+        abs_val = math::fabs(element_getter()(lu, k, i));
 
         if (abs_val > max_val) {
 

--- a/math/common/include/algebra/math/common.hpp
+++ b/math/common/include/algebra/math/common.hpp
@@ -1,6 +1,6 @@
 /** Algebra plugins library, part of the ACTS project
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -26,6 +26,12 @@ namespace math_ns = cl::sycl;
 #else
 namespace math_ns = std;
 #endif  // SYCL
+
+/// Absolute value of arg
+template <typename scalar_t>
+ALGEBRA_HOST_DEVICE inline scalar_t fabs(scalar_t arg) {
+  return math_ns::fabs(arg);
+}
 
 /// Arc tangent of y/x
 template <typename scalar_t>


### PR DESCRIPTION
As one might guess, #113 and #114 were just collateral updates for this PR. :stuck_out_tongue:

With [oneAPI 2024.1.0](https://www.intel.com/content/www/us/en/developer/articles/release-notes/intel-oneapi-dpc-c-compiler-release-notes.html) Intel switched to enforcing [SYCL 2020](https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html) rules more strictly than it did earlier. And as it turns out, using [std::abs](https://en.cppreference.com/w/cpp/numeric/math/fabs) with floating point numbers is no longer okay in SYCL device code. :thinking: Leading to the following, very non-descriptive linker error:

```
[build] ptxas fatal   : Unresolved extern function 'fabs'
[build] llvm-foreach: 
[build] ptxas fatal   : Unresolved extern function 'fabsf'
[build] llvm-foreach: 
[build] clang++: error: ptxas command failed with exit code 255 (use -v to see invocation)
[build] Intel(R) oneAPI DPC++/C++ Compiler 2024.1.0 (2024.1.0.20240308)
[build] Target: x86_64-unknown-linux-gnu
[build] Thread model: posix
[build] InstalledDir: /software/intel/oneapi-2024.1.0/compiler/2024.1/bin/compiler
[build] clang++: note: diagnostic msg: Error generating preprocessed source(s).
[build] gmake[2]: *** [tests/accelerator/sycl/CMakeFiles/algebra_test_vecmem_sycl.dir/build.make:93: bin/algebra_test_vecmem_sycl] Error 1
[build] gmake[1]: *** [CMakeFiles/Makefile2:14540: tests/accelerator/sycl/CMakeFiles/algebra_test_vecmem_sycl.dir/all] Error 2
```

Switching to `sycl::fabs` solves the issue.

Note that one must not even use `sycl::abs` on floating point numbers. :confused: So I'll have some further fixes to do in the higher level projects as well... :thinking: