### PR TITLE
Disable Fastor in macOS CI job

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -41,6 +41,7 @@ jobs:
     # Run the CMake configuration.
     - name: Configure
       run: cmake --preset default-x86-64
+                 -DALGEBRA_PLUGINS_INCLUDE_FASTOR=${{ (matrix.PLATFORM.OS == 'macos-latest') && 'OFF' || 'ON' }}
                  -S ${{ github.workspace }} -B build
                  -G "${{ matrix.PLATFORM.GENERATOR }}"
     # Perform the build.


### PR DESCRIPTION
XCode refuses to compile algebra-plugins with the Fastor plugin turned on, and this is causing the CI to fail. This commit disables Fastor in the macOS CI job to ensure that it runs through.