### PR TITLE
Fix debug compilation with HIP

### DIFF
--- a/storage/cmath/include/algebra/storage/impl/cmath_getter.hpp
+++ b/storage/cmath/include/algebra/storage/impl/cmath_getter.hpp
@@ -17,6 +17,10 @@
 #include <cstddef>
 #include <type_traits>
 
+#if defined(__HIP__)
+#include <hip/hip_runtime.h>
+#endif
+
 namespace algebra::cmath::storage {
 
 /// "Element getter", assuming a simple 2D array access


### PR DESCRIPTION
Add HIP runtime header for assert when compiling as a HIP source file: avoid host/device function issues.