### PR TITLE
fix: Eigen Identity matrix and Vc/SMatrix matrix getter and hide arithmetic operators in algebra namespace

### DIFF
--- a/frontend/array_cmath/include/algebra/array_cmath.hpp
+++ b/frontend/array_cmath/include/algebra/array_cmath.hpp
@@ -12,6 +12,8 @@
 #include "algebra/math/generic.hpp"
 #include "algebra/storage/array.hpp"
 
+namespace algebra {
+
 /// @name Operators on @c algebra::array::storage_type
 /// @{
 
@@ -20,8 +22,6 @@ using algebra::cmath::operator-;
 using algebra::cmath::operator+;
 
 /// @}
-
-namespace algebra {
 
 namespace getter {
 

--- a/frontend/vecmem_cmath/include/algebra/vecmem_cmath.hpp
+++ b/frontend/vecmem_cmath/include/algebra/vecmem_cmath.hpp
@@ -12,6 +12,8 @@
 #include "algebra/math/generic.hpp"
 #include "algebra/storage/vecmem.hpp"
 
+namespace algebra {
+
 /// @name Operators on @c algebra::vecmem::storage_type
 /// @{
 
@@ -20,8 +22,6 @@ using algebra::cmath::operator-;
 using algebra::cmath::operator+;
 
 /// @}
-
-namespace algebra {
 
 namespace getter {
 

--- a/math/eigen/include/algebra/math/impl/eigen_transform3.hpp
+++ b/math/eigen/include/algebra/math/impl/eigen_transform3.hpp
@@ -163,11 +163,12 @@ struct transform3 {
   /// @param m is the rotation matrix
   /// @param v is the vector to be rotated
   template <typename derived_type>
-    requires(Eigen::MatrixBase<derived_type>::RowsAtCompileTime == 3 &&
-             Eigen::MatrixBase<derived_type>::ColsAtCompileTime == 1)
-  ALGEBRA_HOST_DEVICE static inline auto rotate(
-      const Eigen::Transform<scalar_type, 3, Eigen::Affine> &m,
-      const Eigen::MatrixBase<derived_type> &v) {
+  requires(Eigen::MatrixBase<derived_type>::RowsAtCompileTime == 3 &&
+           Eigen::MatrixBase<derived_type>::ColsAtCompileTime ==
+               1) ALGEBRA_HOST_DEVICE
+      static inline auto rotate(
+          const Eigen::Transform<scalar_type, 3, Eigen::Affine> &m,
+          const Eigen::MatrixBase<derived_type> &v) {
 
     return m.matrix().template block<3, 3>(0, 0) * v;
   }
@@ -209,10 +210,11 @@ struct transform3 {
   /// This method transform from a point from the local 3D cartesian frame to
   /// the global 3D cartesian frame
   template <typename derived_type>
-    requires(Eigen::MatrixBase<derived_type>::RowsAtCompileTime == 3 &&
-             Eigen::MatrixBase<derived_type>::ColsAtCompileTime == 1)
-  ALGEBRA_HOST_DEVICE inline auto point_to_global(
-      const Eigen::MatrixBase<derived_type> &v) const {
+  requires(Eigen::MatrixBase<derived_type>::RowsAtCompileTime == 3 &&
+           Eigen::MatrixBase<derived_type>::ColsAtCompileTime ==
+               1) ALGEBRA_HOST_DEVICE
+      inline auto point_to_global(
+          const Eigen::MatrixBase<derived_type> &v) const {
 
     return (_data * v);
   }
@@ -220,10 +222,11 @@ struct transform3 {
   /// This method transform from a vector from the global 3D cartesian frame
   /// into the local 3D cartesian frame
   template <typename derived_type>
-    requires(Eigen::MatrixBase<derived_type>::RowsAtCompileTime == 3 &&
-             Eigen::MatrixBase<derived_type>::ColsAtCompileTime == 1)
-  ALGEBRA_HOST_DEVICE inline auto point_to_local(
-      const Eigen::MatrixBase<derived_type> &v) const {
+  requires(Eigen::MatrixBase<derived_type>::RowsAtCompileTime == 3 &&
+           Eigen::MatrixBase<derived_type>::ColsAtCompileTime ==
+               1) ALGEBRA_HOST_DEVICE
+      inline auto point_to_local(
+          const Eigen::MatrixBase<derived_type> &v) const {
 
     return (_data_inv * v);
   }
@@ -231,10 +234,11 @@ struct transform3 {
   /// This method transform from a vector from the local 3D cartesian frame to
   /// the global 3D cartesian frame
   template <typename derived_type>
-    requires(Eigen::MatrixBase<derived_type>::RowsAtCompileTime == 3 &&
-             Eigen::MatrixBase<derived_type>::ColsAtCompileTime == 1)
-  ALGEBRA_HOST_DEVICE inline auto vector_to_global(
-      const Eigen::MatrixBase<derived_type> &v) const {
+  requires(Eigen::MatrixBase<derived_type>::RowsAtCompileTime == 3 &&
+           Eigen::MatrixBase<derived_type>::ColsAtCompileTime ==
+               1) ALGEBRA_HOST_DEVICE
+      inline auto vector_to_global(
+          const Eigen::MatrixBase<derived_type> &v) const {
 
     return (_data.linear() * v);
   }
@@ -242,10 +246,11 @@ struct transform3 {
   /// This method transform from a vector from the global 3D cartesian frame
   /// into the local 3D cartesian frame
   template <typename derived_type>
-    requires(Eigen::MatrixBase<derived_type>::RowsAtCompileTime == 3 &&
-             Eigen::MatrixBase<derived_type>::ColsAtCompileTime == 1)
-  ALGEBRA_HOST_DEVICE inline auto vector_to_local(
-      const Eigen::MatrixBase<derived_type> &v) const {
+  requires(Eigen::MatrixBase<derived_type>::RowsAtCompileTime == 3 &&
+           Eigen::MatrixBase<derived_type>::ColsAtCompileTime ==
+               1) ALGEBRA_HOST_DEVICE
+      inline auto vector_to_local(
+          const Eigen::MatrixBase<derived_type> &v) const {
 
     return (_data_inv.linear() * v);
   }

--- a/math/eigen/include/algebra/math/impl/eigen_transform3.hpp
+++ b/math/eigen/include/algebra/math/impl/eigen_transform3.hpp
@@ -65,10 +65,8 @@ struct transform3 {
   /// @name Data objects
   /// @{
 
-  Eigen::Transform<scalar_type, 3, Eigen::Affine> _data =
-      Eigen::Transform<scalar_type, 3, Eigen::Affine>::Identity();
-  Eigen::Transform<scalar_type, 3, Eigen::Affine> _data_inv =
-      Eigen::Transform<scalar_type, 3, Eigen::Affine>::Identity();
+  Eigen::Transform<scalar_type, 3, Eigen::Affine> _data;
+  Eigen::Transform<scalar_type, 3, Eigen::Affine> _data_inv;
 
   /// @}
 
@@ -81,6 +79,8 @@ struct transform3 {
   ALGEBRA_HOST_DEVICE
   transform3(const vector3 &t, const vector3 &x, const vector3 &y,
              const vector3 &z, bool get_inverse = true) {
+    _data.setIdentity();
+
     auto &matrix = _data.matrix();
     matrix.template block<3, 1>(0, 0) = x;
     matrix.template block<3, 1>(0, 1) = y;
@@ -89,6 +89,8 @@ struct transform3 {
 
     if (get_inverse) {
       _data_inv = _data.inverse();
+    } else {
+      _data_inv.setIdentity();
     }
   }
 
@@ -161,12 +163,11 @@ struct transform3 {
   /// @param m is the rotation matrix
   /// @param v is the vector to be rotated
   template <typename derived_type>
-  requires(Eigen::MatrixBase<derived_type>::RowsAtCompileTime == 3 &&
-           Eigen::MatrixBase<derived_type>::ColsAtCompileTime ==
-               1) ALGEBRA_HOST_DEVICE
-      static inline auto rotate(
-          const Eigen::Transform<scalar_type, 3, Eigen::Affine> &m,
-          const Eigen::MatrixBase<derived_type> &v) {
+    requires(Eigen::MatrixBase<derived_type>::RowsAtCompileTime == 3 &&
+             Eigen::MatrixBase<derived_type>::ColsAtCompileTime == 1)
+  ALGEBRA_HOST_DEVICE static inline auto rotate(
+      const Eigen::Transform<scalar_type, 3, Eigen::Affine> &m,
+      const Eigen::MatrixBase<derived_type> &v) {
 
     return m.matrix().template block<3, 3>(0, 0) * v;
   }
@@ -208,11 +209,10 @@ struct transform3 {
   /// This method transform from a point from the local 3D cartesian frame to
   /// the global 3D cartesian frame
   template <typename derived_type>
-  requires(Eigen::MatrixBase<derived_type>::RowsAtCompileTime == 3 &&
-           Eigen::MatrixBase<derived_type>::ColsAtCompileTime ==
-               1) ALGEBRA_HOST_DEVICE
-      inline auto point_to_global(
-          const Eigen::MatrixBase<derived_type> &v) const {
+    requires(Eigen::MatrixBase<derived_type>::RowsAtCompileTime == 3 &&
+             Eigen::MatrixBase<derived_type>::ColsAtCompileTime == 1)
+  ALGEBRA_HOST_DEVICE inline auto point_to_global(
+      const Eigen::MatrixBase<derived_type> &v) const {
 
     return (_data * v);
   }
@@ -220,11 +220,10 @@ struct transform3 {
   /// This method transform from a vector from the global 3D cartesian frame
   /// into the local 3D cartesian frame
   template <typename derived_type>
-  requires(Eigen::MatrixBase<derived_type>::RowsAtCompileTime == 3 &&
-           Eigen::MatrixBase<derived_type>::ColsAtCompileTime ==
-               1) ALGEBRA_HOST_DEVICE
-      inline auto point_to_local(
-          const Eigen::MatrixBase<derived_type> &v) const {
+    requires(Eigen::MatrixBase<derived_type>::RowsAtCompileTime == 3 &&
+             Eigen::MatrixBase<derived_type>::ColsAtCompileTime == 1)
+  ALGEBRA_HOST_DEVICE inline auto point_to_local(
+      const Eigen::MatrixBase<derived_type> &v) const {
 
     return (_data_inv * v);
   }
@@ -232,11 +231,10 @@ struct transform3 {
   /// This method transform from a vector from the local 3D cartesian frame to
   /// the global 3D cartesian frame
   template <typename derived_type>
-  requires(Eigen::MatrixBase<derived_type>::RowsAtCompileTime == 3 &&
-           Eigen::MatrixBase<derived_type>::ColsAtCompileTime ==
-               1) ALGEBRA_HOST_DEVICE
-      inline auto vector_to_global(
-          const Eigen::MatrixBase<derived_type> &v) const {
+    requires(Eigen::MatrixBase<derived_type>::RowsAtCompileTime == 3 &&
+             Eigen::MatrixBase<derived_type>::ColsAtCompileTime == 1)
+  ALGEBRA_HOST_DEVICE inline auto vector_to_global(
+      const Eigen::MatrixBase<derived_type> &v) const {
 
     return (_data.linear() * v);
   }
@@ -244,11 +242,10 @@ struct transform3 {
   /// This method transform from a vector from the global 3D cartesian frame
   /// into the local 3D cartesian frame
   template <typename derived_type>
-  requires(Eigen::MatrixBase<derived_type>::RowsAtCompileTime == 3 &&
-           Eigen::MatrixBase<derived_type>::ColsAtCompileTime ==
-               1) ALGEBRA_HOST_DEVICE
-      inline auto vector_to_local(
-          const Eigen::MatrixBase<derived_type> &v) const {
+    requires(Eigen::MatrixBase<derived_type>::RowsAtCompileTime == 3 &&
+             Eigen::MatrixBase<derived_type>::ColsAtCompileTime == 1)
+  ALGEBRA_HOST_DEVICE inline auto vector_to_local(
+      const Eigen::MatrixBase<derived_type> &v) const {
 
     return (_data_inv.linear() * v);
   }

--- a/storage/common/include/algebra/storage/matrix_getter.hpp
+++ b/storage/common/include/algebra/storage/matrix_getter.hpp
@@ -241,7 +241,7 @@ ALGEBRA_HOST_DEVICE constexpr void set_block(
   if constexpr (ROWS == mROW &&
                 matrix_t::storage_rows() == input_matrix_t::storage_rows()) {
     if (row == 0u) {
-      for (std::size_t j = col; j < mCOL; ++j) {
+      for (std::size_t j = col; j < col + COLS; ++j) {
         m[j] = b[j - col];
       }
       return;

--- a/storage/smatrix/include/algebra/storage/impl/smatrix_getter.hpp
+++ b/storage/smatrix/include/algebra/storage/impl/smatrix_getter.hpp
@@ -145,8 +145,8 @@ struct block_getter {
 
     ROOT::Math::SVector<scalar_t, SIZE> ret;
 
-    for (std::size_t irow = row; irow < row + SIZE; ++irow) {
-      ret[irow - row] = m[col][irow];
+    for (unsigned int irow = row; irow < row + SIZE; ++irow) {
+      ret[irow - row] = m(irow, col);
     }
 
     return ret;

--- a/tests/common/test_device_basics.hpp
+++ b/tests/common/test_device_basics.hpp
@@ -40,6 +40,7 @@ class test_device_basics : public test_base<T> {
   /// Perform various 2D vector operations, and produce a scalar output
   ALGEBRA_HOST_DEVICE
   scalar vector_2d_ops(point2 a, point2 b) const {
+    using namespace algebra;
 
     point2 c = a + b;
     point2 c2 = c * 2.0;
@@ -58,6 +59,7 @@ class test_device_basics : public test_base<T> {
   /// Perform various 3D vector operations, and produce a scalar output
   ALGEBRA_HOST_DEVICE
   scalar vector_3d_ops(vector3 a, vector3 b) const {
+    using namespace algebra;
 
     vector3 c = a + b;
     vector3 c2 = c * 2.0;
@@ -78,6 +80,7 @@ class test_device_basics : public test_base<T> {
   /// Perform some trivial operations on an asymmetrix matrix
   ALGEBRA_HOST_DEVICE
   scalar matrix64_ops(const matrix<6, 4>& m) const {
+    using namespace algebra;
 
     matrix<6, 4> m2;
     for (size_type i = 0; i < 6; ++i) {
@@ -139,6 +142,7 @@ class test_device_basics : public test_base<T> {
   /// Perform some trivial operations on an asymmetrix matrix
   ALGEBRA_HOST_DEVICE
   scalar matrix22_ops(const matrix<2, 2>& m22) const {
+    using namespace algebra;
 
     // Test 2 X 2 matrix determinant
     auto m22_det = algebra::matrix::determinant(m22);
@@ -202,6 +206,7 @@ class test_device_basics : public test_base<T> {
   ALGEBRA_HOST_DEVICE
   scalar transform3_ops(vector3 t1, vector3 t2, vector3 t3, vector3 a,
                         vector3 b) const {
+    using namespace algebra;
 
     transform3 tr1(t1, t2, t3);
     transform3 tr2;

--- a/tests/common/test_host_basics.hpp
+++ b/tests/common/test_host_basics.hpp
@@ -21,6 +21,8 @@
 #include <climits>
 #include <cmath>
 
+using namespace algebra;
+
 /// Test case class, to be specialised for the different plugins - vectors
 template <typename T>
 class test_host_basics_vector : public testing::Test, public test_base<T> {};


### PR DESCRIPTION
The Eigen Identity matrix in the transform class leads to invalid instructions in CUDA. Also fixes small issues in the matrix getters of the Vc and SMatrix plugins.

Also moves the arithmetic operators of the cmath plugin to the algebra namespace, since they were picked up in ACTS builds by Eigen types