### PR TITLE
feat: Cleanup benchmark names and add inversion and determinant

### DIFF
--- a/benchmarks/array/array_matrix.cpp
+++ b/benchmarks/array/array_matrix.cpp
@@ -40,6 +40,32 @@ int main(int argc, char** argv) {
   using mat88_transp_d_t =
       matrix_unaryOP_bm<array::matrix_type<double, 8, 8>, bench_op::transpose>;
 
+  using mat44_inv_f_t =
+      matrix_unaryOP_bm<array::matrix_type<float, 4, 4>, bench_op::invert>;
+  using mat44_inv_d_t =
+      matrix_unaryOP_bm<array::matrix_type<double, 4, 4>, bench_op::invert>;
+  using mat66_inv_f_t =
+      matrix_unaryOP_bm<array::matrix_type<float, 6, 6>, bench_op::invert>;
+  using mat66_inv_d_t =
+      matrix_unaryOP_bm<array::matrix_type<double, 6, 6>, bench_op::invert>;
+  using mat88_inv_f_t =
+      matrix_unaryOP_bm<array::matrix_type<float, 8, 8>, bench_op::invert>;
+  using mat88_inv_d_t =
+      matrix_unaryOP_bm<array::matrix_type<double, 8, 8>, bench_op::invert>;
+
+  using mat44_det_f_t =
+      matrix_unaryOP_bm<array::matrix_type<float, 4, 4>, bench_op::determinant>;
+  using mat44_det_d_t = matrix_unaryOP_bm<array::matrix_type<double, 4, 4>,
+                                          bench_op::determinant>;
+  using mat66_det_f_t =
+      matrix_unaryOP_bm<array::matrix_type<float, 6, 6>, bench_op::determinant>;
+  using mat66_det_d_t = matrix_unaryOP_bm<array::matrix_type<double, 6, 6>,
+                                          bench_op::determinant>;
+  using mat88_det_f_t =
+      matrix_unaryOP_bm<array::matrix_type<float, 8, 8>, bench_op::determinant>;
+  using mat88_det_d_t = matrix_unaryOP_bm<array::matrix_type<double, 8, 8>,
+                                          bench_op::determinant>;
+
   using mat44_add_f_t =
       matrix_binaryOP_bm<array::matrix_type<float, 4, 4>, bench_op::add>;
   using mat44_add_d_t =

--- a/benchmarks/common/include/benchmark/common/benchmark_base.hpp
+++ b/benchmarks/common/include/benchmark/common/benchmark_base.hpp
@@ -79,10 +79,10 @@ struct benchmark_base {
   virtual ~benchmark_base() = default;
 
   /// @returns the benchmark name
-  virtual std::string name() const = 0;
+  virtual constexpr std::string name() const = 0;
 
   /// Benchmark case
-  virtual void operator()(::benchmark::State&) = 0;
+  virtual void operator()(::benchmark::State&) const = 0;
 };
 
 }  // namespace algebra

--- a/benchmarks/common/include/benchmark/common/benchmark_transform3.hpp
+++ b/benchmarks/common/include/benchmark/common/benchmark_transform3.hpp
@@ -13,7 +13,7 @@
 // System include(s)
 #include <chrono>
 #include <iostream>
-#include <string>
+#include <string_view>
 #include <thread>
 #include <vector>
 
@@ -30,7 +30,7 @@ struct transform3_bm : public vector_bm<typename transform3_t::vector3> {
 
  public:
   /// Prefix for the benchmark name
-  inline static const std::string bm_name{"transform3"};
+  static constexpr std::string_view bm_name{"transform3"};
 
   std::vector<transform3_t> trfs;
 
@@ -49,10 +49,12 @@ struct transform3_bm : public vector_bm<typename transform3_t::vector3> {
   /// Clear state
   ~transform3_bm() override { trfs.clear(); }
 
-  std::string name() const override { return base_type::name + "_" + bm_name; }
+  constexpr std::string name() const override {
+    return std::string{base_type::name} + "_" + std::string{bm_name};
+  }
 
   /// Benchmark case
-  void operator()(::benchmark::State& state) override {
+  inline void operator()(::benchmark::State& state) const override {
 
     using vector_t = typename transform3_t::vector3;
     using point_t = typename transform3_t::point3;

--- a/benchmarks/common/include/benchmark/common/benchmark_vector.hpp
+++ b/benchmarks/common/include/benchmark/common/benchmark_vector.hpp
@@ -14,7 +14,7 @@
 // System include(s)
 #include <chrono>
 #include <iostream>
-#include <string>
+#include <string_view>
 #include <thread>
 #include <vector>
 
@@ -28,7 +28,7 @@ template <concepts::vector vector_t>
 struct vector_bm : public benchmark_base {
 
   /// Prefix for the benchmark name
-  inline static const std::string name{"vector"};
+  static constexpr std::string_view name{"vector"};
 
   std::vector<vector_t> a;
   std::vector<vector_t> b;
@@ -71,11 +71,11 @@ requires std::invocable<unaryOP, vector_t<scalar_t>> struct vector_unaryOP_bm
   vector_unaryOP_bm(const vector_unaryOP_bm &bm) = default;
   vector_unaryOP_bm &operator=(vector_unaryOP_bm &other) = default;
 
-  std::string name() const override {
-    return base_type::name + "_" + unaryOP::name;
+  constexpr std::string name() const override {
+    return std::string{base_type::name} + "_" + std::string{unaryOP::name};
   }
 
-  void operator()(::benchmark::State &state) override {
+  inline void operator()(::benchmark::State &state) const override {
 
     using result_t = std::invoke_result_t<unaryOP, vector_t<scalar_t>>;
 
@@ -105,11 +105,11 @@ requires std::invocable<binaryOP, vector_t<scalar_t>,
   vector_binaryOP_bm(const vector_binaryOP_bm &bm) = default;
   vector_binaryOP_bm &operator=(vector_binaryOP_bm &other) = default;
 
-  std::string name() const override {
-    return base_type::name + "_" + binaryOP::name;
+  constexpr std::string name() const override {
+    return std::string{base_type::name} + "_" + std::string{binaryOP::name};
   }
 
-  void operator()(::benchmark::State &state) override {
+  inline void operator()(::benchmark::State &state) const override {
 
     using result_t =
         std::invoke_result_t<binaryOP, vector_t<scalar_t>, vector_t<scalar_t>>;
@@ -130,43 +130,43 @@ requires std::invocable<binaryOP, vector_t<scalar_t>,
 namespace bench_op {
 
 struct add {
-  inline static const std::string name{"add"};
+  static constexpr std::string_view name{"add"};
   template <concepts::vector vector_t>
-  vector_t operator()(const vector_t &a, const vector_t &b) const {
+  constexpr vector_t operator()(const vector_t &a, const vector_t &b) const {
     return a + b;
   }
 };
 struct sub {
-  inline static const std::string name{"sub"};
+  static constexpr std::string_view name{"sub"};
   template <concepts::vector vector_t>
-  vector_t operator()(const vector_t &a, const vector_t &b) const {
+  constexpr vector_t operator()(const vector_t &a, const vector_t &b) const {
     return a - b;
   }
 };
 struct dot {
-  inline static const std::string name{"dot"};
+  static constexpr std::string_view name{"dot"};
   template <concepts::vector vector_t>
-  algebra::traits::scalar_t<vector_t> operator()(const vector_t &a,
-                                                 const vector_t &b) const {
+  constexpr algebra::traits::scalar_t<vector_t> operator()(
+      const vector_t &a, const vector_t &b) const {
     return algebra::vector::dot(a, b);
   }
 };
 struct cross {
-  inline static const std::string name{"cross"};
+  static constexpr std::string_view name{"cross"};
   template <concepts::vector vector_t>
-  vector_t operator()(const vector_t &a, const vector_t &b) const {
+  constexpr vector_t operator()(const vector_t &a, const vector_t &b) const {
     return algebra::vector::cross(a, b);
   }
 };
 
 // Macro for declaring vector unary ops
-#define ALGEBRA_PLUGINS_BENCH_VECTOR(OP, RES)  \
-  struct OP {                                  \
-    inline static const std::string name{#OP}; \
-    template <concepts::vector vector_t>       \
-    RES operator()(const vector_t &a) const {  \
-      return algebra::vector::OP(a);           \
-    }                                          \
+#define ALGEBRA_PLUGINS_BENCH_VECTOR(OP, RES)           \
+  struct OP {                                           \
+    static constexpr std::string_view name{#OP};        \
+    template <concepts::vector vector_t>                \
+    constexpr RES operator()(const vector_t &a) const { \
+      return algebra::vector::OP(a);                    \
+    }                                                   \
   };
 
 ALGEBRA_PLUGINS_BENCH_VECTOR(phi, algebra::traits::scalar_t<vector_t>)

--- a/benchmarks/common/include/benchmark/common/register_benchmark.hpp
+++ b/benchmarks/common/include/benchmark/common/register_benchmark.hpp
@@ -19,8 +19,9 @@
 namespace algebra {
 
 template <typename benchmark_t>
-requires std::derived_from<benchmark_t, benchmark_base> void register_benchmark(
-    const benchmark_base::configuration& cfg, const std::string& suffix) {
+requires std::derived_from<benchmark_t, benchmark_base> inline void
+register_benchmark(const benchmark_base::configuration& cfg,
+                   const std::string& suffix) {
   benchmark_t bench{cfg};
 
   ::benchmark::RegisterBenchmark((bench.name() + suffix).c_str(), bench)

--- a/benchmarks/eigen/eigen_matrix.cpp
+++ b/benchmarks/eigen/eigen_matrix.cpp
@@ -40,6 +40,32 @@ int main(int argc, char** argv) {
   using mat88_transp_d_t =
       matrix_unaryOP_bm<eigen::matrix_type<double, 8, 8>, bench_op::transpose>;
 
+  using mat44_inv_f_t =
+      matrix_unaryOP_bm<eigen::matrix_type<float, 4, 4>, bench_op::invert>;
+  using mat44_inv_d_t =
+      matrix_unaryOP_bm<eigen::matrix_type<double, 4, 4>, bench_op::invert>;
+  using mat66_inv_f_t =
+      matrix_unaryOP_bm<eigen::matrix_type<float, 6, 6>, bench_op::invert>;
+  using mat66_inv_d_t =
+      matrix_unaryOP_bm<eigen::matrix_type<double, 6, 6>, bench_op::invert>;
+  using mat88_inv_f_t =
+      matrix_unaryOP_bm<eigen::matrix_type<float, 8, 8>, bench_op::invert>;
+  using mat88_inv_d_t =
+      matrix_unaryOP_bm<eigen::matrix_type<double, 8, 8>, bench_op::invert>;
+
+  using mat44_det_f_t =
+      matrix_unaryOP_bm<eigen::matrix_type<float, 4, 4>, bench_op::determinant>;
+  using mat44_det_d_t = matrix_unaryOP_bm<eigen::matrix_type<double, 4, 4>,
+                                          bench_op::determinant>;
+  using mat66_det_f_t =
+      matrix_unaryOP_bm<eigen::matrix_type<float, 6, 6>, bench_op::determinant>;
+  using mat66_det_d_t = matrix_unaryOP_bm<eigen::matrix_type<double, 6, 6>,
+                                          bench_op::determinant>;
+  using mat88_det_f_t =
+      matrix_unaryOP_bm<eigen::matrix_type<float, 8, 8>, bench_op::determinant>;
+  using mat88_det_d_t = matrix_unaryOP_bm<eigen::matrix_type<double, 8, 8>,
+                                          bench_op::determinant>;
+
   using mat44_add_f_t =
       matrix_binaryOP_bm<eigen::matrix_type<float, 4, 4>, bench_op::add>;
   using mat44_add_d_t =

--- a/benchmarks/vc_aos/vc_aos_matrix.cpp
+++ b/benchmarks/vc_aos/vc_aos_matrix.cpp
@@ -40,6 +40,32 @@ int main(int argc, char** argv) {
   using mat88_transp_d_t =
       matrix_unaryOP_bm<vc_aos::matrix_type<double, 8, 8>, bench_op::transpose>;
 
+  using mat44_inv_f_t =
+      matrix_unaryOP_bm<vc_aos::matrix_type<float, 4, 4>, bench_op::invert>;
+  using mat44_inv_d_t =
+      matrix_unaryOP_bm<vc_aos::matrix_type<double, 4, 4>, bench_op::invert>;
+  using mat66_inv_f_t =
+      matrix_unaryOP_bm<vc_aos::matrix_type<float, 6, 6>, bench_op::invert>;
+  using mat66_inv_d_t =
+      matrix_unaryOP_bm<vc_aos::matrix_type<double, 6, 6>, bench_op::invert>;
+  using mat88_inv_f_t =
+      matrix_unaryOP_bm<vc_aos::matrix_type<float, 8, 8>, bench_op::invert>;
+  using mat88_inv_d_t =
+      matrix_unaryOP_bm<vc_aos::matrix_type<double, 8, 8>, bench_op::invert>;
+
+  using mat44_det_f_t = matrix_unaryOP_bm<vc_aos::matrix_type<float, 4, 4>,
+                                          bench_op::determinant>;
+  using mat44_det_d_t = matrix_unaryOP_bm<vc_aos::matrix_type<double, 4, 4>,
+                                          bench_op::determinant>;
+  using mat66_det_f_t = matrix_unaryOP_bm<vc_aos::matrix_type<float, 6, 6>,
+                                          bench_op::determinant>;
+  using mat66_det_d_t = matrix_unaryOP_bm<vc_aos::matrix_type<double, 6, 6>,
+                                          bench_op::determinant>;
+  using mat88_det_f_t = matrix_unaryOP_bm<vc_aos::matrix_type<float, 8, 8>,
+                                          bench_op::determinant>;
+  using mat88_det_d_t = matrix_unaryOP_bm<vc_aos::matrix_type<double, 8, 8>,
+                                          bench_op::determinant>;
+
   using mat44_add_f_t =
       matrix_binaryOP_bm<vc_aos::matrix_type<float, 4, 4>, bench_op::add>;
   using mat44_add_d_t =

--- a/math/eigen/include/algebra/math/impl/eigen_matrix.hpp
+++ b/math/eigen/include/algebra/math/impl/eigen_matrix.hpp
@@ -73,8 +73,11 @@ determinant(const Eigen::MatrixBase<derived_type> &m) {
 
 /// @returns the inverse of @param m
 template <typename derived_type>
-ALGEBRA_HOST_DEVICE inline auto inverse(
-    const Eigen::MatrixBase<derived_type> &m) {
+ALGEBRA_HOST_DEVICE inline matrix_type<
+    typename Eigen::MatrixBase<derived_type>::value_type,
+    Eigen::MatrixBase<derived_type>::RowsAtCompileTime,
+    Eigen::MatrixBase<derived_type>::ColsAtCompileTime>
+inverse(const Eigen::MatrixBase<derived_type> &m) {
   return m.inverse();
 }
 


### PR DESCRIPTION
Uses constexpr string views for the benchmarks names now and adds the new cases for the determinant and matrix inversion that were missing previously. The Eigen plugin inversion algorithm is returning a concrete type now in order to prevent expression templates to be handed through.