### PR TITLE
MSVC Fix, main branch (2024.11.21.)

### DIFF
--- a/cmake/algebra-plugins-functions.cmake
+++ b/cmake/algebra-plugins-functions.cmake
@@ -1,6 +1,6 @@
 # Algebra plugins library, part of the ACTS project (R&D line)
 #
-# (c) 2021-2023 CERN for the benefit of the ACTS project
+# (c) 2021-2024 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -8,6 +8,7 @@
 include_guard( GLOBAL )
 
 # CMake include(s).
+include( CheckCXXCompilerFlag )
 include( CMakeParseArguments )
 
 # Helper function for setting up the algebra plugins libraries.
@@ -121,8 +122,18 @@ function( algebra_add_benchmark name )
    set( bench_exe_name "algebra_benchmark_${name}" )
    add_executable( ${bench_exe_name} ${ARG_UNPARSED_ARGUMENTS} )
 
-   target_compile_options( algebra_benchmark_${name} PRIVATE
-   "-march=native" "-ftree-vectorize")
+   # Build benchmarks for the native architecture by default. Can be overridden
+   # from the command line.
+   set( ALGEBRA_BENCHMARK_ARCHITECTURE_FLAG "-march=native" CACHE STRING
+      "Architecture flag for the algebra benchmarks" )
+   mark_as_advanced( ALGEBRA_BENCHMARK_ARCHITECTURE_FLAG )
+   check_cxx_compiler_flag( "${ALGEBRA_BENCHMARK_ARCHITECTURE_FLAG}"
+      ALGEBRA_BENCHMARK_ARCHITECTURE_FLAG_SUPPORTED )
+   if( ALGEBRA_BENCHMARK_ARCHITECTURE_FLAG_SUPPORTED AND
+       ( NOT "${CMAKE_CXX_FLAGS}" MATCHES "-march=" ) )
+      target_compile_options( algebra_benchmark_${name} PRIVATE
+         "${ALGEBRA_BENCHMARK_ARCHITECTURE_FLAG}" )
+   endif()
 
    if( ARG_LINK_LIBRARIES )
       target_link_libraries( ${bench_exe_name} PRIVATE ${ARG_LINK_LIBRARIES} )


### PR DESCRIPTION
Made the benchmark build work correctly with MSVC. After #131 we collected the following type of warnings into our CI:

```
     Creating library D:/a/algebra-plugins/algebra-plugins/build/lib/Debug/benchmark.lib and object D:/a/algebra-plugins/algebra-plugins/build/lib/Debug/benchmark.exp
  benchmark.vcxproj -> D:\a\algebra-plugins\algebra-plugins\build\bin\Debug\benchmark.dll
  Building Custom Rule D:/a/algebra-plugins/algebra-plugins/benchmarks/CMakeLists.txt
cl : command line  warning D9002: ignoring unknown option '-march=native' [D:\a\algebra-plugins\algebra-plugins\build\benchmarks\algebra_benchmark_array_getter.vcxproj]
cl : command line  warning D9002: ignoring unknown option '-ftree-vectorize' [D:\a\algebra-plugins\algebra-plugins\build\benchmarks\algebra_benchmark_array_getter.vcxproj]
```

Note that I completely removed `-ftree-vectorize`, and only kept `-march=native` behind a check that makes sure that the compiler would accept that flag.

Since forever `-ftree-vectorize` is part of `-O3` with GCC. (https://gcc.gnu.org/projects/tree-ssa/vectorization.html) So to use auto-vectorization, just use `-DCMAKE_BUILD_TYPE=Release`. Which should anyway be mandatory for benchmarking... 🤔