### PR TITLE
ref: Adapt to client interface and allow to compile multiple plugins side by side

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,9 +170,10 @@ endif()
 
 # Set up the Algebra Plugin libraries.
 add_subdirectory( common )
-add_subdirectory( storage )
-add_subdirectory( math )
 add_subdirectory( frontend )
+add_subdirectory( math )
+add_subdirectory( storage )
+add_subdirectory( utils )
 
 # Set up the test(s).
 if( BUILD_TESTING AND ALGEBRA_PLUGINS_BUILD_TESTING )

--- a/benchmarks/array/include/benchmark/array/data_generator.hpp
+++ b/benchmarks/array/include/benchmark/array/data_generator.hpp
@@ -46,7 +46,9 @@ inline void fill_random_trf(std::vector<transform3_t> &collection) {
                                                                           1.f);
 
   auto rand_obj = [&]() {
-    vector_t x_axis, z_axis, t;
+    vector_t x_axis;
+    vector_t z_axis;
+    vector_t t;
 
     x_axis = vector::normalize(vector_t{dist(mt), dist(mt), dist(mt)});
     z_axis = {dist(mt), dist(mt), dist(mt)};

--- a/benchmarks/common/include/benchmark/common/benchmark_base.hpp
+++ b/benchmarks/common/include/benchmark/common/benchmark_base.hpp
@@ -52,7 +52,15 @@ struct benchmark_base {
     /// @}
 
     /// Print configuration
-    friend std::ostream& operator<<(std::ostream& os, const configuration& c);
+    friend std::ostream& operator<<(std::ostream& os,
+                                    const benchmark_base::configuration& cfg) {
+      os << " -> running:\t " << cfg.n_samples() << " samples" << std::endl;
+      if (cfg.do_sleep()) {
+        os << " -> cool down:\t " << cfg.n_sleep() << "s" << std::endl;
+      }
+      os << std::endl;
+      return os;
+    }
   };
 
   /// The benchmark configuration
@@ -76,15 +84,5 @@ struct benchmark_base {
   /// Benchmark case
   virtual void operator()(::benchmark::State&) = 0;
 };
-
-std::ostream& operator<<(std::ostream& os,
-                         const benchmark_base::configuration& cfg) {
-  os << " -> running:\t " << cfg.n_samples() << " samples" << std::endl;
-  if (cfg.do_sleep()) {
-    os << " -> cool down:\t " << cfg.n_sleep() << "s" << std::endl;
-  }
-  os << std::endl;
-  return os;
-}
 
 }  // namespace algebra

--- a/benchmarks/common/include/benchmark/common/benchmark_vector.hpp
+++ b/benchmarks/common/include/benchmark/common/benchmark_vector.hpp
@@ -30,7 +30,9 @@ struct vector_bm : public benchmark_base {
   /// Prefix for the benchmark name
   inline static const std::string name{"vector"};
 
-  std::vector<vector_t> a, b, results;
+  std::vector<vector_t> a;
+  std::vector<vector_t> b;
+  std::vector<vector_t> results;
 
   /// No default construction: Cannot prepare data
   vector_bm() = delete;
@@ -82,8 +84,8 @@ requires std::invocable<unaryOP, vector_t<scalar_t>> struct vector_unaryOP_bm
     // Run the benchmark
     for (auto _ : state) {
       for (std::size_t i{0}; i < n_samples; ++i) {
-        result_t result = unaryOP{}(this->a[i]);
-        ::benchmark::DoNotOptimize(const_cast<const result_t &>(result));
+        const result_t result = unaryOP{}(this->a[i]);
+        ::benchmark::DoNotOptimize(result);
       }
     }
   }
@@ -117,8 +119,8 @@ requires std::invocable<binaryOP, vector_t<scalar_t>,
     // Run the benchmark
     for (auto _ : state) {
       for (std::size_t i{0}; i < n_samples; ++i) {
-        result_t result = binaryOP{}(this->a[i], this->b[i]);
-        ::benchmark::DoNotOptimize(const_cast<const result_t &>(result));
+        const result_t result = binaryOP{}(this->a[i], this->b[i]);
+        ::benchmark::DoNotOptimize(result);
       }
     }
   }

--- a/benchmarks/eigen/include/benchmark/eigen/data_generator.hpp
+++ b/benchmarks/eigen/include/benchmark/eigen/data_generator.hpp
@@ -33,7 +33,9 @@ inline void fill_random_trf(std::vector<transform3_t> &collection) {
   using vector_t = typename transform3_t::vector3;
 
   auto rand_obj = []() {
-    vector_t x_axis, z_axis, t;
+    vector_t x_axis;
+    vector_t z_axis;
+    vector_t t;
 
     x_axis = vector::normalize(vector_t::Random());
     z_axis = vector_t::Random();

--- a/benchmarks/vc_aos/include/benchmark/vc_aos/data_generator.hpp
+++ b/benchmarks/vc_aos/include/benchmark/vc_aos/data_generator.hpp
@@ -35,7 +35,9 @@ inline void fill_random_trf(std::vector<transform3_t> &collection) {
   // Generate a random, but valid affine transformation
   auto rand_obj = []() {
     using vector_t = typename transform3_t::vector3;
-    vector_t x_axis, z_axis, t;
+    vector_t x_axis;
+    vector_t z_axis;
+    vector_t t;
 
     x_axis = vector_t{vector_t::array_type::Random()};
     x_axis = vector::normalize(x_axis);

--- a/benchmarks/vc_soa/include/benchmark/vc_soa/data_generator.hpp
+++ b/benchmarks/vc_soa/include/benchmark/vc_soa/data_generator.hpp
@@ -38,8 +38,13 @@ template <concepts::transform3D transform3_t>
 inline void fill_random_trf(std::vector<transform3_t> &collection) {
   // Generate a random, but valid affine transformation
   auto rand_obj = []() {
+    using vector_t = typename transform3_t::vector3;
     using simd_vector_t = typename transform3_t::scalar_type;
-    typename transform3_t::vector3 x_axis, z_axis, t;
+
+    vector_t x_axis;
+    vector_t z_axis;
+    vector_t t;
+
     x_axis[0] = simd_vector_t::Random();
     x_axis[1] = simd_vector_t::Random();
     x_axis[2] = simd_vector_t::Random();

--- a/benchmarks/vc_soa/vc_soa_vector.cpp
+++ b/benchmarks/vc_soa/vc_soa_vector.cpp
@@ -70,17 +70,6 @@ int main(int argc, char** argv) {
   //
   // Register all benchmarks
   //
-  algebra::register_benchmark<phi_f_t>(cfg_s, "_single");
-  algebra::register_benchmark<phi_d_t>(cfg_d, "_double");
-  algebra::register_benchmark<theta_f_t>(cfg_s, "_single");
-  algebra::register_benchmark<theta_d_t>(cfg_d, "_double");
-  algebra::register_benchmark<perp_f_t>(cfg_s, "_single");
-  algebra::register_benchmark<perp_d_t>(cfg_d, "_double");
-  algebra::register_benchmark<norm_f_t>(cfg_s, "_single");
-  algebra::register_benchmark<norm_d_t>(cfg_d, "_double");
-  algebra::register_benchmark<eta_f_t>(cfg_s, "_single");
-  algebra::register_benchmark<eta_d_t>(cfg_d, "_double");
-
   algebra::register_benchmark<add_f_t>(cfg_s, "_single");
   algebra::register_benchmark<add_d_t>(cfg_d, "_double");
   algebra::register_benchmark<sub_f_t>(cfg_s, "_single");
@@ -91,6 +80,17 @@ int main(int argc, char** argv) {
   algebra::register_benchmark<cross_d_t>(cfg_d, "_double");
   algebra::register_benchmark<normlz_f_t>(cfg_s, "_single");
   algebra::register_benchmark<normlz_d_t>(cfg_d, "_double");
+
+  algebra::register_benchmark<phi_f_t>(cfg_s, "_single");
+  algebra::register_benchmark<phi_d_t>(cfg_d, "_double");
+  algebra::register_benchmark<theta_f_t>(cfg_s, "_single");
+  algebra::register_benchmark<theta_d_t>(cfg_d, "_double");
+  algebra::register_benchmark<perp_f_t>(cfg_s, "_single");
+  algebra::register_benchmark<perp_d_t>(cfg_d, "_double");
+  algebra::register_benchmark<norm_f_t>(cfg_s, "_single");
+  algebra::register_benchmark<norm_d_t>(cfg_d, "_double");
+  algebra::register_benchmark<eta_f_t>(cfg_s, "_single");
+  algebra::register_benchmark<eta_d_t>(cfg_d, "_double");
 
   ::benchmark::Initialize(&argc, argv);
   ::benchmark::RunSpecifiedBenchmarks();

--- a/common/include/algebra/concepts.hpp
+++ b/common/include/algebra/concepts.hpp
@@ -15,23 +15,23 @@
 
 namespace algebra::concepts {
 
+/// Arithmetic types
+template <typename T>
+concept arithmetic = std::is_arithmetic_v<T>;
+
 // Value concept: Single entry
 template <typename T>
-concept value = std::is_arithmetic_v<std::decay_t<T>>;
+concept value = algebra::concepts::arithmetic<std::decay_t<T>>;
 
 /// Scalar concept: Elements of vectors/matrices (can be simd vectors)
 template <typename T>
 concept scalar = !algebra::traits::is_matrix<T> &&
                  !algebra::traits::is_vector<T> && requires(T a, T b) {
-  { a + b }
-  ->std::convertible_to<T>;
-  { a - b }
-  ->std::convertible_to<T>;
-  { a* b }
-  ->std::convertible_to<T>;
-  { a / b }
-  ->std::convertible_to<T>;
-};
+                   { a + b } -> std::convertible_to<T>;
+                   { a - b } -> std::convertible_to<T>;
+                   { a* b } -> std::convertible_to<T>;
+                   { a / b } -> std::convertible_to<T>;
+                 };
 
 /// Check if a scalar is simd
 template <typename T>
@@ -71,7 +71,7 @@ template <typename M>
 concept matrix = algebra::traits::is_matrix<M>;
 
 template <typename M>
-concept square_matrix = matrix<M>&& algebra::traits::is_square<M>;
+concept square_matrix = matrix<M> && algebra::traits::is_square<M>;
 
 template <typename M>
 concept row_matrix = matrix<M> && (algebra::traits::rows<M> == 1);
@@ -103,5 +103,26 @@ concept transform3D = requires(T trf) {
   trf.vector_to_global(typename T::vector3());
   trf.vector_to_local(typename T::vector3());
 };
+
+/// Algebra plugin concept
+template <typename A>
+concept algebra = (concepts::value<typename A::value_type> &&
+                   concepts::scalar<typename A::scalar> &&
+                   concepts::index<typename A::size_type> &&
+                   concepts::simd_scalar<typename A::template simd<float>> &&
+                   concepts::vector3D<typename A::vector3D> &&
+                   concepts::point2D<typename A::point2D> &&
+                   concepts::point3D<typename A::point3D> &&
+                   concepts::transform3D<typename A::transform3D> &&
+                   concepts::matrix<typename A::template matrix<3, 3>>);
+
+/// Check if an algebra has soa layout
+/// @{
+template <typename A>
+concept soa = (!concepts::arithmetic<algebra::get_scalar_t<A>>);
+
+template <typename A>
+concept aos = (!concepts::soa<A>);
+/// @}
 
 }  // namespace algebra::concepts

--- a/common/include/algebra/concepts.hpp
+++ b/common/include/algebra/concepts.hpp
@@ -27,11 +27,15 @@ concept value = algebra::concepts::arithmetic<std::decay_t<T>>;
 template <typename T>
 concept scalar = !algebra::traits::is_matrix<T> &&
                  !algebra::traits::is_vector<T> && requires(T a, T b) {
-                   { a + b } -> std::convertible_to<T>;
-                   { a - b } -> std::convertible_to<T>;
-                   { a* b } -> std::convertible_to<T>;
-                   { a / b } -> std::convertible_to<T>;
-                 };
+  { a + b }
+  ->std::convertible_to<T>;
+  { a - b }
+  ->std::convertible_to<T>;
+  { a* b }
+  ->std::convertible_to<T>;
+  { a / b }
+  ->std::convertible_to<T>;
+};
 
 /// Check if a scalar is simd
 template <typename T>
@@ -71,7 +75,7 @@ template <typename M>
 concept matrix = algebra::traits::is_matrix<M>;
 
 template <typename M>
-concept square_matrix = matrix<M> && algebra::traits::is_square<M>;
+concept square_matrix = matrix<M>&& algebra::traits::is_square<M>;
 
 template <typename M>
 concept row_matrix = matrix<M> && (algebra::traits::rows<M> == 1);

--- a/common/include/algebra/print.hpp
+++ b/common/include/algebra/print.hpp
@@ -1,0 +1,99 @@
+/** Algebra plugins, part of the ACTS project
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s)
+#include "algebra/concepts.hpp"
+#include "algebra/qualifiers.hpp"
+
+// System include(s).
+#include <iostream>
+
+namespace algebra {
+
+/// Print a generic vector or point @param v
+template <typename vector_t>
+  requires(concepts::vector<vector_t> || concepts::point<vector_t>)
+ALGEBRA_HOST std::ostream& operator<<(std::ostream& out, const vector_t& v) {
+
+  using index_t = algebra::traits::index_t<vector_t>;
+
+  constexpr index_t size{algebra::traits::size<vector_t>};
+
+  out << "[";
+  for (index_t i = 0; i < size; ++i) {
+    out << v[i];
+    if (i != size - 1) {
+      out << ", ";
+    }
+  }
+  out << "]";
+
+  return out;
+}
+
+/// Print a column matrix @param v
+template <concepts::column_matrix vector_t>
+ALGEBRA_HOST std::ostream& operator<<(std::ostream& out, const vector_t& v) {
+
+  using index_t = algebra::traits::index_t<vector_t>;
+  using element_getter_t = algebra::traits::element_getter_t<vector_t>;
+
+  constexpr index_t rows{algebra::traits::rows<vector_t>};
+
+  out << "[";
+  for (index_t i = 0; i < rows; ++i) {
+    out << element_getter_t{}(v, i, 0);
+    if (i != rows - 1) {
+      out << ", ";
+    }
+  }
+  out << "]";
+
+  return out;
+}
+
+/// Print a generic matrix @param m
+template <concepts::matrix matrix_t>
+ALGEBRA_HOST std::ostream& operator<<(std::ostream& out, const matrix_t& m) {
+
+  using index_t = algebra::traits::index_t<matrix_t>;
+  using element_getter_t = algebra::traits::element_getter_t<matrix_t>;
+
+  constexpr index_t rows{algebra::traits::rows<matrix_t>};
+  constexpr index_t columns{algebra::traits::columns<matrix_t>};
+
+  out << "[";
+  for (index_t i = 0; i < rows; ++i) {
+    out << "[";
+    for (index_t j = 0; j < columns; ++j) {
+      out << element_getter_t{}(m, i, j);
+      if (j != columns - 1) {
+        out << ", ";
+      }
+    }
+    out << "]";
+    if (i != rows - 1) {
+      out << ", ";
+    }
+  }
+  out << "]";
+
+  return out;
+}
+
+/// Print a 3D transform @param trf
+template <concepts::transform3D transform_t>
+ALGEBRA_HOST std::ostream& operator<<(std::ostream& out,
+                                      const transform_t& trf) {
+  out << trf.matrix();
+
+  return out;
+}
+
+}  // namespace algebra

--- a/common/include/algebra/type_traits.hpp
+++ b/common/include/algebra/type_traits.hpp
@@ -81,8 +81,7 @@ struct dimensions {
 
 /// Specilization for scalar types
 template <typename M>
-  requires std::is_fundamental_v<M>
-struct dimensions<M> {
+requires std::is_fundamental_v<M> struct dimensions<M> {
 
   using size_type = std::size_t;
 
@@ -138,11 +137,11 @@ template <typename T>
 struct get_algebra {};
 
 template <typename T>
-  requires(!std::is_same_v<typename T::point3D, void>)
-struct get_algebra<T> {
+requires(!std::is_same_v<typename T::point3D, void>) struct get_algebra<T> {
   template <typename U>
   using simd = typename T::template simd<U>;
   using size_type = typename T::size_type;
+  using boolean = typename T::boolean;
   using value = typename T::value_type;
   using scalar = typename T::scalar;
   using point2D = typename T::point2D;
@@ -156,10 +155,19 @@ struct get_algebra<T> {
 }  // namespace traits
 
 template <typename A>
-using get_scalar_t = typename traits::get_algebra<A>::scalar;
+using get_value_t = typename traits::get_algebra<A>::value;
+
+template <typename A>
+using get_boolean_t = typename traits::get_algebra<A>::boolean;
 
 template <typename A, typename T>
 using get_simd_t = typename traits::get_algebra<A>::template simd<T>;
+
+template <typename A>
+using get_size_t = typename traits::get_algebra<A>::size_type;
+
+template <typename A>
+using get_scalar_t = typename traits::get_algebra<A>::scalar;
 
 template <typename A>
 using get_point2D_t = typename traits::get_algebra<A>::point2D;
@@ -172,9 +180,6 @@ using get_vector3D_t = typename traits::get_algebra<A>::vector3D;
 
 template <typename A>
 using get_transform3D_t = typename traits::get_algebra<A>::transform3D;
-
-template <typename A>
-using get_size_t = typename traits::get_algebra<A>::size_type;
 
 template <typename A, std::size_t R, std::size_t C>
 using get_matrix_t = typename traits::get_algebra<A>::template matrix<R, C>;

--- a/common/include/algebra/type_traits.hpp
+++ b/common/include/algebra/type_traits.hpp
@@ -12,7 +12,9 @@
 #include <cmath>
 #include <type_traits>
 
-namespace algebra::traits {
+namespace algebra {
+
+namespace traits {
 
 /// Matrix traits
 /// @{
@@ -79,7 +81,8 @@ struct dimensions {
 
 /// Specilization for scalar types
 template <typename M>
-requires std::is_fundamental_v<M> struct dimensions<M> {
+  requires std::is_fundamental_v<M>
+struct dimensions<M> {
 
   using size_type = std::size_t;
 
@@ -129,7 +132,55 @@ template <class M>
 using block_getter_t = typename block_getter<M>::type;
 /// @}
 
-}  // namespace algebra::traits
+/// The algebra types
+/// @{
+template <typename T>
+struct get_algebra {};
+
+template <typename T>
+  requires(!std::is_same_v<typename T::point3D, void>)
+struct get_algebra<T> {
+  template <typename U>
+  using simd = typename T::template simd<U>;
+  using size_type = typename T::size_type;
+  using value = typename T::value_type;
+  using scalar = typename T::scalar;
+  using point2D = typename T::point2D;
+  using point3D = typename T::point3D;
+  using vector3D = typename T::vector3D;
+  using transform3D = typename T::transform3D;
+  template <std::size_t ROWS, std::size_t COLS>
+  using matrix = typename T::template matrix<ROWS, COLS>;
+};
+
+}  // namespace traits
+
+template <typename A>
+using get_scalar_t = typename traits::get_algebra<A>::scalar;
+
+template <typename A, typename T>
+using get_simd_t = typename traits::get_algebra<A>::template simd<T>;
+
+template <typename A>
+using get_point2D_t = typename traits::get_algebra<A>::point2D;
+
+template <typename A>
+using get_point3D_t = typename traits::get_algebra<A>::point3D;
+
+template <typename A>
+using get_vector3D_t = typename traits::get_algebra<A>::vector3D;
+
+template <typename A>
+using get_transform3D_t = typename traits::get_algebra<A>::transform3D;
+
+template <typename A>
+using get_size_t = typename traits::get_algebra<A>::size_type;
+
+template <typename A, std::size_t R, std::size_t C>
+using get_matrix_t = typename traits::get_algebra<A>::template matrix<R, C>;
+/// @}
+
+}  // namespace algebra
 
 /// Default type trait specializations
 /// @{

--- a/frontend/array_cmath/include/algebra/array_cmath.hpp
+++ b/frontend/array_cmath/include/algebra/array_cmath.hpp
@@ -10,6 +10,7 @@
 // Project include(s).
 #include "algebra/math/cmath.hpp"
 #include "algebra/math/generic.hpp"
+#include "algebra/print.hpp"
 #include "algebra/storage/array.hpp"
 
 /// @name Operators on @c algebra::array::storage_type
@@ -18,6 +19,9 @@
 using algebra::cmath::operator*;
 using algebra::cmath::operator-;
 using algebra::cmath::operator+;
+
+/// Print the linear algebra types of this backend
+using algebra::operator<<;
 
 /// @}
 

--- a/frontend/array_cmath/include/algebra/array_cmath.hpp
+++ b/frontend/array_cmath/include/algebra/array_cmath.hpp
@@ -115,4 +115,31 @@ using transform3 =
 
 }  // namespace array
 
+namespace plugin {
+
+/// Define the plugin types
+/// @{
+template <typename V>
+struct cmath {
+    /// Define scalar type
+    using value_type = V;
+
+    template <typename T>
+    using simd = T;
+
+    using boolean = bool;
+    using scalar = value_type;
+    using size_type = algebra::array::size_type;
+    using transform3D = algebra::array::transform3<value_type>;
+    using point2D = algebra::array::point2<value_type>;
+    using point3D = algebra::array::point3<value_type>;
+    using vector3D = algebra::array::vector3<value_type>;
+
+    template <std::size_t ROWS, std::size_t COLS>
+    using matrix = algebra::array::matrix_type<value_type, ROWS, COLS>;
+};
+/// @}
+
+} // namespace plugin
+
 }  // namespace algebra

--- a/frontend/array_cmath/include/algebra/array_cmath.hpp
+++ b/frontend/array_cmath/include/algebra/array_cmath.hpp
@@ -10,7 +10,6 @@
 // Project include(s).
 #include "algebra/math/cmath.hpp"
 #include "algebra/math/generic.hpp"
-#include "algebra/print.hpp"
 #include "algebra/storage/array.hpp"
 
 /// @name Operators on @c algebra::array::storage_type
@@ -19,9 +18,6 @@
 using algebra::cmath::operator*;
 using algebra::cmath::operator-;
 using algebra::cmath::operator+;
-
-/// Print the linear algebra types of this backend
-using algebra::operator<<;
 
 /// @}
 
@@ -119,27 +115,27 @@ namespace plugin {
 
 /// Define the plugin types
 /// @{
-template <typename V>
-struct cmath {
-    /// Define scalar type
-    using value_type = V;
+template <concepts::value V>
+struct array {
+  /// Define scalar type
+  using value_type = V;
 
-    template <typename T>
-    using simd = T;
+  template <concepts::value T>
+  using simd = T;
 
-    using boolean = bool;
-    using scalar = value_type;
-    using size_type = algebra::array::size_type;
-    using transform3D = algebra::array::transform3<value_type>;
-    using point2D = algebra::array::point2<value_type>;
-    using point3D = algebra::array::point3<value_type>;
-    using vector3D = algebra::array::vector3<value_type>;
+  using boolean = bool;
+  using scalar = value_type;
+  using size_type = algebra::array::size_type;
+  using transform3D = algebra::array::transform3<value_type>;
+  using point2D = algebra::array::point2<value_type>;
+  using point3D = algebra::array::point3<value_type>;
+  using vector3D = algebra::array::vector3<value_type>;
 
-    template <std::size_t ROWS, std::size_t COLS>
-    using matrix = algebra::array::matrix_type<value_type, ROWS, COLS>;
+  template <std::size_t ROWS, std::size_t COLS>
+  using matrix = algebra::array::matrix_type<value_type, ROWS, COLS>;
 };
 /// @}
 
-} // namespace plugin
+}  // namespace plugin
 
 }  // namespace algebra

--- a/frontend/array_cmath/include/algebra/array_cmath.hpp
+++ b/frontend/array_cmath/include/algebra/array_cmath.hpp
@@ -47,12 +47,12 @@ using cmath::dot;
 using cmath::normalize;
 
 // generic implementations
-using generic::math::cross;
-using generic::math::eta;
-using generic::math::norm;
-using generic::math::perp;
-using generic::math::phi;
-using generic::math::theta;
+using cmath::cross;
+using cmath::eta;
+using cmath::norm;
+using cmath::perp;
+using cmath::phi;
+using cmath::theta;
 
 /// @}
 
@@ -88,9 +88,10 @@ using cmath::set_identity;
 using cmath::set_zero;
 using cmath::zero;
 
-using generic::math::determinant;
-using generic::math::inverse;
-using generic::math::transpose;
+// Uses generic implementation in the background
+using cmath::determinant;
+using cmath::inverse;
+using cmath::transpose;
 
 /// @}
 

--- a/frontend/eigen_eigen/CMakeLists.txt
+++ b/frontend/eigen_eigen/CMakeLists.txt
@@ -8,7 +8,7 @@
 algebra_add_library( algebra_eigen_eigen eigen_eigen
    "include/algebra/eigen_eigen.hpp" )
 target_link_libraries( algebra_eigen_eigen
-   INTERFACE algebra::common algebra::eigen_storage algebra::generic_math
-             algebra::eigen_math Eigen3::Eigen )
+   INTERFACE algebra::common algebra::eigen_storage algebra::eigen_math
+             Eigen3::Eigen )
 algebra_test_public_headers( algebra_eigen_eigen
    "algebra/eigen_eigen.hpp" )

--- a/frontend/eigen_eigen/include/algebra/eigen_eigen.hpp
+++ b/frontend/eigen_eigen/include/algebra/eigen_eigen.hpp
@@ -9,7 +9,6 @@
 
 // Project include(s).
 #include "algebra/math/eigen.hpp"
-#include "algebra/math/generic.hpp"
 #include "algebra/storage/eigen.hpp"
 
 // Eigen include(s).
@@ -47,12 +46,9 @@ using eigen::math::dot;
 using eigen::math::eta;
 using eigen::math::norm;
 using eigen::math::normalize;
-
-using generic::math::perp;
-using generic::math::phi;
-using generic::math::theta;
-
-/// @}
+using eigen::math::perp;
+using eigen::math::phi;
+using eigen::math::theta;
 
 }  // namespace vector
 

--- a/frontend/eigen_eigen/include/algebra/eigen_eigen.hpp
+++ b/frontend/eigen_eigen/include/algebra/eigen_eigen.hpp
@@ -80,4 +80,31 @@ using transform3 = math::transform3<T>;
 
 }  // namespace eigen
 
+namespace plugin {
+
+/// Define the plugin types
+/// @{
+template <typename V>
+struct eigen {
+    /// Define scalar type
+    using value_type = V;
+
+    template <typename T>
+    using simd = T;
+
+    using boolean = bool;
+    using scalar = value_type;
+    using size_type = algebra::eigen::size_type;
+    using transform3D = algebra::eigen::transform3<value_type>;
+    using point2D = algebra::eigen::point2<value_type>;
+    using point3D = algebra::eigen::point3<value_type>;
+    using vector3D = algebra::eigen::vector3<value_type>;
+
+    template <std::size_t ROWS, std::size_t COLS>
+    using matrix = algebra::eigen::matrix_type<value_type, ROWS, COLS>;
+};
+/// @}
+
+} // namespace plugin
+
 }  // namespace algebra

--- a/frontend/eigen_eigen/include/algebra/eigen_eigen.hpp
+++ b/frontend/eigen_eigen/include/algebra/eigen_eigen.hpp
@@ -9,6 +9,7 @@
 
 // Project include(s).
 #include "algebra/math/eigen.hpp"
+#include "algebra/print.hpp"
 #include "algebra/storage/eigen.hpp"
 
 // Eigen include(s).
@@ -19,6 +20,9 @@
 #ifdef _MSC_VER
 #pragma warning(pop)
 #endif  // MSVC
+
+/// Print the linear algebra types of this backend
+using algebra::operator<<;
 
 namespace algebra {
 

--- a/frontend/eigen_eigen/include/algebra/eigen_eigen.hpp
+++ b/frontend/eigen_eigen/include/algebra/eigen_eigen.hpp
@@ -9,7 +9,6 @@
 
 // Project include(s).
 #include "algebra/math/eigen.hpp"
-#include "algebra/print.hpp"
 #include "algebra/storage/eigen.hpp"
 
 // Eigen include(s).
@@ -20,9 +19,6 @@
 #ifdef _MSC_VER
 #pragma warning(pop)
 #endif  // MSVC
-
-/// Print the linear algebra types of this backend
-using algebra::operator<<;
 
 namespace algebra {
 
@@ -84,27 +80,27 @@ namespace plugin {
 
 /// Define the plugin types
 /// @{
-template <typename V>
+template <concepts::value V>
 struct eigen {
-    /// Define scalar type
-    using value_type = V;
+  /// Define scalar type
+  using value_type = V;
 
-    template <typename T>
-    using simd = T;
+  template <concepts::value T>
+  using simd = T;
 
-    using boolean = bool;
-    using scalar = value_type;
-    using size_type = algebra::eigen::size_type;
-    using transform3D = algebra::eigen::transform3<value_type>;
-    using point2D = algebra::eigen::point2<value_type>;
-    using point3D = algebra::eigen::point3<value_type>;
-    using vector3D = algebra::eigen::vector3<value_type>;
+  using boolean = bool;
+  using scalar = value_type;
+  using size_type = algebra::eigen::size_type;
+  using transform3D = algebra::eigen::transform3<value_type>;
+  using point2D = algebra::eigen::point2<value_type>;
+  using point3D = algebra::eigen::point3<value_type>;
+  using vector3D = algebra::eigen::vector3<value_type>;
 
-    template <std::size_t ROWS, std::size_t COLS>
-    using matrix = algebra::eigen::matrix_type<value_type, ROWS, COLS>;
+  template <std::size_t ROWS, std::size_t COLS>
+  using matrix = algebra::eigen::matrix_type<value_type, ROWS, COLS>;
 };
 /// @}
 
-} // namespace plugin
+}  // namespace plugin
 
 }  // namespace algebra

--- a/frontend/eigen_generic/include/algebra/eigen_generic.hpp
+++ b/frontend/eigen_generic/include/algebra/eigen_generic.hpp
@@ -10,7 +10,6 @@
 // Project include(s).
 #include "algebra/math/eigen.hpp"
 #include "algebra/math/generic.hpp"
-#include "algebra/print.hpp"
 #include "algebra/storage/eigen.hpp"
 
 // Eigen include(s).
@@ -21,9 +20,6 @@
 #ifdef _MSC_VER
 #pragma warning(pop)
 #endif  // MSVC
-
-/// Print the linear algebra types of this backend
-using algebra::operator<<;
 
 // System include(s).
 #include <type_traits>
@@ -97,27 +93,27 @@ namespace plugin {
 
 /// Define the plugin types
 /// @{
-template <typename V>
+template <concepts::value V>
 struct eigen_generic {
-    /// Define scalar type
-    using value_type = V;
+  /// Define scalar type
+  using value_type = V;
 
-    template <typename T>
-    using simd = T;
+  template <concepts::value T>
+  using simd = T;
 
-    using boolean = bool;
-    using scalar = value_type;
-    using size_type = algebra::eigen::size_type;
-    using transform3D = algebra::eigen::transform3<value_type>;
-    using point2D = algebra::eigen::point2<value_type>;
-    using point3D = algebra::eigen::point3<value_type>;
-    using vector3D = algebra::eigen::vector3<value_type>;
+  using boolean = bool;
+  using scalar = value_type;
+  using size_type = algebra::eigen::size_type;
+  using transform3D = algebra::eigen::transform3<value_type>;
+  using point2D = algebra::eigen::point2<value_type>;
+  using point3D = algebra::eigen::point3<value_type>;
+  using vector3D = algebra::eigen::vector3<value_type>;
 
-    template <std::size_t ROWS, std::size_t COLS>
-    using matrix = algebra::eigen::matrix_type<value_type, ROWS, COLS>;
+  template <std::size_t ROWS, std::size_t COLS>
+  using matrix = algebra::eigen::matrix_type<value_type, ROWS, COLS>;
 };
 /// @}
 
-} // namespace plugin
+}  // namespace plugin
 
 }  // namespace algebra

--- a/frontend/eigen_generic/include/algebra/eigen_generic.hpp
+++ b/frontend/eigen_generic/include/algebra/eigen_generic.hpp
@@ -93,4 +93,31 @@ using transform3 =
 
 }  // namespace eigen
 
+namespace plugin {
+
+/// Define the plugin types
+/// @{
+template <typename V>
+struct eigen_generic {
+    /// Define scalar type
+    using value_type = V;
+
+    template <typename T>
+    using simd = T;
+
+    using boolean = bool;
+    using scalar = value_type;
+    using size_type = algebra::eigen::size_type;
+    using transform3D = algebra::eigen::transform3<value_type>;
+    using point2D = algebra::eigen::point2<value_type>;
+    using point3D = algebra::eigen::point3<value_type>;
+    using vector3D = algebra::eigen::vector3<value_type>;
+
+    template <std::size_t ROWS, std::size_t COLS>
+    using matrix = algebra::eigen::matrix_type<value_type, ROWS, COLS>;
+};
+/// @}
+
+} // namespace plugin
+
 }  // namespace algebra

--- a/frontend/eigen_generic/include/algebra/eigen_generic.hpp
+++ b/frontend/eigen_generic/include/algebra/eigen_generic.hpp
@@ -10,6 +10,7 @@
 // Project include(s).
 #include "algebra/math/eigen.hpp"
 #include "algebra/math/generic.hpp"
+#include "algebra/print.hpp"
 #include "algebra/storage/eigen.hpp"
 
 // Eigen include(s).
@@ -20,6 +21,9 @@
 #ifdef _MSC_VER
 #pragma warning(pop)
 #endif  // MSVC
+
+/// Print the linear algebra types of this backend
+using algebra::operator<<;
 
 // System include(s).
 #include <type_traits>

--- a/frontend/fastor_fastor/CMakeLists.txt
+++ b/frontend/fastor_fastor/CMakeLists.txt
@@ -8,7 +8,6 @@
 algebra_add_library( algebra_fastor_fastor fastor_fastor
    "include/algebra/fastor_fastor.hpp" )
 target_link_libraries( algebra_fastor_fastor
-   INTERFACE algebra::common algebra::fastor_storage algebra::generic_math
-   			 algebra::fastor_math )
+   INTERFACE algebra::common algebra::fastor_storage algebra::fastor_math )
 algebra_test_public_headers( algebra_fastor_fastor
    "algebra/fastor_fastor.hpp" )

--- a/frontend/fastor_fastor/include/algebra/fastor_fastor.hpp
+++ b/frontend/fastor_fastor/include/algebra/fastor_fastor.hpp
@@ -9,7 +9,6 @@
 
 // Project include(s).
 #include "algebra/math/fastor.hpp"
-#include "algebra/print.hpp"
 #include "algebra/storage/fastor.hpp"
 
 // Fastor include(s).
@@ -20,9 +19,6 @@
 #ifdef _MSC_VER
 #pragma warning(default : 4244 4701 4702)
 #endif  // MSVC
-
-/// Print the linear algebra types of this backend
-using algebra::operator<<;
 
 namespace algebra {
 
@@ -91,27 +87,27 @@ namespace plugin {
 
 /// Define the plugin types
 /// @{
-template <typename V>
+template <concepts::value V>
 struct fastor {
-    /// Define scalar type
-    using value_type = V;
+  /// Define scalar type
+  using value_type = V;
 
-    template <typename T>
-    using simd = T;
+  template <concepts::value T>
+  using simd = T;
 
-    using boolean = bool;
-    using scalar = value_type;
-    using size_type = algebra::fastor::size_type;
-    using transform3D = algebra::fastor::transform3<value_type>;
-    using point2D = algebra::fastor::point2<value_type>;
-    using point3D = algebra::fastor::point3<value_type>;
-    using vector3D = algebra::fastor::vector3<value_type>;
+  using boolean = bool;
+  using scalar = value_type;
+  using size_type = algebra::fastor::size_type;
+  using transform3D = algebra::fastor::transform3<value_type>;
+  using point2D = algebra::fastor::point2<value_type>;
+  using point3D = algebra::fastor::point3<value_type>;
+  using vector3D = algebra::fastor::vector3<value_type>;
 
-    template <std::size_t ROWS, std::size_t COLS>
-    using matrix = algebra::fastor::matrix_type<value_type, ROWS, COLS>;
+  template <std::size_t ROWS, std::size_t COLS>
+  using matrix = algebra::fastor::matrix_type<value_type, ROWS, COLS>;
 };
 /// @}
 
-} // namespace plugin
+}  // namespace plugin
 
 }  // namespace algebra

--- a/frontend/fastor_fastor/include/algebra/fastor_fastor.hpp
+++ b/frontend/fastor_fastor/include/algebra/fastor_fastor.hpp
@@ -87,4 +87,31 @@ using transform3 = math::transform3<T>;
 
 }  // namespace fastor
 
+namespace plugin {
+
+/// Define the plugin types
+/// @{
+template <typename V>
+struct fastor {
+    /// Define scalar type
+    using value_type = V;
+
+    template <typename T>
+    using simd = T;
+
+    using boolean = bool;
+    using scalar = value_type;
+    using size_type = algebra::fastor::size_type;
+    using transform3D = algebra::fastor::transform3<value_type>;
+    using point2D = algebra::fastor::point2<value_type>;
+    using point3D = algebra::fastor::point3<value_type>;
+    using vector3D = algebra::fastor::vector3<value_type>;
+
+    template <std::size_t ROWS, std::size_t COLS>
+    using matrix = algebra::fastor::matrix_type<value_type, ROWS, COLS>;
+};
+/// @}
+
+} // namespace plugin
+
 }  // namespace algebra

--- a/frontend/fastor_fastor/include/algebra/fastor_fastor.hpp
+++ b/frontend/fastor_fastor/include/algebra/fastor_fastor.hpp
@@ -9,6 +9,7 @@
 
 // Project include(s).
 #include "algebra/math/fastor.hpp"
+#include "algebra/print.hpp"
 #include "algebra/storage/fastor.hpp"
 
 // Fastor include(s).
@@ -19,6 +20,9 @@
 #ifdef _MSC_VER
 #pragma warning(default : 4244 4701 4702)
 #endif  // MSVC
+
+/// Print the linear algebra types of this backend
+using algebra::operator<<;
 
 namespace algebra {
 

--- a/frontend/fastor_fastor/include/algebra/fastor_fastor.hpp
+++ b/frontend/fastor_fastor/include/algebra/fastor_fastor.hpp
@@ -9,7 +9,6 @@
 
 // Project include(s).
 #include "algebra/math/fastor.hpp"
-#include "algebra/math/generic.hpp"
 #include "algebra/storage/fastor.hpp"
 
 // Fastor include(s).
@@ -48,9 +47,8 @@ using fastor::math::eta;
 using fastor::math::norm;
 using fastor::math::normalize;
 using fastor::math::perp;
+using fastor::math::phi;
 using fastor::math::theta;
-
-using generic::math::phi;
 
 /// @}
 

--- a/frontend/smatrix_generic/include/algebra/smatrix_generic.hpp
+++ b/frontend/smatrix_generic/include/algebra/smatrix_generic.hpp
@@ -10,10 +10,14 @@
 // Project include(s).
 #include "algebra/math/generic.hpp"
 #include "algebra/math/smatrix.hpp"
+#include "algebra/print.hpp"
 #include "algebra/storage/smatrix.hpp"
 
 // ROOT/Smatrix include(s).
 #include <Math/SMatrix.h>
+
+/// Print the linear algebra types of this backend
+using algebra::operator<<;
 
 namespace algebra {
 

--- a/frontend/smatrix_generic/include/algebra/smatrix_generic.hpp
+++ b/frontend/smatrix_generic/include/algebra/smatrix_generic.hpp
@@ -10,14 +10,10 @@
 // Project include(s).
 #include "algebra/math/generic.hpp"
 #include "algebra/math/smatrix.hpp"
-#include "algebra/print.hpp"
 #include "algebra/storage/smatrix.hpp"
 
 // ROOT/Smatrix include(s).
 #include <Math/SMatrix.h>
-
-/// Print the linear algebra types of this backend
-using algebra::operator<<;
 
 namespace algebra {
 
@@ -88,27 +84,27 @@ namespace plugin {
 
 /// Define the plugin types
 /// @{
-template <typename V>
+template <concepts::value V>
 struct smatrix_generic {
-    /// Define scalar type
-    using value_type = V;
+  /// Define scalar type
+  using value_type = V;
 
-    template <typename T>
-    using simd = T;
+  template <concepts::value T>
+  using simd = T;
 
-    using boolean = bool;
-    using scalar = value_type;
-    using size_type = algebra::smatrix::size_type;
-    using transform3D = algebra::smatrix::transform3<value_type>;
-    using point2D = algebra::smatrix::point2<value_type>;
-    using point3D = algebra::smatrix::point3<value_type>;
-    using vector3D = algebra::smatrix::vector3<value_type>;
+  using boolean = bool;
+  using scalar = value_type;
+  using size_type = algebra::smatrix::size_type;
+  using transform3D = algebra::smatrix::transform3<value_type>;
+  using point2D = algebra::smatrix::point2<value_type>;
+  using point3D = algebra::smatrix::point3<value_type>;
+  using vector3D = algebra::smatrix::vector3<value_type>;
 
-    template <std::size_t ROWS, std::size_t COLS>
-    using matrix = algebra::smatrix::matrix_type<value_type, ROWS, COLS>;
+  template <std::size_t ROWS, std::size_t COLS>
+  using matrix = algebra::smatrix::matrix_type<value_type, ROWS, COLS>;
 };
 /// @}
 
-} // namespace plugin
+}  // namespace plugin
 
 }  // namespace algebra

--- a/frontend/smatrix_generic/include/algebra/smatrix_generic.hpp
+++ b/frontend/smatrix_generic/include/algebra/smatrix_generic.hpp
@@ -84,4 +84,31 @@ using transform3 =
 
 }  // namespace smatrix
 
+namespace plugin {
+
+/// Define the plugin types
+/// @{
+template <typename V>
+struct smatrix_generic {
+    /// Define scalar type
+    using value_type = V;
+
+    template <typename T>
+    using simd = T;
+
+    using boolean = bool;
+    using scalar = value_type;
+    using size_type = algebra::smatrix::size_type;
+    using transform3D = algebra::smatrix::transform3<value_type>;
+    using point2D = algebra::smatrix::point2<value_type>;
+    using point3D = algebra::smatrix::point3<value_type>;
+    using vector3D = algebra::smatrix::vector3<value_type>;
+
+    template <std::size_t ROWS, std::size_t COLS>
+    using matrix = algebra::smatrix::matrix_type<value_type, ROWS, COLS>;
+};
+/// @}
+
+} // namespace plugin
+
 }  // namespace algebra

--- a/frontend/smatrix_smatrix/include/algebra/smatrix_smatrix.hpp
+++ b/frontend/smatrix_smatrix/include/algebra/smatrix_smatrix.hpp
@@ -78,4 +78,31 @@ using transform3 = math::transform3<T>;
 
 }  // namespace smatrix
 
+namespace plugin {
+
+/// Define the plugin types
+/// @{
+template <typename V>
+struct smatrix {
+    /// Define scalar type
+    using value_type = V;
+
+    template <typename T>
+    using simd = T;
+
+    using boolean = bool;
+    using scalar = value_type;
+    using size_type = algebra::smatrix::size_type;
+    using transform3D = algebra::smatrix::transform3<value_type>;
+    using point2D = algebra::smatrix::point2<value_type>;
+    using point3D = algebra::smatrix::point3<value_type>;
+    using vector3D = algebra::smatrix::vector3<value_type>;
+
+    template <std::size_t ROWS, std::size_t COLS>
+    using matrix = algebra::smatrix::matrix_type<value_type, ROWS, COLS>;
+};
+/// @}
+
+} // namespace plugin
+
 }  // namespace algebra

--- a/frontend/smatrix_smatrix/include/algebra/smatrix_smatrix.hpp
+++ b/frontend/smatrix_smatrix/include/algebra/smatrix_smatrix.hpp
@@ -9,7 +9,11 @@
 
 // Project include(s).
 #include "algebra/math/smatrix.hpp"
+#include "algebra/print.hpp"
 #include "algebra/storage/smatrix.hpp"
+
+/// Print the linear algebra types of this backend
+using algebra::operator<<;
 
 namespace algebra {
 

--- a/frontend/smatrix_smatrix/include/algebra/smatrix_smatrix.hpp
+++ b/frontend/smatrix_smatrix/include/algebra/smatrix_smatrix.hpp
@@ -9,11 +9,7 @@
 
 // Project include(s).
 #include "algebra/math/smatrix.hpp"
-#include "algebra/print.hpp"
 #include "algebra/storage/smatrix.hpp"
-
-/// Print the linear algebra types of this backend
-using algebra::operator<<;
 
 namespace algebra {
 
@@ -82,27 +78,27 @@ namespace plugin {
 
 /// Define the plugin types
 /// @{
-template <typename V>
+template <concepts::value V>
 struct smatrix {
-    /// Define scalar type
-    using value_type = V;
+  /// Define scalar type
+  using value_type = V;
 
-    template <typename T>
-    using simd = T;
+  template <concepts::value T>
+  using simd = T;
 
-    using boolean = bool;
-    using scalar = value_type;
-    using size_type = algebra::smatrix::size_type;
-    using transform3D = algebra::smatrix::transform3<value_type>;
-    using point2D = algebra::smatrix::point2<value_type>;
-    using point3D = algebra::smatrix::point3<value_type>;
-    using vector3D = algebra::smatrix::vector3<value_type>;
+  using boolean = bool;
+  using scalar = value_type;
+  using size_type = algebra::smatrix::size_type;
+  using transform3D = algebra::smatrix::transform3<value_type>;
+  using point2D = algebra::smatrix::point2<value_type>;
+  using point3D = algebra::smatrix::point3<value_type>;
+  using vector3D = algebra::smatrix::vector3<value_type>;
 
-    template <std::size_t ROWS, std::size_t COLS>
-    using matrix = algebra::smatrix::matrix_type<value_type, ROWS, COLS>;
+  template <std::size_t ROWS, std::size_t COLS>
+  using matrix = algebra::smatrix::matrix_type<value_type, ROWS, COLS>;
 };
 /// @}
 
-} // namespace plugin
+}  // namespace plugin
 
 }  // namespace algebra

--- a/frontend/vc_aos/CMakeLists.txt
+++ b/frontend/vc_aos/CMakeLists.txt
@@ -8,7 +8,6 @@
 algebra_add_library( algebra_vc_aos vc_aos
    "include/algebra/vc_aos.hpp" )
 target_link_libraries( algebra_vc_aos
-   INTERFACE algebra::common algebra::vc_aos_storage algebra::generic_math
-             algebra::vc_aos_math )
+   INTERFACE algebra::common algebra::vc_aos_storage algebra::vc_aos_math )
 algebra_test_public_headers( algebra_vc_aos
    "algebra/vc_aos.hpp" )

--- a/frontend/vc_aos/include/algebra/vc_aos.hpp
+++ b/frontend/vc_aos/include/algebra/vc_aos.hpp
@@ -83,4 +83,31 @@ using transform3 = math::transform3<vc_aos::storage_type, T>;
 
 }  // namespace vc_aos
 
+namespace plugin {
+
+/// Define the plugin types
+/// @{
+template <typename V>
+struct vc_aos {
+    /// Define scalar type
+    using value_type = V;
+
+    template <typename T>
+    using simd = T;
+
+    using boolean = bool;
+    using scalar = value_type;
+    using size_type = algebra::vc_aos::size_type;
+    using transform3D = algebra::vc_aos::transform3<value_type>;
+    using point2D = algebra::vc_aos::point2<value_type>;
+    using point3D = algebra::vc_aos::point3<value_type>;
+    using vector3D = algebra::vc_aos::vector3<value_type>;
+
+    template <std::size_t ROWS, std::size_t COLS>
+    using matrix = algebra::vc_aos::matrix_type<value_type, ROWS, COLS>;
+};
+/// @}
+
+} // namespace plugin
+
 }  // namespace algebra

--- a/frontend/vc_aos/include/algebra/vc_aos.hpp
+++ b/frontend/vc_aos/include/algebra/vc_aos.hpp
@@ -8,7 +8,6 @@
 #pragma once
 
 // Project include(s).
-#include "algebra/math/generic.hpp"
 #include "algebra/math/vc_aos.hpp"
 #include "algebra/storage/vc_aos.hpp"
 
@@ -43,11 +42,9 @@ using vc_aos::math::dot;
 using vc_aos::math::eta;
 using vc_aos::math::norm;
 using vc_aos::math::normalize;
-
-// No specific vectorized implementation needed
-using generic::math::perp;
-using generic::math::phi;
-using generic::math::theta;
+using vc_aos::math::perp;
+using vc_aos::math::phi;
+using vc_aos::math::theta;
 
 /// @}
 
@@ -58,15 +55,13 @@ namespace matrix {
 /// @name Matrix functions on @c algebra::vc_aos types
 /// @{
 
+using vc_aos::math::determinant;
 using vc_aos::math::identity;
+using vc_aos::math::inverse;
 using vc_aos::math::set_identity;
 using vc_aos::math::set_zero;
 using vc_aos::math::transpose;
 using vc_aos::math::zero;
-
-// Placeholder, until vectorization-friendly version is available
-using generic::math::determinant;
-using generic::math::inverse;
 
 /// @}
 

--- a/frontend/vc_aos/include/algebra/vc_aos.hpp
+++ b/frontend/vc_aos/include/algebra/vc_aos.hpp
@@ -9,11 +9,15 @@
 
 // Project include(s).
 #include "algebra/math/vc_aos.hpp"
+#include "algebra/print.hpp"
 #include "algebra/storage/vc_aos.hpp"
 
 // System include(s).
 #include <cassert>
 #include <type_traits>
+
+/// Print the linear algebra types of this backend
+using algebra::operator<<;
 
 namespace algebra {
 

--- a/frontend/vc_aos/include/algebra/vc_aos.hpp
+++ b/frontend/vc_aos/include/algebra/vc_aos.hpp
@@ -9,15 +9,11 @@
 
 // Project include(s).
 #include "algebra/math/vc_aos.hpp"
-#include "algebra/print.hpp"
 #include "algebra/storage/vc_aos.hpp"
 
 // System include(s).
 #include <cassert>
 #include <type_traits>
-
-/// Print the linear algebra types of this backend
-using algebra::operator<<;
 
 namespace algebra {
 
@@ -87,27 +83,27 @@ namespace plugin {
 
 /// Define the plugin types
 /// @{
-template <typename V>
+template <concepts::value V>
 struct vc_aos {
-    /// Define scalar type
-    using value_type = V;
+  /// Define scalar type
+  using value_type = V;
 
-    template <typename T>
-    using simd = T;
+  template <concepts::value T>
+  using simd = T;
 
-    using boolean = bool;
-    using scalar = value_type;
-    using size_type = algebra::vc_aos::size_type;
-    using transform3D = algebra::vc_aos::transform3<value_type>;
-    using point2D = algebra::vc_aos::point2<value_type>;
-    using point3D = algebra::vc_aos::point3<value_type>;
-    using vector3D = algebra::vc_aos::vector3<value_type>;
+  using boolean = bool;
+  using scalar = value_type;
+  using size_type = algebra::vc_aos::size_type;
+  using transform3D = algebra::vc_aos::transform3<value_type>;
+  using point2D = algebra::vc_aos::point2<value_type>;
+  using point3D = algebra::vc_aos::point3<value_type>;
+  using vector3D = algebra::vc_aos::vector3<value_type>;
 
-    template <std::size_t ROWS, std::size_t COLS>
-    using matrix = algebra::vc_aos::matrix_type<value_type, ROWS, COLS>;
+  template <std::size_t ROWS, std::size_t COLS>
+  using matrix = algebra::vc_aos::matrix_type<value_type, ROWS, COLS>;
 };
 /// @}
 
-} // namespace plugin
+}  // namespace plugin
 
 }  // namespace algebra

--- a/frontend/vc_aos_generic/include/algebra/vc_aos_generic.hpp
+++ b/frontend/vc_aos_generic/include/algebra/vc_aos_generic.hpp
@@ -11,6 +11,7 @@
 #include "algebra/math/cmath.hpp"
 #include "algebra/math/generic.hpp"
 #include "algebra/math/vc_aos.hpp"
+#include "algebra/print.hpp"
 #include "algebra/storage/array.hpp"
 #include "algebra/storage/vc_aos.hpp"
 
@@ -20,6 +21,9 @@
 using algebra::cmath::operator*;
 using algebra::cmath::operator-;
 using algebra::cmath::operator+;
+
+/// Print the linear algebra types of this backend
+using algebra::operator<<;
 
 /// @}
 

--- a/frontend/vc_aos_generic/include/algebra/vc_aos_generic.hpp
+++ b/frontend/vc_aos_generic/include/algebra/vc_aos_generic.hpp
@@ -92,4 +92,31 @@ using transform3 =
 
 }  // namespace vc_aos
 
+namespace plugin {
+
+/// Define the plugin types
+/// @{
+template <typename V>
+struct vc_aos_generic {
+    /// Define scalar type
+    using value_type = V;
+
+    template <typename T>
+    using simd = T;
+
+    using boolean = bool;
+    using scalar = value_type;
+    using size_type = algebra::vc_aos::size_type;
+    using transform3D = algebra::vc_aos::transform3<value_type>;
+    using point2D = algebra::vc_aos::point2<value_type>;
+    using point3D = algebra::vc_aos::point3<value_type>;
+    using vector3D = algebra::vc_aos::vector3<value_type>;
+
+    template <std::size_t ROWS, std::size_t COLS>
+    using matrix = algebra::vc_aos::matrix_type<value_type, ROWS, COLS>;
+};
+/// @}
+
+} // namespace plugin
+
 }  // namespace algebra

--- a/frontend/vc_aos_generic/include/algebra/vc_aos_generic.hpp
+++ b/frontend/vc_aos_generic/include/algebra/vc_aos_generic.hpp
@@ -11,7 +11,6 @@
 #include "algebra/math/cmath.hpp"
 #include "algebra/math/generic.hpp"
 #include "algebra/math/vc_aos.hpp"
-#include "algebra/print.hpp"
 #include "algebra/storage/array.hpp"
 #include "algebra/storage/vc_aos.hpp"
 
@@ -21,9 +20,6 @@
 using algebra::cmath::operator*;
 using algebra::cmath::operator-;
 using algebra::cmath::operator+;
-
-/// Print the linear algebra types of this backend
-using algebra::operator<<;
 
 /// @}
 
@@ -96,27 +92,27 @@ namespace plugin {
 
 /// Define the plugin types
 /// @{
-template <typename V>
+template <concepts::value V>
 struct vc_aos_generic {
-    /// Define scalar type
-    using value_type = V;
+  /// Define scalar type
+  using value_type = V;
 
-    template <typename T>
-    using simd = T;
+  template <concepts::value T>
+  using simd = T;
 
-    using boolean = bool;
-    using scalar = value_type;
-    using size_type = algebra::vc_aos::size_type;
-    using transform3D = algebra::vc_aos::transform3<value_type>;
-    using point2D = algebra::vc_aos::point2<value_type>;
-    using point3D = algebra::vc_aos::point3<value_type>;
-    using vector3D = algebra::vc_aos::vector3<value_type>;
+  using boolean = bool;
+  using scalar = value_type;
+  using size_type = algebra::vc_aos::size_type;
+  using transform3D = algebra::vc_aos::transform3<value_type>;
+  using point2D = algebra::vc_aos::point2<value_type>;
+  using point3D = algebra::vc_aos::point3<value_type>;
+  using vector3D = algebra::vc_aos::vector3<value_type>;
 
-    template <std::size_t ROWS, std::size_t COLS>
-    using matrix = algebra::vc_aos::matrix_type<value_type, ROWS, COLS>;
+  template <std::size_t ROWS, std::size_t COLS>
+  using matrix = algebra::vc_aos::matrix_type<value_type, ROWS, COLS>;
 };
 /// @}
 
-} // namespace plugin
+}  // namespace plugin
 
 }  // namespace algebra

--- a/frontend/vc_soa/include/algebra/vc_soa.hpp
+++ b/frontend/vc_soa/include/algebra/vc_soa.hpp
@@ -84,10 +84,42 @@ namespace vc_soa {
 
 template <concepts::value T>
 using transform3 =
-    algebra::vc_aos::math::transform3<algebra::vc_soa::storage_type, T>;
+    algebra::vc_aos::math::transform3<algebra::vc_soa::storage_type,
+                                      Vc::Vector<T>>;
 
 /// @}
 
 }  // namespace vc_soa
+
+namespace plugin {
+
+/// Define the plugin types
+/// @{
+template <typename V>
+struct vc_soa {
+  /// Define scalar precision
+  using value_type = V;
+
+  template <typename T>
+  using simd = Vc::Vector<T>;
+
+  using boolean = Vc::Mask<V>;
+
+  /// Linear Algebra type definitions
+  /// @{
+  using scalar = simd<value_type>;
+  using size_type = algebra::vc_soa::size_type;
+  using transform3D = algebra::vc_soa::transform3<value_type>;
+  using point2D = algebra::vc_soa::point2<value_type>;
+  using point3D = algebra::vc_soa::point3<value_type>;
+  using vector3D = algebra::vc_soa::vector3<value_type>;
+
+  template <std::size_t ROWS, std::size_t COLS>
+  using matrix = algebra::vc_soa::matrix_type<value_type, ROWS, COLS>;
+  /// @}
+};
+/// @}
+
+}  // namespace plugin
 
 }  // namespace algebra

--- a/frontend/vc_soa/include/algebra/vc_soa.hpp
+++ b/frontend/vc_soa/include/algebra/vc_soa.hpp
@@ -10,7 +10,6 @@
 // Project include(s).
 #include "algebra/math/impl/vc_aos_transform3.hpp"
 #include "algebra/math/vc_soa.hpp"
-#include "algebra/print.hpp"
 #include "algebra/storage/vc_soa.hpp"
 
 // System include(s).
@@ -38,9 +37,6 @@ using vc_soa::storage::block;
 using vc_soa::storage::element;
 using vc_soa::storage::set_block;
 using vc_soa::storage::vector;
-
-/// Print the linear algebra types of this backend
-using algebra::operator<<;
 
 /// @}
 
@@ -95,12 +91,12 @@ namespace plugin {
 
 /// Define the plugin types
 /// @{
-template <typename V>
+template <concepts::value V>
 struct vc_soa {
   /// Define scalar precision
   using value_type = V;
 
-  template <typename T>
+  template <concepts::value T>
   using simd = Vc::Vector<T>;
 
   using boolean = Vc::Mask<V>;

--- a/frontend/vc_soa/include/algebra/vc_soa.hpp
+++ b/frontend/vc_soa/include/algebra/vc_soa.hpp
@@ -10,6 +10,7 @@
 // Project include(s).
 #include "algebra/math/impl/vc_aos_transform3.hpp"
 #include "algebra/math/vc_soa.hpp"
+#include "algebra/print.hpp"
 #include "algebra/storage/vc_soa.hpp"
 
 // System include(s).
@@ -37,6 +38,9 @@ using vc_soa::storage::block;
 using vc_soa::storage::element;
 using vc_soa::storage::set_block;
 using vc_soa::storage::vector;
+
+/// Print the linear algebra types of this backend
+using algebra::operator<<;
 
 /// @}
 

--- a/frontend/vecmem_cmath/include/algebra/vecmem_cmath.hpp
+++ b/frontend/vecmem_cmath/include/algebra/vecmem_cmath.hpp
@@ -114,4 +114,31 @@ using transform3 =
 
 }  // namespace vecmem
 
+namespace plugin {
+
+/// Define the plugin types
+/// @{
+template <typename V>
+struct vecmem {
+    /// Define scalar type
+    using value_type = V;
+
+    template <typename T>
+    using simd = T;
+
+    using boolean = bool;
+    using scalar = value_type;
+    using size_type = algebra::vecmem::size_type;
+    using transform3D = algebra::vecmem::transform3<value_type>;
+    using point2D = algebra::vecmem::point2<value_type>;
+    using point3D = algebra::vecmem::point3<value_type>;
+    using vector3D = algebra::vecmem::vector3<value_type>;
+
+    template <std::size_t ROWS, std::size_t COLS>
+    using matrix = algebra::vecmem::matrix_type<value_type, ROWS, COLS>;
+};
+/// @}
+
+} // namespace plugin
+
 }  // namespace algebra

--- a/frontend/vecmem_cmath/include/algebra/vecmem_cmath.hpp
+++ b/frontend/vecmem_cmath/include/algebra/vecmem_cmath.hpp
@@ -10,7 +10,6 @@
 // Project include(s).
 #include "algebra/math/cmath.hpp"
 #include "algebra/math/generic.hpp"
-#include "algebra/print.hpp"
 #include "algebra/storage/vecmem.hpp"
 
 /// @name Operators on @c algebra::vecmem::storage_type
@@ -19,9 +18,6 @@
 using algebra::cmath::operator*;
 using algebra::cmath::operator-;
 using algebra::cmath::operator+;
-
-/// Print the linear algebra types of this backend
-using algebra::operator<<;
 
 /// @}
 
@@ -118,27 +114,27 @@ namespace plugin {
 
 /// Define the plugin types
 /// @{
-template <typename V>
+template <concepts::value V>
 struct vecmem {
-    /// Define scalar type
-    using value_type = V;
+  /// Define scalar type
+  using value_type = V;
 
-    template <typename T>
-    using simd = T;
+  template <concepts::value T>
+  using simd = T;
 
-    using boolean = bool;
-    using scalar = value_type;
-    using size_type = algebra::vecmem::size_type;
-    using transform3D = algebra::vecmem::transform3<value_type>;
-    using point2D = algebra::vecmem::point2<value_type>;
-    using point3D = algebra::vecmem::point3<value_type>;
-    using vector3D = algebra::vecmem::vector3<value_type>;
+  using boolean = bool;
+  using scalar = value_type;
+  using size_type = algebra::vecmem::size_type;
+  using transform3D = algebra::vecmem::transform3<value_type>;
+  using point2D = algebra::vecmem::point2<value_type>;
+  using point3D = algebra::vecmem::point3<value_type>;
+  using vector3D = algebra::vecmem::vector3<value_type>;
 
-    template <std::size_t ROWS, std::size_t COLS>
-    using matrix = algebra::vecmem::matrix_type<value_type, ROWS, COLS>;
+  template <std::size_t ROWS, std::size_t COLS>
+  using matrix = algebra::vecmem::matrix_type<value_type, ROWS, COLS>;
 };
 /// @}
 
-} // namespace plugin
+}  // namespace plugin
 
 }  // namespace algebra

--- a/frontend/vecmem_cmath/include/algebra/vecmem_cmath.hpp
+++ b/frontend/vecmem_cmath/include/algebra/vecmem_cmath.hpp
@@ -10,6 +10,7 @@
 // Project include(s).
 #include "algebra/math/cmath.hpp"
 #include "algebra/math/generic.hpp"
+#include "algebra/print.hpp"
 #include "algebra/storage/vecmem.hpp"
 
 /// @name Operators on @c algebra::vecmem::storage_type
@@ -18,6 +19,9 @@
 using algebra::cmath::operator*;
 using algebra::cmath::operator-;
 using algebra::cmath::operator+;
+
+/// Print the linear algebra types of this backend
+using algebra::operator<<;
 
 /// @}
 

--- a/math/cmath/include/algebra/math/cmath.hpp
+++ b/math/cmath/include/algebra/math/cmath.hpp
@@ -8,6 +8,8 @@
 #pragma once
 
 // Impl include(s).
+#include "algebra/math/boolean.hpp"
+#include "algebra/math/common.hpp"
 #include "algebra/math/impl/cmath_matrix.hpp"
 #include "algebra/math/impl/cmath_operators.hpp"
 #include "algebra/math/impl/cmath_vector.hpp"

--- a/math/cmath/include/algebra/math/impl/cmath_matrix.hpp
+++ b/math/cmath/include/algebra/math/impl/cmath_matrix.hpp
@@ -10,6 +10,7 @@
 // Project include(s).
 #include "algebra/concepts.hpp"
 #include "algebra/math/common.hpp"
+#include "algebra/math/generic.hpp"
 #include "algebra/qualifiers.hpp"
 
 namespace algebra::cmath {
@@ -48,6 +49,30 @@ template <std::size_t ROWS, std::size_t COLS, concepts::scalar scalar_t,
 ALGEBRA_HOST_DEVICE constexpr void set_identity(
     array_t<array_t<scalar_t, ROWS>, COLS> &m) {
   m = identity<array_t<array_t<scalar_t, ROWS>, COLS>>();
+}
+
+/// @returns the transpose matrix of @param m
+template <std::size_t ROWS, std::size_t COLS, concepts::scalar scalar_t,
+          template <typename, std::size_t> class array_t>
+ALGEBRA_HOST_DEVICE inline auto transpose(
+    const array_t<array_t<scalar_t, ROWS>, COLS> &m) {
+  return algebra::generic::math::transpose(m);
+}
+
+/// @returns the determinant of @param m
+template <std::size_t ROWS, std::size_t COLS, concepts::scalar scalar_t,
+          template <typename, std::size_t> class array_t>
+ALGEBRA_HOST_DEVICE inline scalar_t determinant(
+    const array_t<array_t<scalar_t, ROWS>, COLS> &m) {
+  return algebra::generic::math::determinant(m);
+}
+
+/// @returns the determinant of @param m
+template <std::size_t ROWS, std::size_t COLS, concepts::scalar scalar_t,
+          template <typename, std::size_t> class array_t>
+ALGEBRA_HOST_DEVICE inline auto inverse(
+    const array_t<array_t<scalar_t, ROWS>, COLS> &m) {
+  return algebra::generic::math::inverse(m);
 }
 
 }  // namespace algebra::cmath

--- a/math/cmath/include/algebra/math/impl/cmath_vector.hpp
+++ b/math/cmath/include/algebra/math/impl/cmath_vector.hpp
@@ -10,21 +10,104 @@
 // Project include(s).
 #include "algebra/concepts.hpp"
 #include "algebra/math/common.hpp"
+#include "algebra/math/generic.hpp"
 #include "algebra/qualifiers.hpp"
 
 namespace algebra::cmath {
 
-/// Dot product between two input vectors
+/// This method retrieves phi from a vector with rows >= 2
+///
+/// @param v the input vector
+template <concepts::index size_type,
+          template <typename, size_type> class array_t,
+          concepts::scalar scalar_t, size_type N>
+requires(N >= 2) ALGEBRA_HOST_DEVICE inline scalar_t
+    phi(const array_t<scalar_t, N> &v) {
+  return algebra::generic::math::phi(v);
+}
+
+/// This method retrieves the perpendicular magnitude of a vector with rows >= 2
+///
+/// @param v the input vector
+template <concepts::index size_type,
+          template <typename, size_type> class array_t,
+          concepts::scalar scalar_t, size_type N>
+requires(N >= 2) ALGEBRA_HOST_DEVICE inline scalar_t
+    perp(const array_t<scalar_t, N> &v) {
+  return algebra::generic::math::perp(v);
+}
+
+/// This method retrieves theta from a vector with rows >= 3
+///
+/// @param v the input vector
+template <concepts::index size_type,
+          template <typename, size_type> class array_t,
+          concepts::scalar scalar_t, size_type N>
+requires(N >= 2) ALGEBRA_HOST_DEVICE inline scalar_t
+    theta(const array_t<scalar_t, N> &v) {
+  return algebra::generic::math::theta(v);
+}
+
+/// Cross product between two input vectors - 3 Dim
+///
+/// @tparam size_type the index type for this plugin
+/// @tparam array_t the array type the plugin is based on
+/// @tparam scalar_t the scalar type
+/// @tparam N the dimension of the vectors (minimum 3)
+///
+/// @param a the first input vector
+/// @param b the second input vector
+///
+/// @return a vector representing the cross product
+/// @{
+template <concepts::index size_type,
+          template <typename, size_type> class array_t,
+          concepts::scalar scalar_t, size_type N>
+requires(N >= 3) ALGEBRA_HOST_DEVICE
+    inline array_t<scalar_t, N> cross(const array_t<scalar_t, N> &a,
+                                      const array_t<scalar_t, N> &b) {
+  return algebra::generic::math::cross(a, b);
+}
+
+template <concepts::index size_type,
+          template <typename, size_type> class array_t,
+          concepts::scalar scalar_t, size_type N>
+requires(N >= 3) ALGEBRA_HOST_DEVICE inline array_t<scalar_t, N> cross(
+    const array_t<scalar_t, N> &a, const array_t<array_t<scalar_t, N>, 1> &b) {
+  return algebra::generic::math::cross(a, b);
+}
+
+template <concepts::index size_type,
+          template <typename, size_type> class array_t,
+          concepts::scalar scalar_t, size_type N>
+requires(N >= 3) ALGEBRA_HOST_DEVICE
+    inline array_t<scalar_t, N> cross(const array_t<array_t<scalar_t, N>, 1> &a,
+                                      const array_t<scalar_t, N> &b) {
+  return algebra::generic::math::cross(a, b);
+}
+
+template <concepts::index size_type,
+          template <typename, size_type> class array_t,
+          concepts::scalar scalar_t, size_type N>
+requires(N >= 3) ALGEBRA_HOST_DEVICE inline array_t<scalar_t, N> cross(
+    const array_t<array_t<scalar_t, N>, 1> &a,
+    const array_t<array_t<scalar_t, N>, 1> &b) {
+  return algebra::generic::math::cross(a, b);
+}
+/// @}
+
+/// Dot product between two input vectors/column matrices
 ///
 /// @param a the first input vector
 /// @param b the second input vector
 ///
 /// @return the scalar dot product value
+/// @{
 template <concepts::index size_type,
           template <typename, size_type> class array_t,
           concepts::scalar scalar_t, size_type N>
-requires std::is_scalar_v<scalar_t> ALGEBRA_HOST_DEVICE inline scalar_t dot(
-    const array_t<scalar_t, N> &a, const array_t<scalar_t, N> &b) {
+ALGEBRA_HOST_DEVICE inline scalar_t dot(const array_t<scalar_t, N> &a,
+                                        const array_t<scalar_t, N> &b) {
   array_t<scalar_t, N> tmp;
   for (size_type i = 0; i < N; i++) {
     tmp[i] = a[i] * b[i];
@@ -36,18 +119,11 @@ requires std::is_scalar_v<scalar_t> ALGEBRA_HOST_DEVICE inline scalar_t dot(
   return ret;
 }
 
-/// Dot product between two input vectors
-///
-/// @param a the first input vector
-/// @param b the second input matrix with single column
-///
-/// @return the scalar dot product value
 template <concepts::index size_type,
           template <typename, size_type> class array_t,
-          concepts::scalar scalar_t, size_type N, size_type COLS>
-requires(COLS == 1 && std::is_scalar_v<scalar_t>) ALGEBRA_HOST_DEVICE
-    inline scalar_t dot(const array_t<scalar_t, N> &a,
-                        const array_t<array_t<scalar_t, N>, COLS> &b) {
+          concepts::scalar scalar_t, size_type N>
+ALGEBRA_HOST_DEVICE inline scalar_t dot(
+    const array_t<scalar_t, N> &a, const array_t<array_t<scalar_t, N>, 1> &b) {
   array_t<scalar_t, N> tmp;
   for (size_type i = 0; i < N; i++) {
     tmp[i] = a[i] * b[0][i];
@@ -59,18 +135,11 @@ requires(COLS == 1 && std::is_scalar_v<scalar_t>) ALGEBRA_HOST_DEVICE
   return ret;
 }
 
-/// Dot product between two input vectors
-///
-/// @param a the first input matrix with single column
-/// @param b the second input vector
-///
-/// @return the scalar dot product value
 template <concepts::index size_type,
           template <typename, size_type> class array_t,
-          concepts::scalar scalar_t, size_type N, size_type COLS>
-requires(COLS == 1 && std::is_scalar_v<scalar_t>) ALGEBRA_HOST_DEVICE
-    inline scalar_t dot(const array_t<array_t<scalar_t, N>, COLS> &a,
-                        const array_t<scalar_t, N> &b) {
+          concepts::scalar scalar_t, size_type N>
+ALGEBRA_HOST_DEVICE inline scalar_t dot(
+    const array_t<array_t<scalar_t, N>, 1> &a, const array_t<scalar_t, N> &b) {
   array_t<scalar_t, N> tmp;
   for (size_type i = 0; i < N; i++) {
     tmp[i] = a[0][i] * b[i];
@@ -82,18 +151,12 @@ requires(COLS == 1 && std::is_scalar_v<scalar_t>) ALGEBRA_HOST_DEVICE
   return ret;
 }
 
-/// Dot product between two input vectors
-///
-/// @param a the first input matrix with single column
-/// @param b the second input matrix with single column
-///
-/// @return the scalar dot product value
 template <concepts::index size_type,
           template <typename, size_type> class array_t,
-          concepts::scalar scalar_t, size_type N, size_type COLS>
-requires(COLS == 1 && std::is_scalar_v<scalar_t>) ALGEBRA_HOST_DEVICE
-    inline scalar_t dot(const array_t<array_t<scalar_t, N>, COLS> &a,
-                        const array_t<array_t<scalar_t, N>, COLS> &b) {
+          concepts::scalar scalar_t, size_type N>
+ALGEBRA_HOST_DEVICE inline scalar_t dot(
+    const array_t<array_t<scalar_t, N>, 1> &a,
+    const array_t<array_t<scalar_t, N>, 1> &b) {
   array_t<scalar_t, N> tmp;
   for (size_type i = 0; i < N; i++) {
     tmp[i] = a[0][i] * b[0][i];
@@ -104,6 +167,7 @@ requires(COLS == 1 && std::is_scalar_v<scalar_t>) ALGEBRA_HOST_DEVICE
   }
   return ret;
 }
+/// @}
 
 /// This method retrieves the norm of a vector, no dimension restriction
 ///
@@ -111,8 +175,8 @@ requires(COLS == 1 && std::is_scalar_v<scalar_t>) ALGEBRA_HOST_DEVICE
 template <concepts::index size_type,
           template <typename, size_type> class array_t,
           concepts::scalar scalar_t, size_type N>
-requires(N >= 2 && std::is_scalar_v<scalar_t>) ALGEBRA_HOST_DEVICE
-    inline scalar_t norm(const array_t<scalar_t, N> &v) {
+requires(N >= 2) ALGEBRA_HOST_DEVICE inline scalar_t
+    norm(const array_t<scalar_t, N> &v) {
 
   return algebra::math::sqrt(dot(v, v));
 }
@@ -124,8 +188,8 @@ requires(N >= 2 && std::is_scalar_v<scalar_t>) ALGEBRA_HOST_DEVICE
 template <concepts::index size_type,
           template <typename, size_type> class array_t,
           concepts::scalar scalar_t, size_type N>
-requires(N >= 3 && std::is_scalar_v<scalar_t>) ALGEBRA_HOST_DEVICE
-    inline scalar_t eta(const array_t<scalar_t, N> &v) noexcept {
+requires(N >= 3) ALGEBRA_HOST_DEVICE inline scalar_t
+    eta(const array_t<scalar_t, N> &v) noexcept {
 
   return algebra::math::atanh(v[2] / norm(v));
 }
@@ -136,9 +200,8 @@ requires(N >= 3 && std::is_scalar_v<scalar_t>) ALGEBRA_HOST_DEVICE
 template <concepts::index size_type,
           template <typename, size_type> class array_t,
           concepts::scalar scalar_t, size_type N>
-requires std::is_scalar_v<scalar_t>
-    ALGEBRA_HOST_DEVICE inline array_t<scalar_t, N> normalize(
-        const array_t<scalar_t, N> &v) {
+ALGEBRA_HOST_DEVICE inline array_t<scalar_t, N> normalize(
+    const array_t<scalar_t, N> &v) {
 
   return (static_cast<scalar_t>(1.) / norm(v)) * v;
 }

--- a/math/common/CMakeLists.txt
+++ b/math/common/CMakeLists.txt
@@ -7,8 +7,10 @@
 # Set up the library.
 algebra_add_library(algebra_common_math common_math
    # Math
+   "include/algebra/math/boolean.hpp"
    "include/algebra/math/common.hpp")
 target_link_libraries(algebra_common_math
    INTERFACE algebra::common)
 algebra_test_public_headers( algebra_common_math
+   "algebra/math/boolean.hpp"
    "algebra/math/common.hpp" )

--- a/math/common/include/algebra/math/boolean.hpp
+++ b/math/common/include/algebra/math/boolean.hpp
@@ -1,0 +1,25 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+namespace algebra::boolean {
+
+/// Utilities for single booleans: default case
+/// @{
+constexpr bool any_of(bool b) {
+  return b;
+}
+constexpr bool all_of(bool b) {
+  return b;
+}
+constexpr bool none_of(bool b) {
+  return !b;
+}
+/// @}
+
+}  // namespace algebra::boolean

--- a/math/common/include/algebra/math/common.hpp
+++ b/math/common/include/algebra/math/common.hpp
@@ -7,10 +7,6 @@
 
 #pragma once
 
-// Project include(s).
-#include "algebra/concepts.hpp"
-#include "algebra/qualifiers.hpp"
-
 // SYCL include(s).
 #if defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION)
 #include <sycl/sycl.hpp>
@@ -20,55 +16,17 @@
 #include <algorithm>
 #include <cmath>
 
-namespace algebra::math {
+namespace algebra {
 
-/// Namespace to pick up math functions from
+/// Namespace to pick up common math functions from
 #if defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION)
-namespace math_ns = ::sycl;
+namespace math {
+using namespace ::sycl;
+}
 #else
-namespace math_ns = std;
+namespace math {
+using namespace std;
+}
 #endif  // SYCL
 
-/// Absolute value of arg
-template <concepts::scalar scalar_t>
-ALGEBRA_HOST_DEVICE inline auto fabs(scalar_t arg) {
-  return math_ns::fabs(arg);
-}
-
-/// Fused multiply add
-template <concepts::scalar scalar_t>
-ALGEBRA_HOST_DEVICE inline auto fma(scalar_t x, scalar_t y, scalar_t z) {
-  return math_ns::fma(x, y, z);
-}
-
-/// Arc tangent of y/x
-template <concepts::scalar scalar_t>
-ALGEBRA_HOST_DEVICE inline scalar_t atan2(scalar_t y, scalar_t x) {
-  return math_ns::atan2(y, x);
-}
-
-/// Square root of arg
-template <concepts::scalar scalar_t>
-ALGEBRA_HOST_DEVICE inline scalar_t sqrt(scalar_t arg) {
-  return math_ns::sqrt(arg);
-}
-
-/// Inverse hyperbolic tangent of arg
-template <concepts::scalar scalar_t>
-ALGEBRA_HOST_DEVICE inline scalar_t atanh(scalar_t arg) {
-  return math_ns::atanh(arg);
-}
-
-/// Minimum of two values
-template <concepts::scalar scalar_t>
-ALGEBRA_HOST_DEVICE inline scalar_t min(scalar_t a, scalar_t b) {
-  return math_ns::min(a, b);
-}
-
-/// Maximum of two values
-template <concepts::scalar scalar_t>
-ALGEBRA_HOST_DEVICE inline scalar_t max(scalar_t a, scalar_t b) {
-  return math_ns::max(a, b);
-}
-
-}  // namespace algebra::math
+}  // namespace algebra

--- a/math/eigen/include/algebra/math/eigen.hpp
+++ b/math/eigen/include/algebra/math/eigen.hpp
@@ -8,6 +8,8 @@
 #pragma once
 
 // Project include(s).
+#include "algebra/math/boolean.hpp"
+#include "algebra/math/common.hpp"
 #include "algebra/math/impl/eigen_matrix.hpp"
 #include "algebra/math/impl/eigen_transform3.hpp"
 #include "algebra/math/impl/eigen_vector.hpp"

--- a/math/eigen/include/algebra/math/impl/eigen_vector.hpp
+++ b/math/eigen/include/algebra/math/impl/eigen_vector.hpp
@@ -28,6 +28,25 @@
 
 namespace algebra::eigen::math {
 
+/// This method retrieves phi from a vector @param v
+template <typename derived_type>
+ALGEBRA_HOST_DEVICE inline auto phi(const Eigen::MatrixBase<derived_type> &v) {
+  return algebra::math::atan2(v[1], v[0]);
+}
+
+/// This method retrieves the perpendicular magnitude of a vector @param v
+template <typename derived_type>
+ALGEBRA_HOST_DEVICE inline auto perp(const Eigen::MatrixBase<derived_type> &v) {
+  return algebra::math::sqrt(algebra::math::fma(v[0], v[0], v[1] * v[1]));
+}
+
+/// This method retrieves theta from a vector @param v
+template <typename derived_type>
+ALGEBRA_HOST_DEVICE inline auto theta(
+    const Eigen::MatrixBase<derived_type> &v) {
+  return algebra::math::atan2(perp(v), v[2]);
+}
+
 /// This method retrieves the norm of a vector, no dimension restriction
 ///
 /// @param v the input vector

--- a/math/fastor/include/algebra/math/fastor.hpp
+++ b/math/fastor/include/algebra/math/fastor.hpp
@@ -8,6 +8,8 @@
 #pragma once
 
 // Project include(s).
+#include "algebra/math/boolean.hpp"
+#include "algebra/math/common.hpp"
 #include "algebra/math/impl/fastor_matrix.hpp"
 #include "algebra/math/impl/fastor_transform3.hpp"
 #include "algebra/math/impl/fastor_vector.hpp"

--- a/math/fastor/include/algebra/math/impl/fastor_transform3.hpp
+++ b/math/fastor/include/algebra/math/impl/fastor_transform3.hpp
@@ -179,7 +179,7 @@ struct transform3 {
   /// This method transform from a point from the local 3D cartesian frame to
   /// the global 3D cartesian frame
   ALGEBRA_HOST
-  inline const point3 point_to_global(const point3 &v) const {
+  inline point3 point_to_global(const point3 &v) const {
 
     Fastor::Tensor<scalar_type, 4> vector_4;
     vector_4(Fastor::fseq<0, 3>()) = v;
@@ -191,7 +191,7 @@ struct transform3 {
   /// This method transform from a vector from the global 3D cartesian frame
   /// into the local 3D cartesian frame
   ALGEBRA_HOST
-  inline const point3 point_to_local(const point3 &v) const {
+  inline point3 point_to_local(const point3 &v) const {
 
     Fastor::Tensor<scalar_type, 4> vector_4;
     vector_4(Fastor::fseq<0, 3>()) = v;
@@ -203,7 +203,7 @@ struct transform3 {
   /// This method transform from a vector from the local 3D cartesian frame to
   /// the global 3D cartesian frame
   ALGEBRA_HOST
-  inline const point3 vector_to_global(const vector3 &v) const {
+  inline point3 vector_to_global(const vector3 &v) const {
 
     Fastor::Tensor<scalar_type, 4> vector_4;
     vector_4(Fastor::fseq<0, 3>()) = v;
@@ -215,7 +215,7 @@ struct transform3 {
   /// This method transform from a vector from the global 3D cartesian frame
   /// into the local 3D cartesian frame
   ALGEBRA_HOST
-  inline const point3 vector_to_local(const vector3 &v) const {
+  inline point3 vector_to_local(const vector3 &v) const {
 
     Fastor::Tensor<scalar_type, 4> vector_4;
     vector_4(Fastor::fseq<0, 3>()) = v;

--- a/math/fastor/include/algebra/math/impl/fastor_vector.hpp
+++ b/math/fastor/include/algebra/math/impl/fastor_vector.hpp
@@ -21,6 +21,13 @@
 
 namespace algebra::fastor::math {
 
+/// This method retrieves phi from a vector @param v
+template <concepts::scalar scalar_t, auto N>
+requires(N >= 2) ALGEBRA_HOST_DEVICE
+    inline auto phi(const Fastor::Tensor<scalar_t, N> &v) {
+  return algebra::math::atan2(v[1], v[0]);
+}
+
 /// This method retrieves theta from a vector, vector base with rows >= 3
 ///
 /// @param v the input vector

--- a/math/generic/include/algebra/math/generic.hpp
+++ b/math/generic/include/algebra/math/generic.hpp
@@ -8,6 +8,8 @@
 #pragma once
 
 // Impl include(s).
+#include "algebra/math/boolean.hpp"
+#include "algebra/math/common.hpp"
 #include "algebra/math/impl/generic_matrix.hpp"
 #include "algebra/math/impl/generic_transform3.hpp"
 #include "algebra/math/impl/generic_vector.hpp"

--- a/math/smatrix/include/algebra/math/impl/smatrix_transform3.hpp
+++ b/math/smatrix/include/algebra/math/impl/smatrix_transform3.hpp
@@ -196,7 +196,7 @@ struct transform3 {
   /// This method transform from a point from the local 3D cartesian frame to
   /// the global 3D cartesian frame
   ALGEBRA_HOST
-  inline const point3 point_to_global(const point3 &v) const {
+  inline point3 point_to_global(const point3 &v) const {
 
     ROOT::Math::SVector<scalar_type, 4> vector_4;
     vector_4.Place_at(v, 0);
@@ -208,7 +208,7 @@ struct transform3 {
   /// This method transform from a vector from the global 3D cartesian frame
   /// into the local 3D cartesian frame
   ALGEBRA_HOST
-  inline const point3 point_to_local(const point3 &v) const {
+  inline point3 point_to_local(const point3 &v) const {
 
     ROOT::Math::SVector<scalar_type, 4> vector_4;
     vector_4.Place_at(v, 0);
@@ -220,7 +220,7 @@ struct transform3 {
   /// This method transform from a vector from the local 3D cartesian frame to
   /// the global 3D cartesian frame
   ALGEBRA_HOST
-  inline const point3 vector_to_global(const vector3 &v) const {
+  inline point3 vector_to_global(const vector3 &v) const {
 
     ROOT::Math::SVector<scalar_type, 4> vector_4;
     vector_4.Place_at(v, 0);
@@ -231,7 +231,7 @@ struct transform3 {
   /// This method transform from a vector from the global 3D cartesian frame
   /// into the local 3D cartesian frame
   ALGEBRA_HOST
-  inline const point3 vector_to_local(const vector3 &v) const {
+  inline point3 vector_to_local(const vector3 &v) const {
 
     ROOT::Math::SVector<scalar_type, 4> vector_4;
     vector_4.Place_at(v, 0);

--- a/math/smatrix/include/algebra/math/smatrix.hpp
+++ b/math/smatrix/include/algebra/math/smatrix.hpp
@@ -8,6 +8,8 @@
 #pragma once
 
 // Project include(s).
+#include "algebra/math/boolean.hpp"
+#include "algebra/math/common.hpp"
 #include "algebra/math/impl/smatrix_matrix.hpp"
 #include "algebra/math/impl/smatrix_transform3.hpp"
 #include "algebra/math/impl/smatrix_vector.hpp"

--- a/math/vc_aos/CMakeLists.txt
+++ b/math/vc_aos/CMakeLists.txt
@@ -7,7 +7,7 @@
 # Set up the library.
 algebra_add_library( algebra_vc_aos_math vc_aos_math
    "include/algebra/math/vc_aos.hpp"
-   "include/algebra/math/impl/vc_aos_getter.hpp"
+   "include/algebra/math/impl/vc_aos_matrix.hpp"
    "include/algebra/math/impl/vc_aos_transform3.hpp"
    "include/algebra/math/impl/vc_aos_vector.hpp" )
 target_link_libraries( algebra_vc_aos_math

--- a/math/vc_aos/CMakeLists.txt
+++ b/math/vc_aos/CMakeLists.txt
@@ -11,7 +11,6 @@ algebra_add_library( algebra_vc_aos_math vc_aos_math
    "include/algebra/math/impl/vc_aos_transform3.hpp"
    "include/algebra/math/impl/vc_aos_vector.hpp" )
 target_link_libraries( algebra_vc_aos_math
-   INTERFACE Vc::Vc algebra::common algebra::common_math
-             algebra::vc_aos_storage )
+   INTERFACE Vc::Vc algebra::common algebra::common_math algebra::generic_math algebra::vc_aos_storage )
 algebra_test_public_headers( algebra_vc_aos_math
    "algebra/math/vc_aos.hpp" )

--- a/math/vc_aos/include/algebra/math/impl/vc_aos_matrix.hpp
+++ b/math/vc_aos/include/algebra/math/impl/vc_aos_matrix.hpp
@@ -9,6 +9,7 @@
 
 // Project include(s).
 #include "algebra/concepts.hpp"
+#include "algebra/math/generic.hpp"
 #include "algebra/qualifiers.hpp"
 #include "algebra/storage/matrix.hpp"
 
@@ -20,23 +21,28 @@ using storage::set_zero;
 using storage::transpose;
 using storage::zero;
 
-/// General case: Compute the determinant of a square matrix
-///
 /// @returns the determinant
 template <std::size_t N, concepts::value value_t,
           template <typename, std::size_t> class array_t>
 ALGEBRA_HOST_DEVICE constexpr value_t determinant(
-    const storage::matrix<array_t, value_t, N, N> &) noexcept {
-  // @TODO: Implement
-  return value_t(0);
+    const storage::matrix<array_t, value_t, N, N> &m) noexcept {
+  return algebra::generic::math::determinant(m);
 }
 
+/// @returns the inverse
 template <std::size_t ROW, std::size_t COL, concepts::value value_t,
           template <typename, std::size_t> class array_t>
-ALGEBRA_HOST_DEVICE constexpr storage::matrix<array_t, value_t, ROW, COL>
+ALGEBRA_HOST_DEVICE constexpr storage::matrix<array_t, value_t, COL, ROW>
 inverse(const storage::matrix<array_t, value_t, ROW, COL> &m) noexcept {
-  // @TODO: Implement
-  return m;
+  return algebra::generic::math::inverse(m);
+}
+
+/// @returns the transpose
+template <std::size_t ROW, std::size_t COL, concepts::value value_t,
+          template <typename, std::size_t> class array_t>
+ALGEBRA_HOST_DEVICE constexpr storage::matrix<array_t, value_t, COL, ROW>
+transpose(const storage::matrix<array_t, value_t, ROW, COL> &m) noexcept {
+  return algebra::generic::math::transpose(m);
 }
 
 }  // namespace algebra::vc_aos::math

--- a/math/vc_aos/include/algebra/math/impl/vc_aos_transform3.hpp
+++ b/math/vc_aos/include/algebra/math/impl/vc_aos_transform3.hpp
@@ -36,7 +36,7 @@ using algebra::storage::operator+;
 
 /// Transform wrapper class to ensure standard API within differnt plugins
 template <template <typename, std::size_t> class array_t,
-          concepts::value value_t>
+          concepts::scalar scalar_t>
 struct transform3 {
 
  private:
@@ -53,11 +53,7 @@ struct transform3 {
   /// @{
 
   /// Scalar type used by the transform
-  using value_type = value_t;
-  /// The type of the matrix elements (scalar for AoS, Vc::Vector for SoA)
-  using scalar_type =
-      std::conditional_t<Vc::is_simd_vector<array_t<value_t, 4>>::value,
-                         value_t, Vc::Vector<value_t>>;
+  using scalar_type = scalar_t;
 
   template <std::size_t N>
   using array_type = array_t<scalar_type, N>;

--- a/math/vc_aos/include/algebra/math/impl/vc_aos_vector.hpp
+++ b/math/vc_aos/include/algebra/math/impl/vc_aos_vector.hpp
@@ -30,25 +30,19 @@
 namespace algebra::vc_aos::math {
 
 /// This method retrieves phi from a vector @param v
-template <typename vector_t>
-  requires(Vc::is_simd_vector<vector_t>::value ||
-           algebra::detail::is_storage_vector_v<vector_t>)
+template <algebra::concepts::vc_aos_vector vector_t>
 ALGEBRA_HOST_DEVICE inline auto phi(const vector_t &v) {
   return algebra::math::atan2(v[1], v[0]);
 }
 
 /// This method retrieves the perpendicular magnitude of a vector @param v
-template <typename vector_t>
-  requires(Vc::is_simd_vector<vector_t>::value ||
-           algebra::detail::is_storage_vector_v<vector_t>)
+template <algebra::concepts::vc_aos_vector vector_t>
 ALGEBRA_HOST_DEVICE inline auto perp(const vector_t &v) {
   return algebra::math::sqrt(algebra::math::fma(v[0], v[0], v[1] * v[1]));
 }
 
 /// This method retrieves theta from a vector @param v
-template <typename vector_t>
-  requires(Vc::is_simd_vector<vector_t>::value ||
-           algebra::detail::is_storage_vector_v<vector_t>)
+template <algebra::concepts::vc_aos_vector vector_t>
 ALGEBRA_HOST_DEVICE inline auto theta(const vector_t &v) {
   return algebra::math::atan2(perp(v), v[2]);
 }
@@ -61,11 +55,8 @@ ALGEBRA_HOST_DEVICE inline auto theta(const vector_t &v) {
 /// @param b the second input vector
 ///
 /// @return the scalar dot product value
-template <typename vector_t1, typename vector_t2>
-  requires((Vc::is_simd_vector<vector_t1>::value ||
-            algebra::detail::is_storage_vector_v<vector_t1>) &&
-           (Vc::is_simd_vector<vector_t2>::value ||
-            algebra::detail::is_storage_vector_v<vector_t2>))
+template <algebra::concepts::vc_aos_vector vector_t1,
+          algebra::concepts::vc_aos_vector vector_t2>
 ALGEBRA_HOST_DEVICE inline auto dot(const vector_t1 &a, const vector_t2 &b) {
 
   return (a * b).sum();
@@ -74,9 +65,7 @@ ALGEBRA_HOST_DEVICE inline auto dot(const vector_t1 &a, const vector_t2 &b) {
 /// This method retrieves the norm of a vector, no dimension restriction
 ///
 /// @param v the input vector
-template <typename vector_t>
-  requires(Vc::is_simd_vector<vector_t>::value ||
-           algebra::detail::is_storage_vector_v<vector_t>)
+template <algebra::concepts::vc_aos_vector vector_t>
 ALGEBRA_HOST_DEVICE inline auto norm(const vector_t &v) {
 
   return algebra::math::sqrt(dot(v, v));
@@ -87,9 +76,7 @@ ALGEBRA_HOST_DEVICE inline auto norm(const vector_t &v) {
 /// @tparam vector_t generic input vector type
 ///
 /// @param v the input vector
-template <typename vector_t>
-  requires(Vc::is_simd_vector<vector_t>::value ||
-           algebra::detail::is_storage_vector_v<vector_t>)
+template <algebra::concepts::vc_aos_vector vector_t>
 ALGEBRA_HOST_DEVICE inline auto normalize(const vector_t &v) {
 
   return v / norm(v);
@@ -99,9 +86,7 @@ ALGEBRA_HOST_DEVICE inline auto normalize(const vector_t &v) {
 /// rows >= 3
 ///
 /// @param v the input vector
-template <typename vector_t>
-  requires(Vc::is_simd_vector<vector_t>::value ||
-           algebra::detail::is_storage_vector_v<vector_t>)
+template <algebra::concepts::vc_aos_vector vector_t>
 ALGEBRA_HOST_DEVICE inline auto eta(const vector_t &v) noexcept {
 
   return algebra::math::atanh(v[2] / norm(v));
@@ -115,17 +100,14 @@ ALGEBRA_HOST_DEVICE inline auto eta(const vector_t &v) noexcept {
 /// @param b the second input vector
 ///
 /// @return a vector representing the cross product
-template <typename vector_t1, typename vector_t2>
-  requires((Vc::is_simd_vector<vector_t1>::value ||
-            algebra::detail::is_storage_vector_v<vector_t1>) &&
-           (Vc::is_simd_vector<vector_t2>::value ||
-            algebra::detail::is_storage_vector_v<vector_t2>))
-ALGEBRA_HOST_DEVICE inline auto cross(const vector_t1 &a, const vector_t2 &b) -> decltype(a * b - b * a) {
+template <algebra::concepts::vc_aos_vector vector_t1,
+          algebra::concepts::vc_aos_vector vector_t2>
+ALGEBRA_HOST_DEVICE inline auto cross(const vector_t1 &a, const vector_t2 &b)
+    -> decltype(a * b - b * a) {
 
-  return {
-      algebra::math::fma(a[1], b[2], -b[1] * a[2]),
-      algebra::math::fma(a[2], b[0], -b[2] * a[0]),
-      algebra::math::fma(a[0], b[1], -b[0] * a[1]), 0.f};
+  return {algebra::math::fma(a[1], b[2], -b[1] * a[2]),
+          algebra::math::fma(a[2], b[0], -b[2] * a[0]),
+          algebra::math::fma(a[0], b[1], -b[0] * a[1]), 0.f};
 }
 
 /// Elementwise sum
@@ -135,9 +117,7 @@ ALGEBRA_HOST_DEVICE inline auto cross(const vector_t1 &a, const vector_t2 &b) ->
 /// @param v the vector whose elements should be summed
 ///
 /// @return the sum of the elements
-template <typename vector_t>
-  requires(Vc::is_simd_vector<vector_t>::value ||
-           algebra::detail::is_storage_vector_v<vector_t>)
+template <algebra::concepts::vc_aos_vector vector_t>
 ALGEBRA_HOST_DEVICE inline auto sum(const vector_t &v) {
   return v.get().sum();
 }

--- a/math/vc_aos/include/algebra/math/impl/vc_aos_vector.hpp
+++ b/math/vc_aos/include/algebra/math/impl/vc_aos_vector.hpp
@@ -11,6 +11,7 @@
 #include "algebra/concepts.hpp"
 #include "algebra/math/common.hpp"
 #include "algebra/qualifiers.hpp"
+#include "algebra/storage/vc_aos.hpp"
 #include "algebra/storage/vector.hpp"
 
 // Vc include(s).
@@ -30,44 +31,42 @@ namespace algebra::vc_aos::math {
 
 /// This method retrieves phi from a vector @param v
 template <typename vector_t>
-requires(Vc::is_simd_vector<vector_t>::value ||
-         algebra::detail::is_storage_vector_v<vector_t>) ALGEBRA_HOST_DEVICE
-    inline auto phi(const vector_t &v) {
+  requires(Vc::is_simd_vector<vector_t>::value ||
+           algebra::detail::is_storage_vector_v<vector_t>)
+ALGEBRA_HOST_DEVICE inline auto phi(const vector_t &v) {
   return algebra::math::atan2(v[1], v[0]);
 }
 
 /// This method retrieves the perpendicular magnitude of a vector @param v
 template <typename vector_t>
-requires(Vc::is_simd_vector<vector_t>::value ||
-         algebra::detail::is_storage_vector_v<vector_t>) ALGEBRA_HOST_DEVICE
-    inline auto perp(const vector_t &v) {
+  requires(Vc::is_simd_vector<vector_t>::value ||
+           algebra::detail::is_storage_vector_v<vector_t>)
+ALGEBRA_HOST_DEVICE inline auto perp(const vector_t &v) {
   return algebra::math::sqrt(algebra::math::fma(v[0], v[0], v[1] * v[1]));
 }
 
 /// This method retrieves theta from a vector @param v
 template <typename vector_t>
-requires(Vc::is_simd_vector<vector_t>::value ||
-         algebra::detail::is_storage_vector_v<vector_t>) ALGEBRA_HOST_DEVICE
-    inline auto theta(const vector_t &v) {
+  requires(Vc::is_simd_vector<vector_t>::value ||
+           algebra::detail::is_storage_vector_v<vector_t>)
+ALGEBRA_HOST_DEVICE inline auto theta(const vector_t &v) {
   return algebra::math::atan2(perp(v), v[2]);
 }
 
 /// Dot product between two input vectors
 ///
-/// @tparam vector_type generic input vector type
+/// @tparam vector_t generic input vector type
 ///
 /// @param a the first input vector
 /// @param b the second input vector
 ///
 /// @return the scalar dot product value
-template <typename vector_type1, typename vector_type2>
-requires(
-    (Vc::is_simd_vector<vector_type1>::value ||
-     algebra::detail::is_storage_vector_v<
-         vector_type1>)&&(Vc::is_simd_vector<vector_type2>::value ||
-                          algebra::detail::is_storage_vector_v<vector_type2>))
-    ALGEBRA_HOST_DEVICE
-    inline auto dot(const vector_type1 &a, const vector_type2 &b) {
+template <typename vector_t1, typename vector_t2>
+  requires((Vc::is_simd_vector<vector_t1>::value ||
+            algebra::detail::is_storage_vector_v<vector_t1>) &&
+           (Vc::is_simd_vector<vector_t2>::value ||
+            algebra::detail::is_storage_vector_v<vector_t2>))
+ALGEBRA_HOST_DEVICE inline auto dot(const vector_t1 &a, const vector_t2 &b) {
 
   return (a * b).sum();
 }
@@ -76,22 +75,22 @@ requires(
 ///
 /// @param v the input vector
 template <typename vector_t>
-requires(Vc::is_simd_vector<vector_t>::value ||
-         algebra::detail::is_storage_vector_v<vector_t>) ALGEBRA_HOST_DEVICE
-    inline auto norm(const vector_t &v) {
+  requires(Vc::is_simd_vector<vector_t>::value ||
+           algebra::detail::is_storage_vector_v<vector_t>)
+ALGEBRA_HOST_DEVICE inline auto norm(const vector_t &v) {
 
   return algebra::math::sqrt(dot(v, v));
 }
 
 /// Get a normalized version of the input vector
 ///
-/// @tparam vector_type generic input vector type
+/// @tparam vector_t generic input vector type
 ///
 /// @param v the input vector
-template <typename vector_type>
-requires(Vc::is_simd_vector<vector_type>::value ||
-         algebra::detail::is_storage_vector_v<vector_type>) ALGEBRA_HOST_DEVICE
-    inline auto normalize(const vector_type &v) {
+template <typename vector_t>
+  requires(Vc::is_simd_vector<vector_t>::value ||
+           algebra::detail::is_storage_vector_v<vector_t>)
+ALGEBRA_HOST_DEVICE inline auto normalize(const vector_t &v) {
 
   return v / norm(v);
 }
@@ -101,47 +100,45 @@ requires(Vc::is_simd_vector<vector_type>::value ||
 ///
 /// @param v the input vector
 template <typename vector_t>
-requires(Vc::is_simd_vector<vector_t>::value ||
-         algebra::detail::is_storage_vector_v<vector_t>) ALGEBRA_HOST_DEVICE
-    inline auto eta(const vector_t &v) noexcept {
+  requires(Vc::is_simd_vector<vector_t>::value ||
+           algebra::detail::is_storage_vector_v<vector_t>)
+ALGEBRA_HOST_DEVICE inline auto eta(const vector_t &v) noexcept {
 
   return algebra::math::atanh(v[2] / norm(v));
 }
 
 /// Cross product between two input vectors - 3 Dim
 ///
-/// @tparam vector_type generic input vector type
+/// @tparam vector_t generic input vector type
 ///
 /// @param a the first input vector
 /// @param b the second input vector
 ///
 /// @return a vector representing the cross product
-template <typename vector_type1, typename vector_type2>
-requires(
-    (Vc::is_simd_vector<vector_type1>::value ||
-     algebra::detail::is_storage_vector_v<
-         vector_type1>)&&(Vc::is_simd_vector<vector_type2>::value ||
-                          algebra::detail::is_storage_vector_v<vector_type2>))
-    ALGEBRA_HOST_DEVICE
-    inline auto cross(const vector_type1 &a, const vector_type2 &b)
-        -> decltype(a * b - a * b) {
+template <typename vector_t1, typename vector_t2>
+  requires((Vc::is_simd_vector<vector_t1>::value ||
+            algebra::detail::is_storage_vector_v<vector_t1>) &&
+           (Vc::is_simd_vector<vector_t2>::value ||
+            algebra::detail::is_storage_vector_v<vector_t2>))
+ALGEBRA_HOST_DEVICE inline auto cross(const vector_t1 &a, const vector_t2 &b) -> decltype(a * b - b * a) {
 
-  return {algebra::math::fma(a[1], b[2], -b[1] * a[2]),
-          algebra::math::fma(a[2], b[0], -b[2] * a[0]),
-          algebra::math::fma(a[0], b[1], -b[0] * a[1]), 0.f};
+  return {
+      algebra::math::fma(a[1], b[2], -b[1] * a[2]),
+      algebra::math::fma(a[2], b[0], -b[2] * a[0]),
+      algebra::math::fma(a[0], b[1], -b[0] * a[1]), 0.f};
 }
 
 /// Elementwise sum
 ///
-/// @tparam vector_type generic input vector type
+/// @tparam vector_t generic input vector type
 ///
 /// @param v the vector whose elements should be summed
 ///
 /// @return the sum of the elements
-template <typename vector_type>
-requires(Vc::is_simd_vector<vector_type>::value ||
-         algebra::detail::is_storage_vector_v<vector_type>) ALGEBRA_HOST_DEVICE
-    inline auto sum(const vector_type &v) {
+template <typename vector_t>
+  requires(Vc::is_simd_vector<vector_t>::value ||
+           algebra::detail::is_storage_vector_v<vector_t>)
+ALGEBRA_HOST_DEVICE inline auto sum(const vector_t &v) {
   return v.get().sum();
 }
 

--- a/math/vc_aos/include/algebra/math/impl/vc_aos_vector.hpp
+++ b/math/vc_aos/include/algebra/math/impl/vc_aos_vector.hpp
@@ -28,6 +28,30 @@
 
 namespace algebra::vc_aos::math {
 
+/// This method retrieves phi from a vector @param v
+template <typename vector_t>
+requires(Vc::is_simd_vector<vector_t>::value ||
+         algebra::detail::is_storage_vector_v<vector_t>) ALGEBRA_HOST_DEVICE
+    inline auto phi(const vector_t &v) {
+  return algebra::math::atan2(v[1], v[0]);
+}
+
+/// This method retrieves the perpendicular magnitude of a vector @param v
+template <typename vector_t>
+requires(Vc::is_simd_vector<vector_t>::value ||
+         algebra::detail::is_storage_vector_v<vector_t>) ALGEBRA_HOST_DEVICE
+    inline auto perp(const vector_t &v) {
+  return algebra::math::sqrt(algebra::math::fma(v[0], v[0], v[1] * v[1]));
+}
+
+/// This method retrieves theta from a vector @param v
+template <typename vector_t>
+requires(Vc::is_simd_vector<vector_t>::value ||
+         algebra::detail::is_storage_vector_v<vector_t>) ALGEBRA_HOST_DEVICE
+    inline auto theta(const vector_t &v) {
+  return algebra::math::atan2(perp(v), v[2]);
+}
+
 /// Dot product between two input vectors
 ///
 /// @tparam vector_type generic input vector type

--- a/math/vc_aos/include/algebra/math/vc_aos.hpp
+++ b/math/vc_aos/include/algebra/math/vc_aos.hpp
@@ -8,6 +8,8 @@
 #pragma once
 
 // Project include(s).
+#include "algebra/math/boolean.hpp"
+#include "algebra/math/common.hpp"
 #include "algebra/math/impl/vc_aos_matrix.hpp"
 #include "algebra/math/impl/vc_aos_transform3.hpp"
 #include "algebra/math/impl/vc_aos_vector.hpp"

--- a/math/vc_soa/CMakeLists.txt
+++ b/math/vc_soa/CMakeLists.txt
@@ -7,6 +7,9 @@
 # Set up the library.
 algebra_add_library( algebra_vc_soa_math vc_soa_math
    "include/algebra/math/vc_soa.hpp"
+   "include/algebra/math/impl/vc_soa_boolean.hpp"
+   "include/algebra/math/impl/vc_soa_math.hpp"
+   "include/algebra/math/impl/vc_soa_matrix.hpp"
    "include/algebra/math/impl/vc_soa_vector.hpp")
 target_link_libraries( algebra_vc_soa_math
    INTERFACE algebra::common algebra::common_math algebra::common_storage  algebra::vc_soa_storage Vc::Vc )

--- a/math/vc_soa/include/algebra/math/impl/vc_soa_boolean.hpp
+++ b/math/vc_soa/include/algebra/math/impl/vc_soa_boolean.hpp
@@ -1,0 +1,49 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s).
+#include "algebra/math/boolean.hpp"
+
+// Vc include(s).
+#ifdef _MSC_VER
+#pragma warning(push, 0)
+#endif  // MSVC
+#include <Vc/Vc>
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif  // MSVC
+
+namespace algebra::boolean {
+
+/// Boolean utilities on single values
+/// @{
+using algebra::boolean::all_of;
+using algebra::boolean::any_of;
+using algebra::boolean::none_of;
+/// @}
+
+/// Vc overloads of boolean utilities
+/// @{
+template <typename T>
+requires Vc::Traits::is_simd_mask<T>::value inline bool any_of(T &&mask) {
+  return Vc::any_of(std::forward<T>(mask));
+}
+
+template <typename T>
+requires Vc::Traits::is_simd_mask<T>::value inline bool all_of(T &&mask) {
+  return Vc::all_of(std::forward<T>(mask));
+}
+
+template <typename T>
+requires Vc::Traits::is_simd_mask<T>::value inline bool none_of(T &&mask) {
+  return Vc::none_of(std::forward<T>(mask));
+}
+/// @}
+
+}  // namespace algebra::boolean

--- a/math/vc_soa/include/algebra/math/impl/vc_soa_math.hpp
+++ b/math/vc_soa/include/algebra/math/impl/vc_soa_math.hpp
@@ -1,0 +1,138 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s)
+#include "algebra/storage/impl/vc_soa_concepts.hpp"
+
+// Vc include(s).
+#ifdef _MSC_VER
+#pragma warning(push, 0)
+#endif  // MSVC
+#include <Vc/Vc>
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif  // MSVC
+
+// System include(s)
+#include <algorithm>
+#include <cmath>
+
+namespace algebra::math {
+
+/// Math functions on single values
+/// @{
+using std::abs;
+using std::acos;
+using std::asin;
+using std::atan;
+using std::atan2;
+using std::atanh;
+using std::ceil;
+using std::copysign;
+using std::cos;
+using std::cosh;
+using std::exp;
+using std::fabs;
+using std::floor;
+using std::fma;
+using std::hypot;
+using std::log;
+using std::log10;
+using std::max;
+using std::min;
+using std::pow;
+using std::signbit;
+using std::sin;
+using std::sinh;
+using std::sqrt;
+using std::tan;
+using std::tanh;
+/// @}
+
+/// Vc overloads of common math functions
+/// @{
+template <algebra::concepts::vc_simd_vector T>
+inline decltype(auto) abs(T &&vec) {
+  return Vc::abs(std::forward<T>(vec));
+}
+
+template <algebra::concepts::vc_simd_vector T>
+inline decltype(auto) fabs(T &&vec) {
+  return Vc::abs(std::forward<T>(vec));
+}
+
+template <algebra::concepts::vc_simd_vector T>
+inline decltype(auto) sqrt(T &&vec) {
+  return Vc::sqrt(std::forward<T>(vec));
+}
+
+template <algebra::concepts::vc_simd_vector T>
+inline decltype(auto) exp(T &&vec) {
+  return Vc::exp(std::forward<T>(vec));
+}
+
+template <algebra::concepts::vc_simd_vector T>
+inline decltype(auto) log(T &&vec) {
+  return Vc::log(std::forward<T>(vec));
+}
+
+template <algebra::concepts::vc_simd_vector T>
+inline decltype(auto) sin(T &&vec) {
+  return Vc::sin(std::forward<T>(vec));
+}
+
+template <algebra::concepts::vc_simd_vector T>
+inline decltype(auto) asin(T &&vec) {
+  return Vc::asin(std::forward<T>(vec));
+}
+
+template <algebra::concepts::vc_simd_vector T>
+inline decltype(auto) cos(T &&vec) {
+  return Vc::cos(std::forward<T>(vec));
+}
+
+template <algebra::concepts::vc_simd_vector T>
+inline decltype(auto) tan(T &&vec) {
+  // It seems there is no dedicated @c Vc::tan function ?
+  return Vc::sin(std::forward<T>(vec)) / Vc::cos(std::forward<T>(vec));
+}
+
+template <algebra::concepts::vc_simd_vector T>
+inline decltype(auto) atan(T &&vec) {
+  return Vc::atan(std::forward<T>(vec));
+}
+
+template <algebra::concepts::vc_simd_vector T,
+          algebra::concepts::vc_simd_vector S>
+inline decltype(auto) copysign(T &&mag, S &&sgn) {
+  return Vc::copysign(std::forward<T>(mag), std::forward<S>(sgn));
+}
+
+template <algebra::concepts::vc_simd_vector T>
+inline decltype(auto) min(T &&vec) {
+  return Vc::min(std::forward<T>(vec));
+}
+
+template <algebra::concepts::vc_simd_vector T>
+inline decltype(auto) max(T &&vec) {
+  return Vc::max(std::forward<T>(vec));
+}
+
+template <algebra::concepts::vc_simd_vector T>
+inline decltype(auto) signbit(T &&vec) {
+  return Vc::isnegative(std::forward<T>(vec));
+}
+
+template <algebra::concepts::vc_simd_vector T>
+inline decltype(auto) fma(T &&x, T &&y, T &&z) {
+  return Vc::fma(std::forward<T>(x), std::forward<T>(y), std::forward<T>(z));
+}
+/// @}
+
+}  // namespace algebra::math

--- a/math/vc_soa/include/algebra/math/impl/vc_soa_vector.hpp
+++ b/math/vc_soa/include/algebra/math/impl/vc_soa_vector.hpp
@@ -9,6 +9,7 @@
 
 // Project include(s).
 #include "algebra/concepts.hpp"
+#include "algebra/math/impl/vc_soa_math.hpp"
 #include "algebra/qualifiers.hpp"
 #include "algebra/storage/vector.hpp"
 

--- a/math/vc_soa/include/algebra/math/vc_soa.hpp
+++ b/math/vc_soa/include/algebra/math/vc_soa.hpp
@@ -8,5 +8,7 @@
 #pragma once
 
 // Project include(s).
+#include "algebra/math/impl/vc_soa_boolean.hpp"
+#include "algebra/math/impl/vc_soa_math.hpp"
 #include "algebra/math/impl/vc_soa_matrix.hpp"
 #include "algebra/math/impl/vc_soa_vector.hpp"

--- a/storage/cmath/include/algebra/storage/impl/cmath_getter.hpp
+++ b/storage/cmath/include/algebra/storage/impl/cmath_getter.hpp
@@ -169,7 +169,7 @@ struct block_getter {
   template <std::size_t SIZE, std::size_t ROWS, std::size_t COLS,
             concepts::scalar scalar_t,
             template <typename, std::size_t> class array_t>
-  ALGEBRA_HOST_DEVICE inline array_t<scalar_t, SIZE> operator()(
+  ALGEBRA_HOST_DEVICE inline array_t<scalar_t, SIZE> vector(
       const array_t<array_t<scalar_t, ROWS>, COLS> &m, std::size_t row,
       std::size_t col) {
 
@@ -204,7 +204,7 @@ ALGEBRA_HOST_DEVICE inline array_t<scalar_t, SIZE> vector(
     const array_t<array_t<scalar_t, ROWS>, COLS> &m, std::size_t row,
     std::size_t col) {
 
-  return block_getter().template operator()<SIZE>(m, row, col);
+  return block_getter().template vector<SIZE>(m, row, col);
 }
 
 /// Sets a matrix of dimension @tparam ROW and @tparam COL as submatrix of

--- a/storage/common/CMakeLists.txt
+++ b/storage/common/CMakeLists.txt
@@ -10,5 +10,4 @@ algebra_add_library(algebra_common_storage common_storage
    "include/algebra/storage/matrix_getter.hpp"
    "include/algebra/storage/matrix.hpp"
    "include/algebra/storage/vector.hpp")
-target_link_libraries(algebra_common_storage
-   INTERFACE algebra::common)
+target_link_libraries(algebra_common_storage INTERFACE algebra::common)

--- a/storage/common/include/algebra/storage/matrix.hpp
+++ b/storage/common/include/algebra/storage/matrix.hpp
@@ -32,9 +32,9 @@ struct alignas(alignof(storage::vector<ROW, scalar_t, array_t>)) matrix {
 
   /// Construct from given column vectors @param v
   template <concepts::vector... vector_t>
-  ALGEBRA_HOST_DEVICE requires(sizeof...(vector_t) ==
-                               COL) explicit matrix(vector_t &&... v)
-      : m_storage{std::forward<vector_t>(v)...} {}
+  ALGEBRA_HOST_DEVICE
+    requires(sizeof...(vector_t) == COL)
+  explicit matrix(vector_t &&...v) : m_storage{std::forward<vector_t>(v)...} {}
 
   /// Equality operator between two matrices
   template <std::size_t R, std::size_t C, concepts::scalar S,
@@ -76,17 +76,17 @@ struct alignas(alignof(storage::vector<ROW, scalar_t, array_t>)) matrix {
   /// @{
   // AoS
   template <std::size_t... I>
-  ALGEBRA_HOST_DEVICE requires(
-      !std::is_scalar_v<scalar_t>) constexpr bool equal(const matrix &rhs,
-                                                        std::index_sequence<
-                                                            I...>) const {
+  ALGEBRA_HOST_DEVICE
+    requires(!std::is_scalar_v<scalar_t>)
+  constexpr bool equal(const matrix &rhs, std::index_sequence<I...>) const {
     return (... && (m_storage[I] == rhs[I]));
   }
 
   // SoA
   template <std::size_t... I>
-  ALGEBRA_HOST requires(std::is_scalar_v<scalar_t>) constexpr bool equal(
-      const matrix &rhs, std::index_sequence<I...>) const {
+  ALGEBRA_HOST
+    requires(std::is_scalar_v<scalar_t>)
+  constexpr bool equal(const matrix &rhs, std::index_sequence<I...>) const {
     return (... && ((m_storage[I].get() == rhs[I].get()).isFull()));
   }
   /// @}
@@ -105,15 +105,15 @@ struct alignas(alignof(storage::vector<ROW, scalar_t, array_t>)) matrix {
 
   template <std::size_t R, std::size_t C, typename S1, typename S2,
             template <typename, std::size_t> class A>
-  requires(std::is_scalar_v<S2> || std::is_same_v<S1, S2>) ALGEBRA_HOST_DEVICE
-      friend constexpr decltype(auto)
-      operator*(S2 a, const matrix<A, S1, R, C> &rhs) noexcept;
+  /*requires(std::is_scalar_v<S2> || std::is_same_v<S1, S2>)*/
+  ALGEBRA_HOST_DEVICE friend constexpr decltype(auto) operator*(
+      const S2 a, const matrix<A, S1, R, C> &rhs) noexcept;
 
-  template <std::size_t R, std::size_t C, typename S1, typename S2,
-            template <typename, std::size_t> class A>
-  requires(std::is_scalar_v<S2> || std::is_same_v<S1, S2>) ALGEBRA_HOST_DEVICE
-      friend constexpr decltype(auto)
-      operator*(const matrix<A, S1, R, C> &lhs, S2 a) noexcept;
+  template <std::size_t R, std::size_t C, concepts::scalar S1,
+            concepts::scalar S2, template <typename, std::size_t> class A>
+  /*requires(std::is_scalar_v<S2> || std::is_same_v<S1, S2>)*/
+  ALGEBRA_HOST_DEVICE friend constexpr decltype(auto) operator*(
+      const matrix<A, S1, R, C> &lhs, const S2 a) noexcept;
 
   /// Matrix-vector multiplication
   template <std::size_t R, std::size_t C, typename S,
@@ -212,8 +212,9 @@ template <concepts::matrix matrix_t, concepts::scalar scalar_t,
           std::size_t... J>
 ALGEBRA_HOST_DEVICE constexpr matrix_t matrix_scalar_mul(
     scalar_t a, const matrix_t &rhs, std::index_sequence<J...>) noexcept {
+  using mat_scalar_t = algebra::traits::value_t<matrix_t>;
 
-  return matrix_t{(a * rhs[J])...};
+  return matrix_t{(static_cast<mat_scalar_t>(a) * rhs[J])...};
 }
 
 /// Matrix addition
@@ -257,30 +258,22 @@ ALGEBRA_HOST_DEVICE constexpr decltype(auto) operator-(
   return matrix_sub(lhs, rhs, std::make_index_sequence<matrix_t::columns()>());
 }
 
-template <std::size_t ROW, std::size_t COL, concepts::scalar scalar1_t,
-          concepts::scalar scalar2_t,
-          template <typename, std::size_t> class array_t>
-requires(std::is_scalar_v<scalar1_t> ||
-         std::is_same_v<scalar1_t, scalar2_t>) ALGEBRA_HOST_DEVICE
-    constexpr decltype(auto)
-    operator*(scalar1_t a,
-              const matrix<array_t, scalar2_t, ROW, COL> &rhs) noexcept {
+template <std::size_t R, std::size_t C, typename S1, typename S2,
+          template <typename, std::size_t> class A>
+ALGEBRA_HOST_DEVICE constexpr decltype(auto) operator*(
+    const S2 a, const matrix<A, S1, R, C> &rhs) noexcept {
 
-  using matrix_t = matrix<array_t, scalar2_t, ROW, COL>;
+  using matrix_t = matrix<A, S2, R, C>;
 
-  return matrix_scalar_mul(a, rhs,
+  return matrix_scalar_mul(static_cast<S1>(a), rhs,
                            std::make_index_sequence<matrix_t::columns()>());
 }
 
-template <std::size_t ROW, std::size_t COL, concepts::scalar scalar1_t,
-          concepts::scalar scalar2_t,
-          template <typename, std::size_t> class array_t>
-requires(std::is_scalar_v<scalar1_t> ||
-         std::is_same_v<scalar1_t, scalar2_t>) ALGEBRA_HOST_DEVICE
-    constexpr decltype(auto)
-    operator*(const matrix<array_t, scalar1_t, ROW, COL> &lhs,
-              scalar2_t a) noexcept {
-  return a * lhs;
+template <std::size_t R, std::size_t C, concepts::scalar S1,
+          concepts::scalar S2, template <typename, std::size_t> class A>
+ALGEBRA_HOST_DEVICE constexpr decltype(auto) operator*(
+    const matrix<A, S1, R, C> &lhs, const S2 a) noexcept {
+  return static_cast<S1>(a) * lhs;
 }
 
 /// Matrix-vector multiplication

--- a/storage/common/include/algebra/storage/matrix.hpp
+++ b/storage/common/include/algebra/storage/matrix.hpp
@@ -32,9 +32,9 @@ struct alignas(alignof(storage::vector<ROW, scalar_t, array_t>)) matrix {
 
   /// Construct from given column vectors @param v
   template <concepts::vector... vector_t>
-  ALGEBRA_HOST_DEVICE
-    requires(sizeof...(vector_t) == COL)
-  explicit matrix(vector_t &&...v) : m_storage{std::forward<vector_t>(v)...} {}
+  ALGEBRA_HOST_DEVICE requires(sizeof...(vector_t) ==
+                               COL) explicit matrix(vector_t &&... v)
+      : m_storage{std::forward<vector_t>(v)...} {}
 
   /// Equality operator between two matrices
   template <std::size_t R, std::size_t C, concepts::scalar S,
@@ -76,17 +76,17 @@ struct alignas(alignof(storage::vector<ROW, scalar_t, array_t>)) matrix {
   /// @{
   // AoS
   template <std::size_t... I>
-  ALGEBRA_HOST_DEVICE
-    requires(!std::is_scalar_v<scalar_t>)
-  constexpr bool equal(const matrix &rhs, std::index_sequence<I...>) const {
+  ALGEBRA_HOST_DEVICE requires(
+      !std::is_scalar_v<scalar_t>) constexpr bool equal(const matrix &rhs,
+                                                        std::index_sequence<
+                                                            I...>) const {
     return (... && (m_storage[I] == rhs[I]));
   }
 
   // SoA
   template <std::size_t... I>
-  ALGEBRA_HOST
-    requires(std::is_scalar_v<scalar_t>)
-  constexpr bool equal(const matrix &rhs, std::index_sequence<I...>) const {
+  ALGEBRA_HOST requires(std::is_scalar_v<scalar_t>) constexpr bool equal(
+      const matrix &rhs, std::index_sequence<I...>) const {
     return (... && ((m_storage[I].get() == rhs[I].get()).isFull()));
   }
   /// @}
@@ -105,13 +105,11 @@ struct alignas(alignof(storage::vector<ROW, scalar_t, array_t>)) matrix {
 
   template <std::size_t R, std::size_t C, typename S1, typename S2,
             template <typename, std::size_t> class A>
-  /*requires(std::is_scalar_v<S2> || std::is_same_v<S1, S2>)*/
   ALGEBRA_HOST_DEVICE friend constexpr decltype(auto) operator*(
       const S2 a, const matrix<A, S1, R, C> &rhs) noexcept;
 
   template <std::size_t R, std::size_t C, concepts::scalar S1,
             concepts::scalar S2, template <typename, std::size_t> class A>
-  /*requires(std::is_scalar_v<S2> || std::is_same_v<S1, S2>)*/
   ALGEBRA_HOST_DEVICE friend constexpr decltype(auto) operator*(
       const matrix<A, S1, R, C> &lhs, const S2 a) noexcept;
 

--- a/storage/common/include/algebra/storage/matrix_getter.hpp
+++ b/storage/common/include/algebra/storage/matrix_getter.hpp
@@ -182,7 +182,7 @@ struct block_getter {
   template <std::size_t SIZE, std::size_t ROWS, std::size_t COLS,
             concepts::scalar scalar_t,
             template <typename, std::size_t> class array_t>
-  ALGEBRA_HOST_DEVICE constexpr auto operator()(
+  ALGEBRA_HOST_DEVICE constexpr auto vector(
       const matrix<array_t, scalar_t, ROWS, COLS> &m, const std::size_t row,
       const std::size_t col) noexcept {
 
@@ -192,7 +192,7 @@ struct block_getter {
     assert(col <= COLS);
 
     using input_matrix_t = matrix<array_t, scalar_t, ROWS, COLS>;
-    using vector_t = vector<SIZE, scalar_t, array_t>;
+    using vector_t = algebra::storage::vector<SIZE, scalar_t, array_t>;
 
     vector_t res_v{};
 
@@ -238,7 +238,7 @@ ALGEBRA_HOST_DEVICE constexpr void set_block(
   using matrix_t = matrix<array_t, scalar_t, ROWS, COLS>;
 
   // Don't access single elements in underlying vectors unless necessary
-  if constexpr (matrix_t::storage_rows() == input_matrix_t::storage_rows()) {
+  if constexpr (ROWS == mROW && matrix_t::storage_rows() == input_matrix_t::storage_rows()) {
     if (row == 0u) {
       for (std::size_t j = col; j < mCOL; ++j) {
         m[j] = b[j - col];
@@ -254,22 +254,29 @@ ALGEBRA_HOST_DEVICE constexpr void set_block(
 }
 
 /// Operator setting a block with a vector
-template <class matrix_t, std::size_t ROW, concepts::scalar scalar_t,
+template <std::size_t ROWS, std::size_t COLS, std::size_t N,
+          concepts::scalar scalar_t,
           template <typename, std::size_t> class array_t>
 ALGEBRA_HOST_DEVICE constexpr void set_block(
-    matrix_t &m, const storage::vector<ROW, scalar_t, array_t> &b,
-    std::size_t row, std::size_t col) noexcept {
-  assert(row < ROW);
+    matrix<array_t, scalar_t, ROWS, COLS> &m,
+    const vector<N, scalar_t, array_t> &b, const std::size_t row,
+    const std::size_t col) noexcept {
+
+  using matrix_t = matrix<array_t, scalar_t, ROWS, COLS>;
+  using vector_t = vector<N, scalar_t, array_t>;
+
+  static_assert(N <= ROWS);
+  assert(row + N <= matrix_t::rows());
   assert(row < matrix_t::rows());
   assert(col < matrix_t::columns());
 
-  if constexpr (matrix_t::storage_rows() == ROW) {
+  if constexpr (ROWS == N && matrix_t::storage_rows() == vector_t::simd_size()) {
     if (row == 0u) {
       m[col] = b;
       return;
     }
   }
-  for (std::size_t i = row; i < ROW; ++i) {
+  for (std::size_t i = row; i < N + row; ++i) {
     m[col][i] = b[i - row];
   }
 }

--- a/storage/common/include/algebra/storage/matrix_getter.hpp
+++ b/storage/common/include/algebra/storage/matrix_getter.hpp
@@ -203,7 +203,7 @@ struct block_getter {
       }
     }
     for (std::size_t i = row; i < row + SIZE; ++i) {
-      res_v[i] = m[col][i];
+      res_v[i - row] = m[col][i];
     }
 
     return res_v;
@@ -238,7 +238,8 @@ ALGEBRA_HOST_DEVICE constexpr void set_block(
   using matrix_t = matrix<array_t, scalar_t, ROWS, COLS>;
 
   // Don't access single elements in underlying vectors unless necessary
-  if constexpr (ROWS == mROW && matrix_t::storage_rows() == input_matrix_t::storage_rows()) {
+  if constexpr (ROWS == mROW &&
+                matrix_t::storage_rows() == input_matrix_t::storage_rows()) {
     if (row == 0u) {
       for (std::size_t j = col; j < mCOL; ++j) {
         m[j] = b[j - col];
@@ -270,7 +271,8 @@ ALGEBRA_HOST_DEVICE constexpr void set_block(
   assert(row < matrix_t::rows());
   assert(col < matrix_t::columns());
 
-  if constexpr (ROWS == N && matrix_t::storage_rows() == vector_t::simd_size()) {
+  if constexpr (ROWS == N &&
+                matrix_t::storage_rows() == vector_t::simd_size()) {
     if (row == 0u) {
       m[col] = b;
       return;

--- a/storage/common/include/algebra/storage/vector.hpp
+++ b/storage/common/include/algebra/storage/vector.hpp
@@ -76,22 +76,20 @@ class alignas(
 
   /// Construct vector in SoA layout from simd scalars
   template <typename... Scalars>
-    requires(concepts::simd_scalar<scalar_t> && (sizeof...(Scalars) == N) &&
-             ((concepts::simd_scalar<Scalars> ||
-               std::convertible_to<Scalars, scalar_t>) &&
-              ...))
-  ALGEBRA_HOST_DEVICE constexpr vector(Scalars &&...scals)
+  requires(concepts::simd_scalar<scalar_t> && (sizeof...(Scalars) == N) &&
+           ((concepts::simd_scalar<Scalars> ||
+             std::convertible_to<Scalars, scalar_t>)&&...)) ALGEBRA_HOST_DEVICE
+      constexpr vector(Scalars &&... scals)
       : m_data{std::forward<Scalars>(scals)...} {}
 
   /// In order to avoid uninitialized values, which deteriorate the performance
   /// in explicitely vectorized code, the underlying data array is filled with
   /// zeroes if too few arguments are given.
   template <typename... Values>
-    requires(!concepts::simd_scalar<scalar_t> && (sizeof...(Values) > 1) &&
-             ((concepts::value<Values> ||
-               std::convertible_to<Values, scalar_t>) &&
-              ...))
-  ALGEBRA_HOST_DEVICE constexpr vector(Values &&...vals) {
+  requires(!concepts::simd_scalar<scalar_t> && (sizeof...(Values) > 1) &&
+           ((concepts::value<Values> ||
+             std::convertible_to<Values, scalar_t>)&&...)) ALGEBRA_HOST_DEVICE
+      constexpr vector(Values &&... vals) {
 
     static_assert(sizeof...(Values) <= N);
 
@@ -112,18 +110,19 @@ class alignas(
 
   /// Construct from existing array storage @param vals
   template <typename storage_array_t>
-    requires std::convertible_to<storage_array_t, array_type>
-  ALGEBRA_HOST_DEVICE constexpr vector(storage_array_t &&vals)
+  requires(std::convertible_to<storage_array_t, array_type> &&
+           !std::same_as<vector, storage_array_t>) ALGEBRA_HOST_DEVICE
+      constexpr vector(storage_array_t &&vals)
       : m_data{std::forward<storage_array_t>(vals)} {}
 
   /// Assignment operator from a vector with the same underlying storage.
   ///
   /// @param lhs wrap a copy of this data.
   template <std::size_t M>
-    requires(vector<N, scalar_t, array_t>::simd_size() ==
-             vector<M, scalar_t, array_t>::simd_size())
-  ALGEBRA_HOST_DEVICE constexpr const vector &operator=(
-      const vector<M, scalar_t, array_t> &lhs) {
+  requires(vector<N, scalar_t, array_t>::simd_size() ==
+           vector<M, scalar_t, array_t>::simd_size()) ALGEBRA_HOST_DEVICE
+      constexpr const vector &
+      operator=(const vector<M, scalar_t, array_t> &lhs) {
     m_data = lhs;
     return *this;
   }
@@ -159,9 +158,8 @@ class alignas(
   /// @{
   /// AoS
   template <concepts::scalar S = scalar_t>
-    requires(!concepts::simd_scalar<S>)
-  ALGEBRA_HOST_DEVICE constexpr friend bool operator==(
-      const vector &lhs, const vector &rhs) noexcept {
+  requires(!concepts::simd_scalar<S>) ALGEBRA_HOST_DEVICE constexpr friend bool
+  operator==(const vector &lhs, const vector &rhs) noexcept {
 
     const auto comp = lhs.compare(rhs);
     bool is_full = false;
@@ -175,9 +173,8 @@ class alignas(
 
   /// SoA
   template <concepts::scalar S = scalar_t>
-    requires(concepts::simd_scalar<S>)
-  ALGEBRA_HOST_DEVICE constexpr friend bool operator==(
-      const vector &lhs, const vector &rhs) noexcept {
+  requires(concepts::simd_scalar<S>) ALGEBRA_HOST_DEVICE constexpr friend bool
+  operator==(const vector &lhs, const vector &rhs) noexcept {
 
     const auto comp = lhs.compare(rhs);
     bool is_full = false;
@@ -248,16 +245,18 @@ class alignas(
   }                                                                            \
   template <std::size_t N, concepts::scalar scalar_t,                          \
             template <typename, std::size_t> class array_t, typename other_t>  \
-    requires(concepts::vector<other_t> || concepts::simd_scalar<other_t>)      \
-  ALGEBRA_HOST_DEVICE inline constexpr decltype(auto) operator OP(             \
-      const vector<N, scalar_t, array_t> &lhs, const other_t &rhs) noexcept {  \
+  requires(concepts::vector<other_t> || concepts::simd_scalar<other_t>)        \
+      ALGEBRA_HOST_DEVICE inline constexpr decltype(auto)                      \
+      operator OP(const vector<N, scalar_t, array_t> &lhs,                     \
+                  const other_t &rhs) noexcept {                               \
     return lhs.m_data OP rhs;                                                  \
   }                                                                            \
   template <std::size_t N, concepts::scalar scalar_t,                          \
             template <typename, std::size_t> class array_t, typename other_t>  \
-    requires(concepts::vector<other_t> || concepts::simd_scalar<other_t>)      \
-  ALGEBRA_HOST_DEVICE inline constexpr decltype(auto) operator OP(             \
-      const other_t &lhs, const vector<N, scalar_t, array_t> &rhs) noexcept {  \
+  requires(concepts::vector<other_t> || concepts::simd_scalar<other_t>)        \
+      ALGEBRA_HOST_DEVICE inline constexpr decltype(auto)                      \
+      operator OP(const other_t &lhs,                                          \
+                  const vector<N, scalar_t, array_t> &rhs) noexcept {          \
     return lhs OP rhs.m_data;                                                  \
   }
 

--- a/storage/eigen/CMakeLists.txt
+++ b/storage/eigen/CMakeLists.txt
@@ -8,7 +8,7 @@
 algebra_add_library( algebra_eigen_storage eigen_storage
    "include/algebra/storage/eigen.hpp"
    "include/algebra/storage/impl/eigen_array.hpp"
-   "include/algebra/storage/impl/eigen_getter.hpp"  )
+   "include/algebra/storage/impl/eigen_getter.hpp" )
 target_link_libraries( algebra_eigen_storage
    INTERFACE algebra::common Eigen3::Eigen algebra::common_math )
 algebra_test_public_headers( algebra_eigen_storage

--- a/storage/eigen/include/algebra/storage/impl/eigen_getter.hpp
+++ b/storage/eigen/include/algebra/storage/impl/eigen_getter.hpp
@@ -77,7 +77,7 @@ struct element_getter {
 
 /// Function extracting an element from a matrix (const)
 template <typename derived_type>
-ALGEBRA_HOST_DEVICE inline auto element(
+ALGEBRA_HOST_DEVICE inline decltype(auto) element(
     const Eigen::MatrixBase<derived_type> &m, std::size_t row,
     std::size_t col) {
 
@@ -90,7 +90,7 @@ template <typename derived_type>
 requires std::is_base_of_v<
     Eigen::DenseCoeffsBase<derived_type, Eigen::WriteAccessors>,
     Eigen::MatrixBase<derived_type> >
-    ALGEBRA_HOST_DEVICE inline auto &element(Eigen::MatrixBase<derived_type> &m,
+    ALGEBRA_HOST_DEVICE inline decltype(auto) element(Eigen::MatrixBase<derived_type> &m,
                                              std::size_t row, std::size_t col) {
 
   return element_getter()(m, static_cast<Eigen::Index>(row),
@@ -99,7 +99,7 @@ requires std::is_base_of_v<
 
 /// Function extracting an element from a matrix (const)
 template <typename derived_type>
-ALGEBRA_HOST_DEVICE inline auto element(
+ALGEBRA_HOST_DEVICE inline decltype(auto) element(
     const Eigen::MatrixBase<derived_type> &m, std::size_t row) {
 
   return element_getter()(m, static_cast<Eigen::Index>(row));
@@ -110,7 +110,7 @@ template <typename derived_type>
 requires std::is_base_of_v<
     Eigen::DenseCoeffsBase<derived_type, Eigen::WriteAccessors>,
     Eigen::MatrixBase<derived_type> >
-    ALGEBRA_HOST_DEVICE inline auto &element(Eigen::MatrixBase<derived_type> &m,
+    ALGEBRA_HOST_DEVICE inline decltype(auto) element(Eigen::MatrixBase<derived_type> &m,
                                              std::size_t row) {
 
   return element_getter()(m, static_cast<Eigen::Index>(row));
@@ -139,7 +139,7 @@ struct block_getter {
 
   template <int SIZE, typename derived_type, concepts::index size_type_1,
             concepts::index size_type_2>
-  ALGEBRA_HOST_DEVICE decltype(auto) operator()(
+  ALGEBRA_HOST_DEVICE decltype(auto) vector(
       Eigen::MatrixBase<derived_type> &m, size_type_1 row,
       size_type_2 col) const {
 
@@ -148,7 +148,7 @@ struct block_getter {
 
   template <int SIZE, typename derived_type, concepts::index size_type_1,
             concepts::index size_type_2>
-  ALGEBRA_HOST_DEVICE decltype(auto) operator()(
+  ALGEBRA_HOST_DEVICE decltype(auto) vector(
       const Eigen::MatrixBase<derived_type> &m, size_type_1 row,
       size_type_2 col) const {
 
@@ -180,7 +180,7 @@ ALGEBRA_HOST_DEVICE inline decltype(auto) vector(
     const Eigen::MatrixBase<derived_type> &m, std::size_t row,
     std::size_t col) {
 
-  return block_getter{}.template operator()<SIZE>(
+  return block_getter{}.template vector<SIZE>(
       m, static_cast<Eigen::Index>(row), static_cast<Eigen::Index>(col));
 }
 

--- a/storage/eigen/include/algebra/storage/impl/eigen_getter.hpp
+++ b/storage/eigen/include/algebra/storage/impl/eigen_getter.hpp
@@ -90,8 +90,8 @@ template <typename derived_type>
 requires std::is_base_of_v<
     Eigen::DenseCoeffsBase<derived_type, Eigen::WriteAccessors>,
     Eigen::MatrixBase<derived_type> >
-    ALGEBRA_HOST_DEVICE inline decltype(auto) element(Eigen::MatrixBase<derived_type> &m,
-                                             std::size_t row, std::size_t col) {
+    ALGEBRA_HOST_DEVICE inline decltype(auto) element(
+        Eigen::MatrixBase<derived_type> &m, std::size_t row, std::size_t col) {
 
   return element_getter()(m, static_cast<Eigen::Index>(row),
                           static_cast<Eigen::Index>(col));
@@ -110,8 +110,8 @@ template <typename derived_type>
 requires std::is_base_of_v<
     Eigen::DenseCoeffsBase<derived_type, Eigen::WriteAccessors>,
     Eigen::MatrixBase<derived_type> >
-    ALGEBRA_HOST_DEVICE inline decltype(auto) element(Eigen::MatrixBase<derived_type> &m,
-                                             std::size_t row) {
+    ALGEBRA_HOST_DEVICE inline decltype(auto) element(
+        Eigen::MatrixBase<derived_type> &m, std::size_t row) {
 
   return element_getter()(m, static_cast<Eigen::Index>(row));
 }
@@ -139,9 +139,9 @@ struct block_getter {
 
   template <int SIZE, typename derived_type, concepts::index size_type_1,
             concepts::index size_type_2>
-  ALGEBRA_HOST_DEVICE decltype(auto) vector(
-      Eigen::MatrixBase<derived_type> &m, size_type_1 row,
-      size_type_2 col) const {
+  ALGEBRA_HOST_DEVICE decltype(auto) vector(Eigen::MatrixBase<derived_type> &m,
+                                            size_type_1 row,
+                                            size_type_2 col) const {
 
     return m.template block<SIZE, 1>(row, col);
   }
@@ -180,8 +180,8 @@ ALGEBRA_HOST_DEVICE inline decltype(auto) vector(
     const Eigen::MatrixBase<derived_type> &m, std::size_t row,
     std::size_t col) {
 
-  return block_getter{}.template vector<SIZE>(
-      m, static_cast<Eigen::Index>(row), static_cast<Eigen::Index>(col));
+  return block_getter{}.template vector<SIZE>(m, static_cast<Eigen::Index>(row),
+                                              static_cast<Eigen::Index>(col));
 }
 
 /// Operator setting a block

--- a/storage/fastor/CMakeLists.txt
+++ b/storage/fastor/CMakeLists.txt
@@ -8,8 +8,8 @@
 algebra_add_library( algebra_fastor_storage fastor_storage
    "include/algebra/storage/fastor.hpp"
    "include/algebra/storage/impl/fastor_getter.hpp"
-   "include/algebra/storage/impl/fastor_matrix.hpp"  )
+   "include/algebra/storage/impl/fastor_matrix.hpp" )
 target_link_libraries( algebra_fastor_storage
-	INTERFACE Fastor::Fastor algebra::common algebra::common_math)
+	INTERFACE Fastor::Fastor algebra::common algebra::common_math )
 algebra_test_public_headers( algebra_fastor_storage
    "algebra/storage/fastor.hpp" )

--- a/storage/fastor/include/algebra/storage/impl/fastor_getter.hpp
+++ b/storage/fastor/include/algebra/storage/impl/fastor_getter.hpp
@@ -143,7 +143,7 @@ struct block_getter {
 
   template <std::size_t SIZE, std::size_t oROWS, std::size_t oCOLS,
             concepts::scalar scalar_t>
-  ALGEBRA_HOST_DEVICE Fastor::Tensor<scalar_t, SIZE> operator()(
+  ALGEBRA_HOST_DEVICE Fastor::Tensor<scalar_t, SIZE> vector(
       const Fastor::Tensor<scalar_t, oROWS, oCOLS> &m, std::size_t row,
       std::size_t col) const {
 
@@ -170,7 +170,7 @@ ALGEBRA_HOST_DEVICE inline decltype(auto) vector(
     const Fastor::Tensor<scalar_t, ROWS, COLS> &m, std::size_t row,
     std::size_t col) {
 
-  return block_getter{}.template operator()<SIZE>(m, row, col);
+  return block_getter{}.template vector<SIZE>(m, row, col);
 }
 
 /// Operator setting a block with a matrix

--- a/storage/smatrix/CMakeLists.txt
+++ b/storage/smatrix/CMakeLists.txt
@@ -10,8 +10,8 @@ find_package( ROOT COMPONENTS Smatrix REQUIRED )
 # Set up the library.
 algebra_add_library( algebra_smatrix_storage smatrix_storage
    "include/algebra/storage/smatrix.hpp"
-   "include/algebra/storage/impl/smatrix_getter.hpp"  )
+   "include/algebra/storage/impl/smatrix_getter.hpp" )
 target_link_libraries( algebra_smatrix_storage
-   INTERFACE algebra::common ROOT::Smatrix algebra::common_math)
+   INTERFACE algebra::common ROOT::Smatrix algebra::common_math )
 algebra_test_public_headers( algebra_smatrix_storage
    "algebra/storage/smatrix.hpp" )

--- a/storage/smatrix/include/algebra/storage/impl/smatrix_getter.hpp
+++ b/storage/smatrix/include/algebra/storage/impl/smatrix_getter.hpp
@@ -137,7 +137,19 @@ struct block_getter {
       const ROOT::Math::SMatrix<scalar_t, ROWS, COLS> &m, unsigned int row,
       unsigned int col) const {
 
-    return m.template SubCol<ROOT::Math::SVector<scalar_t, SIZE>>(col, row);
+    // TODO: SMatrix bug?
+    // return m.template SubCol<ROOT::Math::SVector<scalar_t, SIZE>>(col, row);
+
+    assert(col < COLS);
+    assert(row + SIZE <= ROWS);
+
+    ROOT::Math::SVector<scalar_t, SIZE> ret;
+
+    for (std::size_t irow = row; irow < row + SIZE; ++irow) {
+      ret[irow - row] = m[col][irow];
+    }
+
+    return ret;
   }
 };  // struct block_getter
 
@@ -159,8 +171,8 @@ ALGEBRA_HOST_DEVICE inline auto vector(
     const ROOT::Math::SMatrix<scalar_t, ROWS, COLS> &m, std::size_t row,
     std::size_t col) {
 
-  return block_getter{}.template vector<SIZE>(
-      m, static_cast<unsigned int>(row), static_cast<unsigned int>(col));
+  return block_getter{}.template vector<SIZE>(m, static_cast<unsigned int>(row),
+                                              static_cast<unsigned int>(col));
 }
 
 /// Operator setting a block with a matrix

--- a/storage/smatrix/include/algebra/storage/impl/smatrix_getter.hpp
+++ b/storage/smatrix/include/algebra/storage/impl/smatrix_getter.hpp
@@ -133,7 +133,7 @@ struct block_getter {
 
   template <unsigned int SIZE, unsigned int ROWS, unsigned int COLS,
             concepts::scalar scalar_t>
-  ALGEBRA_HOST_DEVICE ROOT::Math::SVector<scalar_t, SIZE> operator()(
+  ALGEBRA_HOST_DEVICE ROOT::Math::SVector<scalar_t, SIZE> vector(
       const ROOT::Math::SMatrix<scalar_t, ROWS, COLS> &m, unsigned int row,
       unsigned int col) const {
 
@@ -159,7 +159,7 @@ ALGEBRA_HOST_DEVICE inline auto vector(
     const ROOT::Math::SMatrix<scalar_t, ROWS, COLS> &m, std::size_t row,
     std::size_t col) {
 
-  return block_getter{}.template operator()<SIZE>(
+  return block_getter{}.template vector<SIZE>(
       m, static_cast<unsigned int>(row), static_cast<unsigned int>(col));
 }
 

--- a/storage/vc_aos/CMakeLists.txt
+++ b/storage/vc_aos/CMakeLists.txt
@@ -7,6 +7,7 @@
 # Set up the library.
 algebra_add_library( algebra_vc_aos_storage vc_aos_storage
    "include/algebra/storage/vc_aos.hpp"
+   "include/algebra/storage/impl/vc_aos_concepts.hpp"
    "include/algebra/storage/impl/vc_aos_getter.hpp" )
 target_link_libraries( algebra_vc_aos_storage
    INTERFACE algebra::common algebra::common_storage Vc::Vc algebra::common_math )

--- a/storage/vc_aos/include/algebra/storage/impl/vc_aos_concepts.hpp
+++ b/storage/vc_aos/include/algebra/storage/impl/vc_aos_concepts.hpp
@@ -1,0 +1,39 @@
+/** Algebra plugins library, part of the ACTS project
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s).
+#include "algebra/storage/vector.hpp"
+
+// Vc include(s).
+#ifdef _MSC_VER
+#pragma warning(push, 0)
+#endif  // MSVC
+#include <Vc/Vc>
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif  // MSVC
+
+// System include(s).
+#include <concepts>
+
+namespace algebra::concepts {
+
+/// Vc SIMD types
+template <typename T>
+concept vc_simd_vector = Vc::is_simd_vector<T>::value;
+
+/// Vc SIMD types
+template <typename T>
+concept simd_storage_vector = algebra::detail::is_storage_vector_v<T>;
+
+/// Vc AoS vector
+template <typename T>
+concept vc_aos_vector = (vc_simd_vector<T> || simd_storage_vector<T>);
+
+}  // namespace algebra::concepts

--- a/storage/vc_aos/include/algebra/storage/impl/vc_aos_getter.hpp
+++ b/storage/vc_aos/include/algebra/storage/impl/vc_aos_getter.hpp
@@ -25,8 +25,7 @@ template <std::size_t SIZE, std::size_t ROW, std::size_t COL,
 ALGEBRA_HOST_DEVICE constexpr auto vector(
     const algebra::storage::matrix<array_t, scalar_t, ROW, COL> &m,
     const std::size_t row, const std::size_t col) noexcept {
-  return algebra::storage::block_getter{}.template operator()<SIZE>(m, row,
-                                                                    col);
+  return algebra::storage::block_getter{}.template vector<SIZE>(m, row, col);
 }
 
 }  // namespace algebra::vc_aos::storage

--- a/storage/vc_aos/include/algebra/storage/impl/vc_aos_getter.hpp
+++ b/storage/vc_aos/include/algebra/storage/impl/vc_aos_getter.hpp
@@ -22,7 +22,7 @@ using algebra::storage::set_block;
 template <std::size_t SIZE, std::size_t ROW, std::size_t COL,
           concepts::scalar scalar_t,
           template <typename, std::size_t> class array_t>
-ALGEBRA_HOST_DEVICE constexpr auto vector(
+ALGEBRA_HOST_DEVICE constexpr decltype(auto) vector(
     const algebra::storage::matrix<array_t, scalar_t, ROW, COL> &m,
     const std::size_t row, const std::size_t col) noexcept {
   return algebra::storage::block_getter{}.template vector<SIZE>(m, row, col);

--- a/storage/vc_aos/include/algebra/storage/vc_aos.hpp
+++ b/storage/vc_aos/include/algebra/storage/vc_aos.hpp
@@ -9,6 +9,7 @@
 
 // Project include(s).
 #include "algebra/concepts.hpp"
+#include "algebra/storage/impl/vc_aos_concepts.hpp"
 #include "algebra/storage/impl/vc_aos_getter.hpp"
 #include "algebra/storage/matrix.hpp"
 #include "algebra/storage/vector.hpp"
@@ -81,19 +82,19 @@ namespace traits {
 
 template <typename T, auto N>
 struct index<vc_aos::storage_type<T, N>> {
-  using size_type = algebra::vc_aos::size_type;
+  using size_type = vc_aos::size_type;
 };
 
 template <typename T, auto N>
 struct index<Vc_1::Vector<T, Vc_1::simd_abi::fixed_size<N>>> {
-  using size_type = algebra::vc_aos::size_type;
+  using size_type = vc_aos::size_type;
 };
 
 // Vector and storage types are different
 template <typename T, auto N>
 struct dimensions<vc_aos::storage_type<T, N>> {
 
-  using size_type = algebra::vc_aos::size_type;
+  using size_type = vc_aos::size_type;
 
   static constexpr size_type dim{1};
   static constexpr size_type rows{N};
@@ -104,7 +105,7 @@ struct dimensions<vc_aos::storage_type<T, N>> {
 template <typename T, auto N>
 struct dimensions<Vc_1::Vector<T, Vc_1::simd_abi::fixed_size<N>>> {
 
-  using size_type = algebra::vc_aos::size_type;
+  using size_type = vc_aos::size_type;
 
   static constexpr size_type dim{1};
   static constexpr size_type rows{N};

--- a/storage/vc_aos/include/algebra/storage/vc_aos.hpp
+++ b/storage/vc_aos/include/algebra/storage/vc_aos.hpp
@@ -79,11 +79,21 @@ ALGEBRA_PLUGINS_DEFINE_TYPE_TRAITS(vc_aos)
 
 namespace traits {
 
+template <typename T, auto N>
+struct index<vc_aos::storage_type<T, N>> {
+  using size_type = algebra::vc_aos::size_type;
+};
+
+template <typename T, auto N>
+struct index<Vc_1::Vector<T, Vc_1::simd_abi::fixed_size<N>>> {
+  using size_type = algebra::vc_aos::size_type;
+};
+
 // Vector and storage types are different
 template <typename T, auto N>
 struct dimensions<vc_aos::storage_type<T, N>> {
 
-  using size_type = vc_aos::size_type;
+  using size_type = algebra::vc_aos::size_type;
 
   static constexpr size_type dim{1};
   static constexpr size_type rows{N};
@@ -94,7 +104,7 @@ struct dimensions<vc_aos::storage_type<T, N>> {
 template <typename T, auto N>
 struct dimensions<Vc_1::Vector<T, Vc_1::simd_abi::fixed_size<N>>> {
 
-  using size_type = vc_aos::size_type;
+  using size_type = algebra::vc_aos::size_type;
 
   static constexpr size_type dim{1};
   static constexpr size_type rows{N};

--- a/storage/vc_soa/CMakeLists.txt
+++ b/storage/vc_soa/CMakeLists.txt
@@ -7,8 +7,9 @@
 # Set up the library.
 algebra_add_library( algebra_vc_soa_storage vc_soa_storage
    "include/algebra/storage/vc_soa.hpp"
+   "include/algebra/storage/impl/vc_soa_concepts.hpp"
    "include/algebra/storage/impl/vc_soa_getter.hpp" )
 target_link_libraries( algebra_vc_soa_storage
-   INTERFACE algebra::common algebra::common_storage Vc::Vc )
+   INTERFACE algebra::common algebra::common_storage Vc::Vc algebra::vc_aos_storage )
 algebra_test_public_headers( algebra_vc_soa_storage
    "algebra/storage/vc_soa.hpp" )

--- a/storage/vc_soa/include/algebra/storage/impl/vc_soa_concepts.hpp
+++ b/storage/vc_soa/include/algebra/storage/impl/vc_soa_concepts.hpp
@@ -1,0 +1,23 @@
+/** Algebra plugins library, part of the ACTS project
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s).
+#include "algebra/storage/impl/vc_aos_concepts.hpp"
+
+// System include(s).
+#include <concepts>
+
+namespace algebra::concepts {
+
+/// Vc SoA vector
+template <typename T>
+concept vc_soa_vector = (simd_storage_vector<T> ||
+                         vc_simd_vector<typename T::value_type>);
+
+}  // namespace algebra::concepts

--- a/storage/vc_soa/include/algebra/storage/impl/vc_soa_getter.hpp
+++ b/storage/vc_soa/include/algebra/storage/impl/vc_soa_getter.hpp
@@ -25,8 +25,7 @@ template <std::size_t SIZE, std::size_t ROW, std::size_t COL,
 ALGEBRA_HOST_DEVICE constexpr auto vector(
     const algebra::storage::matrix<array_t, scalar_t, ROW, COL> &m,
     const std::size_t row, const std::size_t col) noexcept {
-  return algebra::storage::block_getter{}.template operator()<SIZE>(m, row,
-                                                                    col);
+  return algebra::storage::block_getter{}.template vector<SIZE>(m, row, col);
 }
 
 }  // namespace algebra::vc_soa::storage

--- a/storage/vc_soa/include/algebra/storage/vc_soa.hpp
+++ b/storage/vc_soa/include/algebra/storage/vc_soa.hpp
@@ -34,7 +34,7 @@ namespace vc_soa {
 /// Size type for Vc storage model
 using size_type = std::size_t;
 /// Array type used to store Vc::Vectors or matrix columns
-template <concepts::scalar T, size_type N>
+template <concepts::simd_scalar T, size_type N>
 using storage_type = std::array<T, N>;
 /// Value type in a linear algebra vector: SoA layout
 template <concepts::value T>
@@ -90,7 +90,7 @@ struct scalar<
 /// @}
 
 // Vector and storage types are different
-template <typename T, auto N>
+template <concepts::simd_scalar T, auto N>
 struct dimensions<vc_soa::storage_type<T, N>> {
 
   using size_type = vc_soa::size_type;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Algebra plugins library, part of the ACTS project (R&D line)
 #
-# (c) 2021-2022 CERN for the benefit of the ACTS project
+# (c) 2021-2024 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -11,6 +11,7 @@ include( algebra-plugins-compiler-options-cpp )
 add_library( algebra_tests_common INTERFACE )
 target_include_directories( algebra_tests_common INTERFACE
    "${CMAKE_CURRENT_SOURCE_DIR}/common" )
+target_link_libraries( algebra_tests_common INTERFACE algebra::utils )
 if( "${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC" )
    target_compile_definitions( algebra_tests_common INTERFACE
       -D_USE_MATH_DEFINES )
@@ -46,7 +47,7 @@ if( ALGEBRA_PLUGINS_INCLUDE_VC )
 
       algebra_add_test( vc_soa
          "vc_soa/vc_soa.cpp"
-         LINK_LIBRARIES GTest::gtest_main algebra::vc_soa )
+         LINK_LIBRARIES GTest::gtest_main algebra::utils algebra::vc_soa )
    endif()
 endif()
 

--- a/tests/common/test_host_basics.hpp
+++ b/tests/common/test_host_basics.hpp
@@ -7,6 +7,9 @@
 
 #pragma once
 
+// Project include(s).
+#include "algebra/utils/print.hpp"
+
 // Local include(s).
 #include "test_base.hpp"
 
@@ -35,6 +38,8 @@ TYPED_TEST_SUITE_P(test_host_basics_transform);
 
 // This defines the local frame test suite
 TYPED_TEST_P(test_host_basics_vector, local_vectors) {
+  // Print the linear algebra types of this backend
+  using algebra::operator<<;
 
   // Construction
   typename TypeParam::point2 vA{0.f, 1.f};
@@ -77,6 +82,8 @@ TYPED_TEST_P(test_host_basics_vector, local_vectors) {
 
 // This defines the vector3 test suite
 TYPED_TEST_P(test_host_basics_vector, vector3) {
+  // Print the linear algebra types of this backend
+  using algebra::operator<<;
 
   // Test concepts
   static_assert(algebra::concepts::scalar<typename TypeParam::scalar>);
@@ -220,6 +227,9 @@ TYPED_TEST_P(test_host_basics_matrix, matrix_2x3) {
 }
 
 TYPED_TEST_P(test_host_basics_matrix, matrix_3x1) {
+  // Print the linear algebra types of this backend
+  using algebra::operator<<;
+
   // Cross product on vector3 and matrix<3,1>
   typename TypeParam::template matrix<3, 1> vF;
   algebra::getter::element(vF, 0, 0) = 5.f;
@@ -241,6 +251,8 @@ TYPED_TEST_P(test_host_basics_matrix, matrix_3x1) {
 }
 
 TYPED_TEST_P(test_host_basics_matrix, matrix_6x4) {
+  // Print the linear algebra types of this backend
+  using algebra::operator<<;
 
   // Create the matrix.
   static constexpr typename TypeParam::size_type ROWS = 6;
@@ -665,6 +677,8 @@ TYPED_TEST_P(test_host_basics_matrix, matrix_small_mixed) {
 
 // This defines the transform3 test suite
 TYPED_TEST_P(test_host_basics_transform, transform3) {
+  // Print the linear algebra types of this backend
+  using algebra::operator<<;
 
   static_assert(algebra::concepts::transform3D<typename TypeParam::transform3>);
 

--- a/tests/common/test_host_basics.hpp
+++ b/tests/common/test_host_basics.hpp
@@ -41,6 +41,9 @@ TYPED_TEST_P(test_host_basics_vector, local_vectors) {
   ASSERT_EQ(vA[0], 0.f);
   ASSERT_EQ(vA[1], 1.f);
 
+  // Test printing
+  std::cout << vA << std::endl;
+
   // Assignment
   typename TypeParam::point2 vB = vA;
   ASSERT_EQ(vB[0], 0.f);
@@ -94,6 +97,9 @@ TYPED_TEST_P(test_host_basics_vector, vector3) {
   ASSERT_EQ(vA[0], 0.f);
   ASSERT_EQ(vA[1], 1.f);
   ASSERT_EQ(vA[2], 2.f);
+
+  // Test printing
+  std::cout << vA << std::endl;
 
   // Assignment
   typename TypeParam::vector3 vB = vA;
@@ -220,6 +226,9 @@ TYPED_TEST_P(test_host_basics_matrix, matrix_3x1) {
   algebra::getter::element(vF, 1, 0) = 6.f;
   algebra::getter::element(vF, 2, 0) = 13.f;
 
+  // Test printing
+  std::cout << vF << std::endl;
+
   typename TypeParam::vector3 vD{1.f, 1.f, 1.f};
   typename TypeParam::vector3 vG = algebra::vector::cross(vD, vF);
   ASSERT_NEAR(vG[0], 7.f, this->m_epsilon);
@@ -342,6 +351,9 @@ TYPED_TEST_P(test_host_basics_matrix, matrix_6x4) {
   ASSERT_NEAR(algebra::getter::element(m, 0, 2), 10., this->m_epsilon);
   ASSERT_NEAR(algebra::getter::element(m, 1, 2), 20., this->m_epsilon);
   ASSERT_NEAR(algebra::getter::element(m, 2, 2), 30., this->m_epsilon);
+
+  // Test printing
+  std::cout << m << std::endl;
 }
 
 TYPED_TEST_P(test_host_basics_matrix, matrix_3x3) {
@@ -669,6 +681,9 @@ TYPED_TEST_P(test_host_basics_transform, transform3) {
   ASSERT_TRUE(trf1 == trf1);
   typename TypeParam::transform3 trf2;
   trf2 = trf1;
+
+  // Test printing
+  std::cout << trf1 << std::endl;
 
   const auto rot = trf2.rotation();
   ASSERT_NEAR(algebra::getter::element(rot, 0, 0), x[0], this->m_epsilon);

--- a/tests/vc_soa/vc_soa.cpp
+++ b/tests/vc_soa/vc_soa.cpp
@@ -8,6 +8,8 @@
 // Project include(s).
 #include "algebra/vc_soa.hpp"
 
+#include "algebra/utils/print.hpp"
+
 // GoogleTest include(s).
 #include <gtest/gtest.h>
 
@@ -21,6 +23,8 @@ constexpr float tol{1e-5f};
 
 /// This test the vector functions on an SoA (Vc::Vector) based vector
 TEST(test_vc_host, vc_soa_vector) {
+  // Print the linear algebra types of this backend
+  using algebra::operator<<;
 
   using vector3_v = vc_soa::vector3<value_t>;
   // Value type is Vc::Vector<float>
@@ -140,6 +144,8 @@ TEST(test_vc_host, vc_soa_getter) {
 
 /// This test an SoA (Vc::Vector) based affine transform3
 TEST(test_vc_host, vc_soa_transform3) {
+  // Print the linear algebra types of this backend
+  using algebra::operator<<;
 
   using vector3 = vc_soa::vector3<value_t>;
   using point3 = vc_soa::point3<value_t>;
@@ -249,6 +255,8 @@ TEST(test_vc_host, vc_soa_matrix3) {
 
 /// This test an SoA (Vc::Vector) based 6x4 matrix
 TEST(test_vc_host, vc_soa_matrix64) {
+  // Print the linear algebra types of this backend
+  using algebra::operator<<;
 
   // Create the matrix.
   using matrix_6x4_t = vc_soa::matrix_type<value_t, 6, 4>;

--- a/tests/vc_soa/vc_soa.cpp
+++ b/tests/vc_soa/vc_soa.cpp
@@ -33,6 +33,9 @@ TEST(test_vc_host, vc_soa_vector) {
   EXPECT_TRUE((a[1] == scalar_t(2.f)).isFull());
   EXPECT_TRUE((a[2] == scalar_t(3.f)).isFull());
 
+  // Test printing
+  std::cout << a << std::endl;
+
   // Masked comparison
   auto m = a.compare(a);
   EXPECT_TRUE(m[0].isFull());
@@ -171,6 +174,9 @@ TEST(test_vc_host, vc_soa_transform3) {
   transform3 trf2;
   trf2 = trf1;
 
+  // Test printing
+  std::cout << trf1 << std::endl;
+
   EXPECT_TRUE((trf2(0, 0) == x[0]).isFull());
   EXPECT_TRUE((trf2(1, 0) == x[1]).isFull());
   EXPECT_TRUE((trf2(2, 0) == x[2]).isFull());
@@ -262,4 +268,7 @@ TEST(test_vc_host, vc_soa_matrix64) {
   static_assert(!algebra::traits::is_square<matrix_6x4_t>);
   static_assert(algebra::traits::is_square<vc_soa::matrix_type<value_t, 4, 4>>);
   static_assert(algebra::traits::is_square<vc_soa::matrix_type<value_t, 6, 6>>);
+
+  // Test printing
+  std::cout << m << std::endl;
 }

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -1,0 +1,12 @@
+# Algebra plugins library, part of the ACTS project (R&D line)
+#
+# (c) 2024 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
+
+# Set up the library.
+algebra_add_library( algebra_utils utils
+   "include/algebra/utils/print.hpp" )
+target_link_libraries( algebra_utils INTERFACE algebra::common )
+algebra_test_public_headers( algebra_utils
+   "algebra/utils/print.hpp" )

--- a/utils/include/algebra/utils/print.hpp
+++ b/utils/include/algebra/utils/print.hpp
@@ -18,8 +18,9 @@ namespace algebra {
 
 /// Print a generic vector or point @param v
 template <typename vector_t>
-  requires(concepts::vector<vector_t> || concepts::point<vector_t>)
-ALGEBRA_HOST std::ostream& operator<<(std::ostream& out, const vector_t& v) {
+requires(concepts::vector<vector_t> ||
+         concepts::point<vector_t>) ALGEBRA_HOST std::ostream&
+operator<<(std::ostream& out, const vector_t& v) {
 
   using index_t = algebra::traits::index_t<vector_t>;
 


### PR DESCRIPTION
Hide the generic function overloads behind the functions of specific plugins, because they would otherwise always take precedence when using multiple plugins side by side.