### PR TITLE
Vectorize the cmath matrix operations

### DIFF
--- a/math/cmath/include/algebra/math/impl/cmath_matrix.hpp
+++ b/math/cmath/include/algebra/math/impl/cmath_matrix.hpp
@@ -69,8 +69,8 @@ struct actor {
   ALGEBRA_HOST_DEVICE void set_block(input_matrix_type &m,
                                      const matrix_type<ROWS, COLS> &b,
                                      size_type row, size_type col) const {
-    for (size_type i = 0; i < ROWS; ++i) {
-      for (size_type j = 0; j < COLS; ++j) {
+    for (size_type j = 0; j < COLS; ++j) {
+      for (size_type i = 0; i < ROWS; ++i) {
         element_getter()(m, i + row, j + col) = element_getter()(b, i, j);
       }
     }
@@ -92,8 +92,8 @@ struct actor {
   ALGEBRA_HOST_DEVICE inline matrix_type<ROWS, COLS> zero() const {
     matrix_type<ROWS, COLS> ret;
 
-    for (size_type i = 0; i < ROWS; ++i) {
-      for (size_type j = 0; j < COLS; ++j) {
+    for (size_type j = 0; j < COLS; ++j) {
+      for (size_type i = 0; i < ROWS; ++i) {
         element_getter()(ret, i, j) = 0;
       }
     }
@@ -106,8 +106,8 @@ struct actor {
   ALGEBRA_HOST_DEVICE inline matrix_type<ROWS, COLS> identity() const {
     matrix_type<ROWS, COLS> ret;
 
-    for (size_type i = 0; i < ROWS; ++i) {
-      for (size_type j = 0; j < COLS; ++j) {
+    for (size_type j = 0; j < COLS; ++j) {
+      for (size_type i = 0; i < ROWS; ++i) {
         if (i == j) {
           element_getter()(ret, i, j) = 1;
         } else {
@@ -123,8 +123,8 @@ struct actor {
   template <size_type ROWS, size_type COLS>
   ALGEBRA_HOST_DEVICE inline void set_zero(matrix_type<ROWS, COLS> &m) const {
 
-    for (size_type i = 0; i < ROWS; ++i) {
-      for (size_type j = 0; j < COLS; ++j) {
+    for (size_type j = 0; j < COLS; ++j) {
+      for (size_type i = 0; i < ROWS; ++i) {
         element_getter()(m, i, j) = 0;
       }
     }
@@ -135,8 +135,8 @@ struct actor {
   ALGEBRA_HOST_DEVICE inline void set_identity(
       matrix_type<ROWS, COLS> &m) const {
 
-    for (size_type i = 0; i < ROWS; ++i) {
-      for (size_type j = 0; j < COLS; ++j) {
+    for (size_type j = 0; j < COLS; ++j) {
+      for (size_type i = 0; i < ROWS; ++i) {
         if (i == j) {
           element_getter()(m, i, j) = 1;
         } else {

--- a/math/cmath/include/algebra/math/impl/cmath_operators.hpp
+++ b/math/cmath/include/algebra/math/impl/cmath_operators.hpp
@@ -137,8 +137,8 @@ ALGEBRA_HOST_DEVICE inline array_t<array_t<scalar_t, ROWS>, COLS> operator*(
 
   array_t<array_t<scalar_t, ROWS>, COLS> ret;
 
-  for (size_type i = 0; i < ROWS; ++i) {
-    for (size_type j = 0; j < COLS; ++j) {
+  for (size_type j = 0; j < COLS; ++j) {
+    for (size_type i = 0; i < ROWS; ++i) {
       ret[j][i] = a[j][i] * static_cast<scalar_t>(s);
     }
   }
@@ -154,8 +154,8 @@ ALGEBRA_HOST_DEVICE inline array_t<array_t<scalar_t, ROWS>, COLS> operator*(
 
   array_t<array_t<scalar_t, ROWS>, COLS> ret;
 
-  for (size_type i = 0; i < ROWS; ++i) {
-    for (size_type j = 0; j < COLS; ++j) {
+  for (size_type j = 0; j < COLS; ++j) {
+    for (size_type i = 0; i < ROWS; ++i) {
       ret[j][i] = a[j][i] * static_cast<scalar_t>(s);
     }
   }
@@ -171,8 +171,8 @@ ALGEBRA_HOST_DEVICE inline array_t<array_t<scalar_t, ROWS>, COLS> operator*(
 
   array_t<array_t<scalar_t, ROWS>, COLS> ret;
 
-  for (size_type i = 0; i < ROWS; ++i) {
-    for (size_type j = 0; j < COLS; ++j) {
+  for (size_type j = 0; j < COLS; ++j) {
+    for (size_type i = 0; i < ROWS; ++i) {
       ret[j][i] = a[j][i] * static_cast<scalar_t>(s);
     }
   }
@@ -188,8 +188,8 @@ ALGEBRA_HOST_DEVICE inline array_t<array_t<scalar_t, ROWS>, COLS> operator*(
 
   array_t<array_t<scalar_t, ROWS>, COLS> ret;
 
-  for (size_type i = 0; i < ROWS; ++i) {
-    for (size_type j = 0; j < COLS; ++j) {
+  for (size_type j = 0; j < COLS; ++j) {
+    for (size_type i = 0; i < ROWS; ++i) {
       ret[j][i] = a[j][i] * static_cast<scalar_t>(s);
     }
   }
@@ -206,16 +206,17 @@ ALGEBRA_HOST_DEVICE inline array_t<array_t<scalar_t, M>, O> operator*(
 
   array_t<array_t<scalar_t, M>, O> C;
 
-  for (size_type i = 0; i < M; ++i) {
+  for (size_type j = 0; j < O; ++j) {
+    for (size_type i = 0; i < M; ++i) {
+      C[j][i] = 0.f;
+    }
+  }
+
+  for (size_type i = 0; i < N; ++i) {
     for (size_type j = 0; j < O; ++j) {
-
-      scalar_t val = 0;
-
-      for (size_type k = 0; k < N; ++k) {
-        val += A[k][i] * B[j][k];
+      for (size_type k = 0; k < M; ++k) {
+        C[j][k] += A[i][k] * B[j][i];
       }
-
-      C[j][i] = val;
     }
   }
 
@@ -231,8 +232,8 @@ ALGEBRA_HOST_DEVICE inline array_t<array_t<scalar_t, ROWS>, COLS> operator+(
 
   array_t<array_t<scalar_t, ROWS>, COLS> C;
 
-  for (size_type i = 0; i < ROWS; ++i) {
-    for (size_type j = 0; j < COLS; ++j) {
+  for (size_type j = 0; j < COLS; ++j) {
+    for (size_type i = 0; i < ROWS; ++i) {
       C[j][i] = A[j][i] + B[j][i];
     }
   }
@@ -249,8 +250,8 @@ ALGEBRA_HOST_DEVICE inline array_t<array_t<scalar_t, ROWS>, COLS> operator-(
 
   array_t<array_t<scalar_t, ROWS>, COLS> C;
 
-  for (size_type i = 0; i < ROWS; ++i) {
-    for (size_type j = 0; j < COLS; ++j) {
+  for (size_type j = 0; j < COLS; ++j) {
+    for (size_type i = 0; i < ROWS; ++i) {
       C[j][i] = A[j][i] - B[j][i];
     }
   }
@@ -272,8 +273,8 @@ ALGEBRA_HOST_DEVICE inline array_t<scalar_t, ROWS> operator*(
 
   array_t<scalar_t, ROWS> ret{0};
 
-  for (size_type i = 0; i < ROWS; ++i) {
-    for (size_type j = 0; j < COLS; ++j) {
+  for (size_type j = 0; j < COLS; ++j) {
+    for (size_type i = 0; i < ROWS; ++i) {
       ret[i] += a[j][i] * b[j];
     }
   }

--- a/tests/common/test_host_basics.hpp
+++ b/tests/common/test_host_basics.hpp
@@ -226,6 +226,22 @@ TYPED_TEST_P(test_host_basics, matrix64) {
   ASSERT_NEAR(algebra::getter::element(m, 0, 2), 10., this->m_epsilon);
   ASSERT_NEAR(algebra::getter::element(m, 1, 2), 20., this->m_epsilon);
   ASSERT_NEAR(algebra::getter::element(m, 2, 2), 30., this->m_epsilon);
+
+  typename TypeParam::template matrix<3, 3> m33;
+  algebra::getter::element(m33, 0, 0) = 1;
+  algebra::getter::element(m33, 1, 0) = 2;
+  algebra::getter::element(m33, 2, 0) = 3;
+  algebra::getter::element(m33, 0, 1) = 5;
+  algebra::getter::element(m33, 1, 1) = 6;
+  algebra::getter::element(m33, 2, 1) = 7;
+  algebra::getter::element(m33, 0, 2) = 9;
+  algebra::getter::element(m33, 1, 2) = 10;
+  algebra::getter::element(m33, 2, 2) = 11;
+
+  const typename TypeParam::vector3 v2 = m33 * v;
+  ASSERT_NEAR(v2[0], 380., this->m_epsilon);
+  ASSERT_NEAR(v2[1], 440., this->m_epsilon);
+  ASSERT_NEAR(v2[2], 500., this->m_epsilon);
 }
 
 // Test matrix operations with 3x3 matrix


### PR DESCRIPTION
Free lunch time

## What's changed?

Just to help understanding what's going on with new matrix multiplication.

It should be noted that the cmath matrix is made of multiple arrays where each of them represents each **column** of matrix. 
Imagine that we do multiply 4x4 matrix **A** and **B** to obtain the matrix **C**. If we do the matrix multiplication as we usually do like the following figure, we will have to pick up the row of **A** which cannot be vectorized:

![image](https://github.com/acts-project/algebra-plugins/assets/63090140/ce72df7e-496f-492a-b53c-0745e1a1001a)

So I came up with an idea to do the matrix multiplication column-wisely by multiplying a column of **A** to the element of **B**:

```c++
     for (size_type k = 0; k < M; ++k) {
        C[j][k] += A[i][k] * B[j][i];
      }
```

The following figure shows how the column of **C** is calculated in the new matrix multiplication

![image](https://github.com/acts-project/algebra-plugins/assets/63090140/c7346611-84f7-4751-997c-dbc89bcbe825)
