### PR TITLE
SYCL2020 Updates, main branch (2024.11.19.)

### DIFF
--- a/.github/ci_setup.sh
+++ b/.github/ci_setup.sh
@@ -14,15 +14,8 @@
 PLATFORM_NAME=$1
 
 # Set up the correct environment for the SYCL tests.
-if [ "${PLATFORM_NAME}" = "SYCL" ]; then
+if [[ "${PLATFORM_NAME}" == *"SYCL"* ]]; then
    if [ -f "/opt/intel/oneapi/setvars.sh" ]; then
       source /opt/intel/oneapi/setvars.sh --include-intel-llvm
    fi
-   # Use clang/clang++ instead of icx/icpx, to avoid some aggressive math
-   # optimizations that break some tests.
-   export CC=`which clang`
-   export CXX=`which clang++`
-   export SYCLCXX="${CXX} -fsycl"
-   export ONEAPI_DEVICE_SELECTOR=opencl:cpu
-   export SYCLFLAGS="-fsycl -fsycl-targets=spir64"
 fi

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -72,34 +72,47 @@ jobs:
             CONTAINER: "ghcr.io/acts-project/ubuntu2404:56"
             OPTIONS: --preset eigen -DALGEBRA_PLUGINS_USE_SYSTEM_EIGEN3=TRUE
             RUN_TESTS: true
+            ENVIRONMENT:
           - NAME: "HOST"
-            CONTAINER: "ghcr.io/acts-project/ubuntu2404:56"
+            CONTAINER: "ghcr.io/acts-project/ubuntu2404:67"
             OPTIONS: --preset eigen
             RUN_TESTS: true
+            ENVIRONMENT:
           - NAME: "HOST"
             CONTAINER: "ghcr.io/acts-project/ubuntu2404:56"
             OPTIONS: -DALGEBRA_PLUGINS_INCLUDE_SMATRIX=TRUE
             RUN_TESTS: true
+            ENVIRONMENT:
           - NAME: "HOST"
-            CONTAINER: "ghcr.io/acts-project/ubuntu2404:56"
+            CONTAINER: "ghcr.io/acts-project/ubuntu2404:67"
             OPTIONS: --preset vc
             RUN_TESTS: true
+            ENVIRONMENT:
           - NAME: "HOST"
-            CONTAINER: "ghcr.io/acts-project/ubuntu2404:56"
+            CONTAINER: "ghcr.io/acts-project/ubuntu2404:67"
             OPTIONS: --preset vecmem
             RUN_TESTS: true
+            ENVIRONMENT:
           - NAME: "HOST"
-            CONTAINER: "ghcr.io/acts-project/ubuntu2404:56"
+            CONTAINER: "ghcr.io/acts-project/ubuntu2404:67"
             OPTIONS: --preset fastor
             RUN_TESTS: true
+            ENVIRONMENT:
           - NAME: "CUDA"
             CONTAINER: "ghcr.io/acts-project/ubuntu2404_cuda:67"
             OPTIONS: --preset cuda
             RUN_TESTS: false
-          - NAME: "SYCL HOST"
-            CONTAINER: "ghcr.io/acts-project/ubuntu2404_oneapi:56"
+            ENVIRONMENT:
+          - NAME: "SYCL Intel"
+            CONTAINER: "ghcr.io/acts-project/ubuntu2404_oneapi:67"
             OPTIONS: --preset sycl
             RUN_TESTS: false
+            ENVIRONMENT: export SYCLFLAGS="-fsycl"
+          - NAME: "SYCL AMD"
+            CONTAINER: "ghcr.io/acts-project/ubuntu2404_rocm_oneapi:67"
+            OPTIONS: --preset sycl
+            RUN_TESTS: false
+            ENVIRONMENT:
 
     # The system to run on.
     runs-on: ubuntu-latest
@@ -118,11 +131,13 @@ jobs:
     - name: Configure
       run: |
         source ${GITHUB_WORKSPACE}/.github/ci_setup.sh ${{ matrix.PLATFORM.NAME }}
+        ${{ matrix.PLATFORM.ENVIRONMENT }}
         cmake ${{ matrix.PLATFORM.OPTIONS }} -DCMAKE_BUILD_TYPE=${{ matrix.BUILD_TYPE }} -S ${GITHUB_WORKSPACE} -B build
     # Perform the build.
     - name: Build
       run: |
         source ${GITHUB_WORKSPACE}/.github/ci_setup.sh ${{ matrix.PLATFORM.NAME }}
+        ${{ matrix.PLATFORM.ENVIRONMENT }}
         cmake --build build
     # Run the unit test(s).
     - name: Test
@@ -130,4 +145,5 @@ jobs:
       run: |
         cd build
         source ${GITHUB_WORKSPACE}/.github/ci_setup.sh ${{ matrix.PLATFORM.NAME }}
+        ${{ matrix.PLATFORM.ENVIRONMENT }}
         ctest --output-on-failure

--- a/extern/vecmem/CMakeLists.txt
+++ b/extern/vecmem/CMakeLists.txt
@@ -13,7 +13,7 @@ message( STATUS "Building VecMem as part of the Algebra Plugins project" )
 
 # Declare where to get VecMem from.
 set( ALGEBRA_PLUGINS_VECMEM_SOURCE
-   "URL;https://github.com/acts-project/vecmem/archive/refs/tags/v1.8.0.tar.gz;URL_MD5;afddf52d9568964f25062e1c887246b7"
+   "URL;https://github.com/acts-project/vecmem/archive/refs/tags/v1.12.0.tar.gz;URL_MD5;a1e314c41e8c7598f50f34a0b27333e5"
    CACHE STRING "Source for VecMem, when built as part of this project" )
 mark_as_advanced( ALGEBRA_PLUGINS_VECMEM_SOURCE )
 

--- a/extern/vecmem/CMakeLists.txt
+++ b/extern/vecmem/CMakeLists.txt
@@ -13,7 +13,7 @@ message( STATUS "Building VecMem as part of the Algebra Plugins project" )
 
 # Declare where to get VecMem from.
 set( ALGEBRA_PLUGINS_VECMEM_SOURCE
-   "URL;https://github.com/acts-project/vecmem/archive/refs/tags/v1.12.0.tar.gz;URL_MD5;a1e314c41e8c7598f50f34a0b27333e5"
+   "URL;https://github.com/acts-project/vecmem/archive/refs/tags/v1.13.0.tar.gz;URL_MD5;02fe327552c21779f501c224b8c95e87"
    CACHE STRING "Source for VecMem, when built as part of this project" )
 mark_as_advanced( ALGEBRA_PLUGINS_VECMEM_SOURCE )
 

--- a/math/common/include/algebra/math/common.hpp
+++ b/math/common/include/algebra/math/common.hpp
@@ -12,7 +12,7 @@
 
 // SYCL include(s).
 #if defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION)
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #endif
 
 // System include(s).
@@ -23,7 +23,7 @@ namespace algebra::math {
 
 /// Namespace to pick up math functions from
 #if defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION)
-namespace math_ns = cl::sycl;
+namespace math_ns = ::sycl;
 #else
 namespace math_ns = std;
 #endif  // SYCL

--- a/tests/accelerator/sycl/common/execute_sycl_test.hpp
+++ b/tests/accelerator/sycl/common/execute_sycl_test.hpp
@@ -1,6 +1,6 @@
 /** Algebra plugins library, part of the ACTS project
  *
- * (c) 2020-2022 CERN for the benefit of the ACTS project
+ * (c) 2020-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -8,14 +8,14 @@
 #pragma once
 
 // SYCL include(s).
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 
 // System include(s).
 #include <cstddef>
 
 /// Execute a test functor using SYCL, on @c arraySizes threads
 template <class FUNCTOR, class... ARGS>
-void execute_sycl_test(cl::sycl::queue& queue, std::size_t arraySizes,
+void execute_sycl_test(::sycl::queue& queue, std::size_t arraySizes,
                        ARGS... args) {
 
   // Submit a kernel that would run the specified functor.
@@ -25,17 +25,16 @@ void execute_sycl_test(cl::sycl::queue& queue, std::size_t arraySizes,
         // Unfortunately the FUNCTOR class is too complicated, and DPC++ dies
         // on it. While providing a unique simple class for every template
         // specialisation is also pretty impossible. :-(
-        h.parallel_for(cl::sycl::range<1>(arraySizes),
-                       [=](cl::sycl::item<1> id) {
-                         // Find the current index that we need to
-                         // process.
-                         const std::size_t i = id[0];
-                         if (i >= arraySizes) {
-                           return;
-                         }
-                         // Execute the test functor for this index.
-                         FUNCTOR()(i, args...);
-                       });
+        h.parallel_for(::sycl::range<1>(arraySizes), [=](::sycl::item<1> id) {
+          // Find the current index that we need to
+          // process.
+          const std::size_t i = id[0];
+          if (i >= arraySizes) {
+            return;
+          }
+          // Execute the test functor for this index.
+          FUNCTOR()(i, args...);
+        });
       })
       .wait_and_throw();
 }

--- a/tests/accelerator/sycl/common/test_sycl_basics.hpp
+++ b/tests/accelerator/sycl/common/test_sycl_basics.hpp
@@ -1,6 +1,6 @@
 /** Algebra plugins library, part of the ACTS project
  *
- * (c) 2020-2023 CERN for the benefit of the ACTS project
+ * (c) 2020-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -21,7 +21,7 @@
 #include <gtest/gtest.h>
 
 // SYCL include(s).
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 
 /// Test case class, to be specialised for the different plugins
 template <typename T>
@@ -33,7 +33,7 @@ class test_sycl_basics : public test_basics_base<T> {
 
  protected:
   /// Queue to be used by all of the tests.
-  cl::sycl::queue m_queue;
+  ::sycl::queue m_queue;
   /// Memory resource for all of the tests.
   vecmem::sycl::shared_memory_resource m_resource{&m_queue};
 };
@@ -45,7 +45,7 @@ TYPED_TEST_P(test_sycl_basics, vector_2d_ops) {
   // Don't run the test at double precision, if the SYCL device doesn't
   // support it.
   if ((typeid(typename TypeParam::scalar) == typeid(double)) &&
-      (this->m_queue.get_device().has(cl::sycl::aspect::fp64) == false)) {
+      (this->m_queue.get_device().has(::sycl::aspect::fp64) == false)) {
     GTEST_SKIP();
   }
 
@@ -69,7 +69,7 @@ TYPED_TEST_P(test_sycl_basics, vector_3d_ops) {
   // Don't run the test at double precision, if the SYCL device doesn't
   // support it.
   if ((typeid(typename TypeParam::scalar) == typeid(double)) &&
-      (this->m_queue.get_device().has(cl::sycl::aspect::fp64) == false)) {
+      (this->m_queue.get_device().has(::sycl::aspect::fp64) == false)) {
     GTEST_SKIP();
   }
 
@@ -101,7 +101,7 @@ TYPED_TEST_P(test_sycl_basics, matrix64_ops) {
   // Don't run the test at double precision, if the SYCL device doesn't
   // support it.
   if ((typeid(typename TypeParam::scalar) == typeid(double)) &&
-      (this->m_queue.get_device().has(cl::sycl::aspect::fp64) == false)) {
+      (this->m_queue.get_device().has(::sycl::aspect::fp64) == false)) {
     GTEST_SKIP();
   }
 
@@ -123,7 +123,7 @@ TYPED_TEST_P(test_sycl_basics, matrix22_ops) {
   // Don't run the test at double precision, if the SYCL device doesn't
   // support it.
   if ((typeid(typename TypeParam::scalar) == typeid(double)) &&
-      (this->m_queue.get_device().has(cl::sycl::aspect::fp64) == false)) {
+      (this->m_queue.get_device().has(::sycl::aspect::fp64) == false)) {
     GTEST_SKIP();
   }
 
@@ -145,7 +145,7 @@ TYPED_TEST_P(test_sycl_basics, transform3) {
   // Don't run the test at double precision, if the SYCL device doesn't
   // support it.
   if ((typeid(typename TypeParam::scalar) == typeid(double)) &&
-      (this->m_queue.get_device().has(cl::sycl::aspect::fp64) == false)) {
+      (this->m_queue.get_device().has(::sycl::aspect::fp64) == false)) {
     GTEST_SKIP();
   }
 


### PR DESCRIPTION
Connected to #128, these updates are needed to be able to use [oneAPI 2025.0.0](https://www.intel.com/content/www/us/en/developer/articles/release-notes/intel-oneapi-toolkit-release-notes.html) with this project. With the hope that the latest version of oneAPI may work a little better. 🤔 (But also to be able to give our code to Intel developers, so that they could see the issues that we see, with the latest compilers.)

It will clash with #128, but we can just push that one in first, and then I'll resolve the one conflict I anticipate.