### PR TITLE
Update deprecated GitHub Action versions

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -37,7 +37,7 @@ jobs:
     # The build/test steps to execute.
     steps:
     # Use a standard checkout of the code.
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     # Run the CMake configuration.
     - name: Configure
       run: cmake --preset default-x86-64
@@ -98,7 +98,7 @@ jobs:
     # The build/test steps to execute.
     steps:
     # Use a standard checkout of the code.
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     # Run the CMake configuration.
     - name: Configure
       run: |

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -18,10 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     container: ghcr.io/acts-project/format10:v11
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Check
         run: .github/check_format.sh .
-      - uses: actions/upload-artifact@v1
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: changed


### PR DESCRIPTION
Several of our GitHub Actions are deprecated, causing the CI to automatically fail. This commit updates the relevant jobs.