### PR TITLE
CI Updates, main branch (2024.11.28.)

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -72,47 +72,47 @@ jobs:
             CONTAINER: "ghcr.io/acts-project/ubuntu2404:56"
             OPTIONS: --preset eigen -DALGEBRA_PLUGINS_USE_SYSTEM_EIGEN3=TRUE
             RUN_TESTS: true
-            ENVIRONMENT:
           - NAME: "HOST"
             CONTAINER: "ghcr.io/acts-project/ubuntu2404:67"
             OPTIONS: --preset eigen
             RUN_TESTS: true
-            ENVIRONMENT:
           - NAME: "HOST"
             CONTAINER: "ghcr.io/acts-project/ubuntu2404:56"
             OPTIONS: -DALGEBRA_PLUGINS_INCLUDE_SMATRIX=TRUE
             RUN_TESTS: true
-            ENVIRONMENT:
           - NAME: "HOST"
             CONTAINER: "ghcr.io/acts-project/ubuntu2404:67"
             OPTIONS: --preset vc
             RUN_TESTS: true
-            ENVIRONMENT:
           - NAME: "HOST"
             CONTAINER: "ghcr.io/acts-project/ubuntu2404:67"
             OPTIONS: --preset vecmem
             RUN_TESTS: true
-            ENVIRONMENT:
           - NAME: "HOST"
             CONTAINER: "ghcr.io/acts-project/ubuntu2404:67"
             OPTIONS: --preset fastor
             RUN_TESTS: true
-            ENVIRONMENT:
           - NAME: "CUDA"
             CONTAINER: "ghcr.io/acts-project/ubuntu2404_cuda:67"
             OPTIONS: --preset cuda
             RUN_TESTS: false
-            ENVIRONMENT:
           - NAME: "SYCL Intel"
-            CONTAINER: "ghcr.io/acts-project/ubuntu2404_oneapi:67"
+            CONTAINER: "ghcr.io/acts-project/ubuntu2404_oneapi:69"
             OPTIONS: --preset sycl
-            RUN_TESTS: false
-            ENVIRONMENT: export SYCLFLAGS="-fsycl"
-          - NAME: "SYCL AMD"
-            CONTAINER: "ghcr.io/acts-project/ubuntu2404_rocm_oneapi:67"
-            OPTIONS: --preset sycl
-            RUN_TESTS: false
-            ENVIRONMENT:
+            RUN_TESTS: true
+        include:
+          - BUILD_TYPE: "Release"
+            PLATFORM:
+              NAME: "SYCL AMD"
+              CONTAINER: "ghcr.io/acts-project/ubuntu2404_rocm_oneapi:69"
+              OPTIONS: --preset sycl
+              RUN_TESTS: false
+          - BUILD_TYPE: "Release"
+            PLATFORM:
+              NAME: "SYCL NVIDIA"
+              CONTAINER: "ghcr.io/acts-project/ubuntu2404_cuda_oneapi:69"
+              OPTIONS: --preset sycl -DALGEBRA_PLUGINS_TEST_CUDA=FALSE
+              RUN_TESTS: false
 
     # The system to run on.
     runs-on: ubuntu-latest
@@ -131,13 +131,11 @@ jobs:
     - name: Configure
       run: |
         source ${GITHUB_WORKSPACE}/.github/ci_setup.sh ${{ matrix.PLATFORM.NAME }}
-        ${{ matrix.PLATFORM.ENVIRONMENT }}
         cmake ${{ matrix.PLATFORM.OPTIONS }} -DCMAKE_BUILD_TYPE=${{ matrix.BUILD_TYPE }} -S ${GITHUB_WORKSPACE} -B build
     # Perform the build.
     - name: Build
       run: |
         source ${GITHUB_WORKSPACE}/.github/ci_setup.sh ${{ matrix.PLATFORM.NAME }}
-        ${{ matrix.PLATFORM.ENVIRONMENT }}
         cmake --build build
     # Run the unit test(s).
     - name: Test
@@ -145,5 +143,4 @@ jobs:
       run: |
         cd build
         source ${GITHUB_WORKSPACE}/.github/ci_setup.sh ${{ matrix.PLATFORM.NAME }}
-        ${{ matrix.PLATFORM.ENVIRONMENT }}
         ctest --output-on-failure

--- a/tests/accelerator/sycl/eigen_eigen.sycl
+++ b/tests/accelerator/sycl/eigen_eigen.sycl
@@ -1,6 +1,6 @@
 /** Algebra plugins library, part of the ACTS project
  *
- * (c) 2020-2023 CERN for the benefit of the ACTS project
+ * (c) 2020-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -43,5 +43,5 @@ typedef testing::Types<
         algebra::eigen::vector2<double>, algebra::eigen::vector3<double>,
         algebra::eigen::transform3<double>, int, algebra::eigen::matrix_type>>
     eigen_eigen_types;
-INSTANTIATE_TYPED_TEST_SUITE_P(algebra_plugins, test_sycl_basics,
+INSTANTIATE_TYPED_TEST_SUITE_P(DISABLED_algebra_plugins, test_sycl_basics,
                                eigen_eigen_types, test_specialisation_name);


### PR DESCRIPTION
With updated Docker images finally being available with oneAPI 2025.0.0, I updated the SYCL CI tests to use these latest images.

With the latest images there's no need anymore to override environment variables, so I removed all of that.

Added an NVIDIA backended SYCL build as well, but only in Release mode. At the same time removed the Debug AMD backended build as well. Unfortunately the non-Intel backends just tend to have issues with assertions since forever. :frowning:

As reported in #136, unfortunately the Eigen tests are just not jiving with SYCL for some reason. They compile fine, and even run without any obvious error. But they produce incorrect outputs. :confused: So I just disabled them for now. I'd really like to understand these issues later on, possibly with the help of some Intel developers (@ivorobts ?), but just testing that the code compiles successfully should be enough for the moment...