### PR TITLE
Include external libraries as system libraries

### DIFF
--- a/extern/benchmark/CMakeLists.txt
+++ b/extern/benchmark/CMakeLists.txt
@@ -16,7 +16,16 @@ set( ALGEBRA_PLUGINS_BENCHMARK_SOURCE
    "URL;https://github.com/google/benchmark/archive/refs/tags/v1.6.1.tar.gz;URL_MD5;8c33c51f9b7154e6c290df3750081c87"
    CACHE STRING "Source for Google Benchmark, when built as part of this project" )
 mark_as_advanced( ALGEBRA_PLUGINS_BENCHMARK_SOURCE )
-FetchContent_Declare( benchmark ${ALGEBRA_PLUGINS_BENCHMARK_SOURCE} )
+
+# Mark the import as a system library on modern CMake versions
+if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.25.0)
+   set(ALGEBRA_PLUGINS_BENCHMARK_SOURCE_FULL "${ALGEBRA_PLUGINS_BENCHMARK_SOURCE};SYSTEM")
+else()
+   set(ALGEBRA_PLUGINS_BENCHMARK_SOURCE_FULL "${ALGEBRA_PLUGINS_BENCHMARK_SOURCE}")
+endif()
+mark_as_advanced( ALGEBRA_PLUGINS_BENCHMARK_SOURCE_FULL )
+
+FetchContent_Declare( benchmark ${ALGEBRA_PLUGINS_BENCHMARK_SOURCE_FULL} )
 
 # Options used in the build of Google Benchmark.
 set(BENCHMARK_ENABLE_TESTING OFF CACHE BOOL "Don't build the Google Benchmark tests")
@@ -29,4 +38,3 @@ set(BENCHMARK_ENABLE_WERROR OFF CACHE BOOL "Enable/disable using -Werror in the 
 FetchContent_Populate( benchmark )
 add_subdirectory( "${benchmark_SOURCE_DIR}" "${benchmark_BINARY_DIR}"
    EXCLUDE_FROM_ALL )
-

--- a/extern/eigen3/CMakeLists.txt
+++ b/extern/eigen3/CMakeLists.txt
@@ -16,7 +16,16 @@ set( ALGEBRA_PLUGINS_EIGEN_SOURCE
    "URL;https://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-3.4.0.tar.bz2;URL_MD5;132dde48fe2b563211675626d29f1707"
    CACHE STRING "Source for Eigen, when built as part of this project" )
 mark_as_advanced( ALGEBRA_PLUGINS_EIGEN_SOURCE )
-FetchContent_Declare( Eigen3 ${ALGEBRA_PLUGINS_EIGEN_SOURCE} )
+
+# Mark the import as a system library on modern CMake versions
+if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.25.0)
+   set(ALGEBRA_PLUGINS_EIGEN_SOURCE_FULL "${ALGEBRA_PLUGINS_EIGEN_SOURCE};SYSTEM")
+else()
+   set(ALGEBRA_PLUGINS_EIGEN_SOURCE_FULL "${ALGEBRA_PLUGINS_EIGEN_SOURCE}")
+endif()
+mark_as_advanced( ALGEBRA_PLUGINS_EIGEN_SOURCE_FULL )
+
+FetchContent_Declare( Eigen3 ${ALGEBRA_PLUGINS_EIGEN_SOURCE_FULL} )
 
 # Turn off the unit tests for Eigen3.
 if( DEFINED CACHE{BUILD_TESTING} )

--- a/extern/fastor/CMakeLists.txt
+++ b/extern/fastor/CMakeLists.txt
@@ -23,7 +23,16 @@ set( ALGEBRA_PLUGINS_FASTOR_SOURCE
    "fastor;GIT_REPOSITORY;https://github.com/romeric/Fastor.git;GIT_TAG;e96e63fe8a05898d732d0b9faba3667d9a25a38f"
    CACHE STRING "Source for Fastor, when built as part of this project" )
 mark_as_advanced( ALGEBRA_PLUGINS_FASTOR_SOURCE )
-FetchContent_Declare( fastor ${ALGEBRA_PLUGINS_FASTOR_SOURCE} )
+
+# Mark the import as a system library on modern CMake versions
+if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.25.0)
+   set(ALGEBRA_PLUGINS_FASTOR_SOURCE_FULL "${ALGEBRA_PLUGINS_FASTOR_SOURCE};SYSTEM")
+else()
+   set(ALGEBRA_PLUGINS_FASTOR_SOURCE_FULL "${ALGEBRA_PLUGINS_FASTOR_SOURCE}")
+endif()
+mark_as_advanced( ALGEBRA_PLUGINS_FASTOR_SOURCE_FULL )
+
+FetchContent_Declare( fastor ${ALGEBRA_PLUGINS_FASTOR_SOURCE_FULL} )
 
 # Turn off the unit tests for Fastor.
 if( DEFINED CACHE{BUILD_TESTING} )

--- a/extern/googletest/CMakeLists.txt
+++ b/extern/googletest/CMakeLists.txt
@@ -16,7 +16,16 @@ set( ALGEBRA_PLUGINS_GOOGLETEST_SOURCE
    "URL;https://github.com/google/googletest/archive/refs/tags/v1.14.0.tar.gz;URL_MD5;c8340a482851ef6a3fe618a082304cfc"
    CACHE STRING "Source for GoogleTest, when built as part of this project" )
 mark_as_advanced( ALGEBRA_PLUGINS_GOOGLETEST_SOURCE )
-FetchContent_Declare( GoogleTest ${ALGEBRA_PLUGINS_GOOGLETEST_SOURCE} )
+
+# Mark the import as a system library on modern CMake versions
+if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.25.0)
+   set(ALGEBRA_PLUGINS_GOOGLETEST_SOURCE_FULL "${ALGEBRA_PLUGINS_GOOGLETEST_SOURCE};SYSTEM")
+else()
+   set(ALGEBRA_PLUGINS_GOOGLETEST_SOURCE_FULL "${ALGEBRA_PLUGINS_GOOGLETEST_SOURCE}")
+endif()
+mark_as_advanced( ALGEBRA_PLUGINS_GOOGLETEST_SOURCE_FULL )
+
+FetchContent_Declare( GoogleTest ${ALGEBRA_PLUGINS_GOOGLETEST_SOURCE_FULL} )
 
 # Options used in the build of GoogleTest.
 set( BUILD_GMOCK TRUE CACHE BOOL "Turn off the build of GMock" )

--- a/extern/vc/CMakeLists.txt
+++ b/extern/vc/CMakeLists.txt
@@ -16,7 +16,16 @@ set( ALGEBRA_PLUGINS_VC_SOURCE
    "URL;https://github.com/VcDevel/Vc/archive/refs/tags/1.4.3.tar.gz;URL_MD5;02d33a9d560a14bb23204be235713f65"
    CACHE STRING "Source for Vc, when built as part of this project" )
 mark_as_advanced( ALGEBRA_PLUGINS_VC_SOURCE )
-FetchContent_Declare( Vc ${ALGEBRA_PLUGINS_VC_SOURCE} )
+
+# Mark the import as a system library on modern CMake versions
+if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.25.0)
+   set(ALGEBRA_PLUGINS_VC_SOURCE_FULL "${ALGEBRA_PLUGINS_VC_SOURCE};SYSTEM")
+else()
+   set(ALGEBRA_PLUGINS_VC_SOURCE_FULL "${ALGEBRA_PLUGINS_VC_SOURCE}")
+endif()
+mark_as_advanced( ALGEBRA_PLUGINS_VC_SOURCE_FULL )
+
+FetchContent_Declare( Vc ${ALGEBRA_PLUGINS_VC_SOURCE_FULL} )
 
 # Turn off the unit tests for Vc.
 if( DEFINED CACHE{BUILD_TESTING} )

--- a/extern/vecmem/CMakeLists.txt
+++ b/extern/vecmem/CMakeLists.txt
@@ -16,7 +16,16 @@ set( ALGEBRA_PLUGINS_VECMEM_SOURCE
    "URL;https://github.com/acts-project/vecmem/archive/refs/tags/v1.5.0.tar.gz;URL_MD5;3cc5a3bb14b93f611513535173a6be28"
    CACHE STRING "Source for VecMem, when built as part of this project" )
 mark_as_advanced( ALGEBRA_PLUGINS_VECMEM_SOURCE )
-FetchContent_Declare( VecMem ${ALGEBRA_PLUGINS_VECMEM_SOURCE} )
+
+# Mark the import as a system library on modern CMake versions
+if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.25.0)
+   set(ALGEBRA_PLUGINS_VECMEM_SOURCE_FULL "${ALGEBRA_PLUGINS_VECMEM_SOURCE};SYSTEM")
+else()
+   set(ALGEBRA_PLUGINS_VECMEM_SOURCE_FULL "${ALGEBRA_PLUGINS_VECMEM_SOURCE}")
+endif()
+mark_as_advanced( ALGEBRA_PLUGINS_VECMEM_SOURCE_FULL )
+
+FetchContent_Declare( VecMem ${ALGEBRA_PLUGINS_VECMEM_SOURCE_FULL} )
 
 # Options used in the build of VecMem.
 set( VECMEM_BUILD_TESTING FALSE CACHE BOOL


### PR DESCRIPTION
The Vc library in particular is throwing a lot of warnings in the compilation of algebra-plugins and, in turn, in detray and traccc. This commit marks all of algebra-plugins' dependencies as system dependencies if allowed by CMake (i.e. on CMake 3.25 and later) to avoid the warnings.