### PR TITLE
feat: loop unrolling and switch to constexpr

### DIFF
--- a/common/include/algebra/qualifiers.hpp
+++ b/common/include/algebra/qualifiers.hpp
@@ -31,3 +31,14 @@
 #else
 #define ALGEBRA_ALIGN(x) alignas(x)
 #endif
+
+// @see https://stackoverflow.com/questions/78071873/gcc-preprocessor-macro-and-pragma-gcc-unroll
+#if defined(__clang__)
+#define ARG_TO_STRING(A) #A
+#define ALGEBRA_UNROLL_N(n) _Pragma(ARG_TO_STRING(clang loop unroll_count(n)))
+#elif defined(__GNUC__) || defined(__GNUG__)
+#define ARG_TO_STRING(A) #A
+#define ALGEBRA_UNROLL_N(n) _Pragma(ARG_TO_STRING(GCC unroll n))
+#else
+#define ALGEBRA_UNROLL_N(n)
+#endif

--- a/common/include/algebra/qualifiers.hpp
+++ b/common/include/algebra/qualifiers.hpp
@@ -32,13 +32,20 @@
 #define ALGEBRA_ALIGN(x) alignas(x)
 #endif
 
-// @see https://stackoverflow.com/questions/78071873/gcc-preprocessor-macro-and-pragma-gcc-unroll
+// @see
+// https://stackoverflow.com/questions/78071873/gcc-preprocessor-macro-and-pragma-gcc-unroll
 #if defined(__clang__)
 #define ARG_TO_STRING(A) #A
 #define ALGEBRA_UNROLL_N(n) _Pragma(ARG_TO_STRING(clang loop unroll_count(n)))
 #elif defined(__GNUC__) || defined(__GNUG__)
 #define ARG_TO_STRING(A) #A
+#if __GNUC__ >= 14
 #define ALGEBRA_UNROLL_N(n) _Pragma(ARG_TO_STRING(GCC unroll n))
 #else
+// For versions below 14, template parameters apparently cannot be used
+#define ALGEBRA_UNROLL_N(n) _Pragma(ARG_TO_STRING(GCC unroll 8))
+#endif
+#else
+// Unknown compiler or does not support unrolling directives
 #define ALGEBRA_UNROLL_N(n)
 #endif

--- a/math/cmath/include/algebra/math/impl/cmath_matrix.hpp
+++ b/math/cmath/include/algebra/math/impl/cmath_matrix.hpp
@@ -18,7 +18,7 @@ namespace algebra::cmath {
 /// @returns zero matrix of type @tparam matrix_t
 template <concepts::matrix matrix_t>
 requires(std::is_scalar_v<typename matrix_t::value_type::value_type>)
-    ALGEBRA_HOST_DEVICE inline matrix_t zero() {
+    ALGEBRA_HOST_DEVICE constexpr matrix_t zero() {
   matrix_t ret;
 
   for (std::size_t j = 0; j < algebra::traits::columns<matrix_t>; ++j) {
@@ -33,7 +33,7 @@ requires(std::is_scalar_v<typename matrix_t::value_type::value_type>)
 /// @returns identity matrix of type @tparam matrix_t
 template <concepts::matrix matrix_t>
 requires(std::is_scalar_v<typename matrix_t::value_type::value_type>)
-    ALGEBRA_HOST_DEVICE inline auto identity() {
+    ALGEBRA_HOST_DEVICE constexpr auto identity() {
   auto ret{zero<matrix_t>()};
 
   for (std::size_t i = 0; i < algebra::traits::rank<matrix_t>; ++i) {
@@ -62,7 +62,7 @@ ALGEBRA_HOST_DEVICE constexpr void set_identity(
 /// @returns the transpose matrix of @param m
 template <std::size_t ROWS, std::size_t COLS, concepts::scalar scalar_t,
           template <typename, std::size_t> class array_t>
-ALGEBRA_HOST_DEVICE inline auto transpose(
+ALGEBRA_HOST_DEVICE constexpr auto transpose(
     const array_t<array_t<scalar_t, ROWS>, COLS> &m) {
   return algebra::generic::math::transpose(m);
 }
@@ -70,7 +70,7 @@ ALGEBRA_HOST_DEVICE inline auto transpose(
 /// @returns the determinant of @param m
 template <std::size_t ROWS, std::size_t COLS, concepts::scalar scalar_t,
           template <typename, std::size_t> class array_t>
-ALGEBRA_HOST_DEVICE inline scalar_t determinant(
+ALGEBRA_HOST_DEVICE constexpr scalar_t determinant(
     const array_t<array_t<scalar_t, ROWS>, COLS> &m) {
   return algebra::generic::math::determinant(m);
 }
@@ -78,7 +78,7 @@ ALGEBRA_HOST_DEVICE inline scalar_t determinant(
 /// @returns the determinant of @param m
 template <std::size_t ROWS, std::size_t COLS, concepts::scalar scalar_t,
           template <typename, std::size_t> class array_t>
-ALGEBRA_HOST_DEVICE inline auto inverse(
+ALGEBRA_HOST_DEVICE constexpr auto inverse(
     const array_t<array_t<scalar_t, ROWS>, COLS> &m) {
   return algebra::generic::math::inverse(m);
 }

--- a/math/cmath/include/algebra/math/impl/cmath_operators.hpp
+++ b/math/cmath/include/algebra/math/impl/cmath_operators.hpp
@@ -21,7 +21,7 @@ namespace algebra::cmath {
 
 template <template <typename, std::size_t> class array_t,
           concepts::scalar scalar1_t, concepts::scalar scalar2_t>
-ALGEBRA_HOST_DEVICE inline array_t<scalar1_t, 2> operator*(
+ALGEBRA_HOST_DEVICE constexpr array_t<scalar1_t, 2> operator*(
     const array_t<scalar1_t, 2> &a, scalar2_t s) {
 
   return {a[0] * static_cast<scalar1_t>(s), a[1] * static_cast<scalar1_t>(s)};
@@ -29,7 +29,7 @@ ALGEBRA_HOST_DEVICE inline array_t<scalar1_t, 2> operator*(
 
 template <template <typename, std::size_t> class array_t,
           concepts::scalar scalar1_t, concepts::scalar scalar2_t>
-ALGEBRA_HOST_DEVICE inline array_t<scalar1_t, 2> operator*(
+ALGEBRA_HOST_DEVICE constexpr array_t<scalar1_t, 2> operator*(
     scalar2_t s, const array_t<scalar1_t, 2> &a) {
 
   return {static_cast<scalar1_t>(s) * a[0], static_cast<scalar1_t>(s) * a[1]};
@@ -37,7 +37,7 @@ ALGEBRA_HOST_DEVICE inline array_t<scalar1_t, 2> operator*(
 
 template <template <typename, std::size_t> class array_t,
           concepts::scalar scalar_t>
-ALGEBRA_HOST_DEVICE inline array_t<scalar_t, 2> operator-(
+ALGEBRA_HOST_DEVICE constexpr array_t<scalar_t, 2> operator-(
     const array_t<scalar_t, 2> &a, const array_t<scalar_t, 2> &b) {
 
   return {a[0] - b[0], a[1] - b[1]};
@@ -45,7 +45,7 @@ ALGEBRA_HOST_DEVICE inline array_t<scalar_t, 2> operator-(
 
 template <template <typename, std::size_t> class array_t,
           concepts::scalar scalar_t>
-ALGEBRA_HOST_DEVICE inline array_t<scalar_t, 2> operator+(
+ALGEBRA_HOST_DEVICE constexpr array_t<scalar_t, 2> operator+(
     const array_t<scalar_t, 2> &a, const array_t<scalar_t, 2> &b) {
 
   return {a[0] + b[0], a[1] + b[1]};
@@ -58,7 +58,7 @@ ALGEBRA_HOST_DEVICE inline array_t<scalar_t, 2> operator+(
 
 template <template <typename, std::size_t> class array_t,
           concepts::scalar scalar1_t, concepts::scalar scalar2_t>
-ALGEBRA_HOST_DEVICE inline array_t<scalar1_t, 3> operator*(
+ALGEBRA_HOST_DEVICE constexpr array_t<scalar1_t, 3> operator*(
     const array_t<scalar1_t, 3> &a, scalar2_t s) {
 
   return {a[0] * static_cast<scalar1_t>(s), a[1] * static_cast<scalar1_t>(s),
@@ -67,7 +67,7 @@ ALGEBRA_HOST_DEVICE inline array_t<scalar1_t, 3> operator*(
 
 template <template <typename, std::size_t> class array_t,
           concepts::scalar scalar1_t, concepts::scalar scalar2_t>
-ALGEBRA_HOST_DEVICE inline array_t<scalar1_t, 3> operator*(
+ALGEBRA_HOST_DEVICE constexpr array_t<scalar1_t, 3> operator*(
     scalar2_t s, const array_t<scalar1_t, 3> &a) {
 
   return {static_cast<scalar1_t>(s) * a[0], static_cast<scalar1_t>(s) * a[1],
@@ -76,7 +76,7 @@ ALGEBRA_HOST_DEVICE inline array_t<scalar1_t, 3> operator*(
 
 template <template <typename, std::size_t> class array_t,
           concepts::scalar scalar_t>
-ALGEBRA_HOST_DEVICE inline array_t<scalar_t, 3> operator-(
+ALGEBRA_HOST_DEVICE constexpr array_t<scalar_t, 3> operator-(
     const array_t<scalar_t, 3> &a, const array_t<scalar_t, 3> &b) {
 
   return {a[0] - b[0], a[1] - b[1], a[2] - b[2]};
@@ -84,7 +84,7 @@ ALGEBRA_HOST_DEVICE inline array_t<scalar_t, 3> operator-(
 
 template <template <typename, std::size_t> class array_t,
           concepts::scalar scalar_t>
-ALGEBRA_HOST_DEVICE inline array_t<scalar_t, 3> operator+(
+ALGEBRA_HOST_DEVICE constexpr array_t<scalar_t, 3> operator+(
     const array_t<scalar_t, 3> &a, const array_t<scalar_t, 3> &b) {
 
   return {a[0] + b[0], a[1] + b[1], a[2] + b[2]};
@@ -98,7 +98,7 @@ ALGEBRA_HOST_DEVICE inline array_t<scalar_t, 3> operator+(
 template <typename size_type, template <typename, size_type> class array_t,
           concepts::scalar scalar1_t, concepts::scalar scalar2_t,
           size_type ROWS, size_type COLS>
-ALGEBRA_HOST_DEVICE inline array_t<array_t<scalar1_t, ROWS>, COLS> operator*(
+ALGEBRA_HOST_DEVICE constexpr array_t<array_t<scalar1_t, ROWS>, COLS> operator*(
     const array_t<array_t<scalar1_t, ROWS>, COLS> &a, scalar2_t s) {
 
   array_t<array_t<scalar1_t, ROWS>, COLS> ret;
@@ -115,7 +115,7 @@ ALGEBRA_HOST_DEVICE inline array_t<array_t<scalar1_t, ROWS>, COLS> operator*(
 template <typename size_type, template <typename, size_type> class array_t,
           concepts::scalar scalar1_t, concepts::scalar scalar2_t,
           size_type ROWS, size_type COLS>
-ALGEBRA_HOST_DEVICE inline array_t<array_t<scalar1_t, ROWS>, COLS> operator*(
+ALGEBRA_HOST_DEVICE constexpr array_t<array_t<scalar1_t, ROWS>, COLS> operator*(
     scalar2_t s, const array_t<array_t<scalar1_t, ROWS>, COLS> &a) {
 
   array_t<array_t<scalar1_t, ROWS>, COLS> ret;
@@ -131,7 +131,7 @@ ALGEBRA_HOST_DEVICE inline array_t<array_t<scalar1_t, ROWS>, COLS> operator*(
 
 template <typename size_type, template <typename, size_type> class array_t,
           concepts::scalar scalar_t, size_type M, size_type N, size_type O>
-ALGEBRA_HOST_DEVICE inline array_t<array_t<scalar_t, M>, O> operator*(
+ALGEBRA_HOST_DEVICE constexpr array_t<array_t<scalar_t, M>, O> operator*(
     const array_t<array_t<scalar_t, M>, N> &A,
     const array_t<array_t<scalar_t, N>, O> &B) {
 
@@ -156,7 +156,7 @@ ALGEBRA_HOST_DEVICE inline array_t<array_t<scalar_t, M>, O> operator*(
 
 template <typename size_type, template <typename, size_type> class array_t,
           concepts::scalar scalar_t, size_type ROWS, size_type COLS>
-ALGEBRA_HOST_DEVICE inline array_t<array_t<scalar_t, ROWS>, COLS> operator+(
+ALGEBRA_HOST_DEVICE constexpr array_t<array_t<scalar_t, ROWS>, COLS> operator+(
     const array_t<array_t<scalar_t, ROWS>, COLS> &A,
     const array_t<array_t<scalar_t, ROWS>, COLS> &B) {
 
@@ -173,7 +173,7 @@ ALGEBRA_HOST_DEVICE inline array_t<array_t<scalar_t, ROWS>, COLS> operator+(
 
 template <typename size_type, template <typename, size_type> class array_t,
           concepts::scalar scalar_t, size_type ROWS, size_type COLS>
-ALGEBRA_HOST_DEVICE inline array_t<array_t<scalar_t, ROWS>, COLS> operator-(
+ALGEBRA_HOST_DEVICE constexpr array_t<array_t<scalar_t, ROWS>, COLS> operator-(
     const array_t<array_t<scalar_t, ROWS>, COLS> &A,
     const array_t<array_t<scalar_t, ROWS>, COLS> &B) {
 
@@ -195,7 +195,7 @@ ALGEBRA_HOST_DEVICE inline array_t<array_t<scalar_t, ROWS>, COLS> operator-(
 
 template <typename size_type, template <typename, size_type> class array_t,
           concepts::scalar scalar_t, size_type ROWS, size_type COLS>
-ALGEBRA_HOST_DEVICE inline array_t<scalar_t, ROWS> operator*(
+ALGEBRA_HOST_DEVICE constexpr array_t<scalar_t, ROWS> operator*(
     const array_t<array_t<scalar_t, ROWS>, COLS> &a,
     const array_t<scalar_t, COLS> &b) {
 

--- a/math/cmath/include/algebra/math/impl/cmath_vector.hpp
+++ b/math/cmath/include/algebra/math/impl/cmath_vector.hpp
@@ -65,7 +65,7 @@ template <concepts::index size_type,
           concepts::scalar scalar_t, size_type N>
 requires(N >= 3) ALGEBRA_HOST_DEVICE
     constexpr array_t<scalar_t, N> cross(const array_t<scalar_t, N> &a,
-                                      const array_t<scalar_t, N> &b) {
+                                         const array_t<scalar_t, N> &b) {
   return algebra::generic::math::cross(a, b);
 }
 
@@ -80,9 +80,8 @@ requires(N >= 3) ALGEBRA_HOST_DEVICE constexpr array_t<scalar_t, N> cross(
 template <concepts::index size_type,
           template <typename, size_type> class array_t,
           concepts::scalar scalar_t, size_type N>
-requires(N >= 3) ALGEBRA_HOST_DEVICE
-    constexpr array_t<scalar_t, N> cross(const array_t<array_t<scalar_t, N>, 1> &a,
-                                      const array_t<scalar_t, N> &b) {
+requires(N >= 3) ALGEBRA_HOST_DEVICE constexpr array_t<scalar_t, N> cross(
+    const array_t<array_t<scalar_t, N>, 1> &a, const array_t<scalar_t, N> &b) {
   return algebra::generic::math::cross(a, b);
 }
 
@@ -107,7 +106,7 @@ template <concepts::index size_type,
           template <typename, size_type> class array_t,
           concepts::scalar scalar_t, size_type N>
 ALGEBRA_HOST_DEVICE constexpr scalar_t dot(const array_t<scalar_t, N> &a,
-                                        const array_t<scalar_t, N> &b) {
+                                           const array_t<scalar_t, N> &b) {
   array_t<scalar_t, N> tmp;
   for (size_type i = 0; i < N; i++) {
     tmp[i] = a[i] * b[i];

--- a/math/cmath/include/algebra/math/impl/cmath_vector.hpp
+++ b/math/cmath/include/algebra/math/impl/cmath_vector.hpp
@@ -21,7 +21,7 @@ namespace algebra::cmath {
 template <concepts::index size_type,
           template <typename, size_type> class array_t,
           concepts::scalar scalar_t, size_type N>
-requires(N >= 2) ALGEBRA_HOST_DEVICE inline scalar_t
+requires(N >= 2) ALGEBRA_HOST_DEVICE constexpr scalar_t
     phi(const array_t<scalar_t, N> &v) {
   return algebra::generic::math::phi(v);
 }
@@ -32,7 +32,7 @@ requires(N >= 2) ALGEBRA_HOST_DEVICE inline scalar_t
 template <concepts::index size_type,
           template <typename, size_type> class array_t,
           concepts::scalar scalar_t, size_type N>
-requires(N >= 2) ALGEBRA_HOST_DEVICE inline scalar_t
+requires(N >= 2) ALGEBRA_HOST_DEVICE constexpr scalar_t
     perp(const array_t<scalar_t, N> &v) {
   return algebra::generic::math::perp(v);
 }
@@ -43,7 +43,7 @@ requires(N >= 2) ALGEBRA_HOST_DEVICE inline scalar_t
 template <concepts::index size_type,
           template <typename, size_type> class array_t,
           concepts::scalar scalar_t, size_type N>
-requires(N >= 2) ALGEBRA_HOST_DEVICE inline scalar_t
+requires(N >= 2) ALGEBRA_HOST_DEVICE constexpr scalar_t
     theta(const array_t<scalar_t, N> &v) {
   return algebra::generic::math::theta(v);
 }
@@ -64,7 +64,7 @@ template <concepts::index size_type,
           template <typename, size_type> class array_t,
           concepts::scalar scalar_t, size_type N>
 requires(N >= 3) ALGEBRA_HOST_DEVICE
-    inline array_t<scalar_t, N> cross(const array_t<scalar_t, N> &a,
+    constexpr array_t<scalar_t, N> cross(const array_t<scalar_t, N> &a,
                                       const array_t<scalar_t, N> &b) {
   return algebra::generic::math::cross(a, b);
 }
@@ -72,7 +72,7 @@ requires(N >= 3) ALGEBRA_HOST_DEVICE
 template <concepts::index size_type,
           template <typename, size_type> class array_t,
           concepts::scalar scalar_t, size_type N>
-requires(N >= 3) ALGEBRA_HOST_DEVICE inline array_t<scalar_t, N> cross(
+requires(N >= 3) ALGEBRA_HOST_DEVICE constexpr array_t<scalar_t, N> cross(
     const array_t<scalar_t, N> &a, const array_t<array_t<scalar_t, N>, 1> &b) {
   return algebra::generic::math::cross(a, b);
 }
@@ -81,7 +81,7 @@ template <concepts::index size_type,
           template <typename, size_type> class array_t,
           concepts::scalar scalar_t, size_type N>
 requires(N >= 3) ALGEBRA_HOST_DEVICE
-    inline array_t<scalar_t, N> cross(const array_t<array_t<scalar_t, N>, 1> &a,
+    constexpr array_t<scalar_t, N> cross(const array_t<array_t<scalar_t, N>, 1> &a,
                                       const array_t<scalar_t, N> &b) {
   return algebra::generic::math::cross(a, b);
 }
@@ -89,7 +89,7 @@ requires(N >= 3) ALGEBRA_HOST_DEVICE
 template <concepts::index size_type,
           template <typename, size_type> class array_t,
           concepts::scalar scalar_t, size_type N>
-requires(N >= 3) ALGEBRA_HOST_DEVICE inline array_t<scalar_t, N> cross(
+requires(N >= 3) ALGEBRA_HOST_DEVICE constexpr array_t<scalar_t, N> cross(
     const array_t<array_t<scalar_t, N>, 1> &a,
     const array_t<array_t<scalar_t, N>, 1> &b) {
   return algebra::generic::math::cross(a, b);
@@ -106,7 +106,7 @@ requires(N >= 3) ALGEBRA_HOST_DEVICE inline array_t<scalar_t, N> cross(
 template <concepts::index size_type,
           template <typename, size_type> class array_t,
           concepts::scalar scalar_t, size_type N>
-ALGEBRA_HOST_DEVICE inline scalar_t dot(const array_t<scalar_t, N> &a,
+ALGEBRA_HOST_DEVICE constexpr scalar_t dot(const array_t<scalar_t, N> &a,
                                         const array_t<scalar_t, N> &b) {
   array_t<scalar_t, N> tmp;
   for (size_type i = 0; i < N; i++) {
@@ -122,7 +122,7 @@ ALGEBRA_HOST_DEVICE inline scalar_t dot(const array_t<scalar_t, N> &a,
 template <concepts::index size_type,
           template <typename, size_type> class array_t,
           concepts::scalar scalar_t, size_type N>
-ALGEBRA_HOST_DEVICE inline scalar_t dot(
+ALGEBRA_HOST_DEVICE constexpr scalar_t dot(
     const array_t<scalar_t, N> &a, const array_t<array_t<scalar_t, N>, 1> &b) {
   array_t<scalar_t, N> tmp;
   for (size_type i = 0; i < N; i++) {
@@ -138,7 +138,7 @@ ALGEBRA_HOST_DEVICE inline scalar_t dot(
 template <concepts::index size_type,
           template <typename, size_type> class array_t,
           concepts::scalar scalar_t, size_type N>
-ALGEBRA_HOST_DEVICE inline scalar_t dot(
+ALGEBRA_HOST_DEVICE constexpr scalar_t dot(
     const array_t<array_t<scalar_t, N>, 1> &a, const array_t<scalar_t, N> &b) {
   array_t<scalar_t, N> tmp;
   for (size_type i = 0; i < N; i++) {
@@ -154,7 +154,7 @@ ALGEBRA_HOST_DEVICE inline scalar_t dot(
 template <concepts::index size_type,
           template <typename, size_type> class array_t,
           concepts::scalar scalar_t, size_type N>
-ALGEBRA_HOST_DEVICE inline scalar_t dot(
+ALGEBRA_HOST_DEVICE constexpr scalar_t dot(
     const array_t<array_t<scalar_t, N>, 1> &a,
     const array_t<array_t<scalar_t, N>, 1> &b) {
   array_t<scalar_t, N> tmp;
@@ -175,7 +175,7 @@ ALGEBRA_HOST_DEVICE inline scalar_t dot(
 template <concepts::index size_type,
           template <typename, size_type> class array_t,
           concepts::scalar scalar_t, size_type N>
-requires(N >= 2) ALGEBRA_HOST_DEVICE inline scalar_t
+requires(N >= 2) ALGEBRA_HOST_DEVICE constexpr scalar_t
     norm(const array_t<scalar_t, N> &v) {
 
   return algebra::math::sqrt(dot(v, v));
@@ -188,7 +188,7 @@ requires(N >= 2) ALGEBRA_HOST_DEVICE inline scalar_t
 template <concepts::index size_type,
           template <typename, size_type> class array_t,
           concepts::scalar scalar_t, size_type N>
-requires(N >= 3) ALGEBRA_HOST_DEVICE inline scalar_t
+requires(N >= 3) ALGEBRA_HOST_DEVICE constexpr scalar_t
     eta(const array_t<scalar_t, N> &v) noexcept {
 
   return algebra::math::atanh(v[2] / norm(v));
@@ -200,7 +200,7 @@ requires(N >= 3) ALGEBRA_HOST_DEVICE inline scalar_t
 template <concepts::index size_type,
           template <typename, size_type> class array_t,
           concepts::scalar scalar_t, size_type N>
-ALGEBRA_HOST_DEVICE inline array_t<scalar_t, N> normalize(
+ALGEBRA_HOST_DEVICE constexpr array_t<scalar_t, N> normalize(
     const array_t<scalar_t, N> &v) {
 
   return (static_cast<scalar_t>(1.) / norm(v)) * v;

--- a/math/eigen/include/algebra/math/impl/eigen_matrix.hpp
+++ b/math/eigen/include/algebra/math/impl/eigen_matrix.hpp
@@ -31,32 +31,32 @@ namespace algebra::eigen::math {
 
 /// Create zero matrix
 template <concepts::matrix matrix_t>
-ALGEBRA_HOST_DEVICE inline matrix_t zero() {
+ALGEBRA_HOST_DEVICE constexpr matrix_t zero() {
   return matrix_t::Zero();
 }
 
 /// Create identity matrix
 template <concepts::matrix matrix_t>
-ALGEBRA_HOST_DEVICE inline matrix_t identity() {
+ALGEBRA_HOST_DEVICE constexpr matrix_t identity() {
   return matrix_t::Identity();
 }
 
 /// Set input matrix as zero matrix
 template <typename derived_type>
-ALGEBRA_HOST_DEVICE inline void set_zero(Eigen::MatrixBase<derived_type> &m) {
+ALGEBRA_HOST_DEVICE constexpr void set_zero(Eigen::MatrixBase<derived_type> &m) {
   m.setZero();
 }
 
 /// Set input matrix as identity matrix
 template <typename derived_type>
-ALGEBRA_HOST_DEVICE inline void set_identity(
+ALGEBRA_HOST_DEVICE constexpr void set_identity(
     Eigen::MatrixBase<derived_type> &m) {
   m.setIdentity();
 }
 
 /// Create transpose matrix
 template <typename derived_type>
-ALGEBRA_HOST_DEVICE inline matrix_type<
+ALGEBRA_HOST_DEVICE constexpr matrix_type<
     typename Eigen::MatrixBase<derived_type>::value_type,
     Eigen::MatrixBase<derived_type>::ColsAtCompileTime,
     Eigen::MatrixBase<derived_type>::RowsAtCompileTime>
@@ -66,18 +66,18 @@ transpose(const Eigen::MatrixBase<derived_type> &m) {
 
 /// @returns the determinant of @param m
 template <typename derived_type>
-ALGEBRA_HOST_DEVICE inline typename Eigen::MatrixBase<derived_type>::value_type
+ALGEBRA_HOST_DEVICE constexpr typename Eigen::MatrixBase<derived_type>::value_type
 determinant(const Eigen::MatrixBase<derived_type> &m) {
   return m.determinant();
 }
 
 /// @returns the inverse of @param m
 template <typename derived_type>
-ALGEBRA_HOST_DEVICE inline matrix_type<
-    typename Eigen::MatrixBase<derived_type>::value_type,
-    Eigen::MatrixBase<derived_type>::RowsAtCompileTime,
-    Eigen::MatrixBase<derived_type>::ColsAtCompileTime>
-inverse(const Eigen::MatrixBase<derived_type> &m) {
+ALGEBRA_HOST_DEVICE constexpr matrix_type<
+typename Eigen::MatrixBase<derived_type>::value_type,
+Eigen::MatrixBase<derived_type>::RowsAtCompileTime,
+Eigen::MatrixBase<derived_type>::ColsAtCompileTime> inverse(
+    const Eigen::MatrixBase<derived_type> &m) {
   return m.inverse();
 }
 

--- a/math/eigen/include/algebra/math/impl/eigen_matrix.hpp
+++ b/math/eigen/include/algebra/math/impl/eigen_matrix.hpp
@@ -43,7 +43,8 @@ ALGEBRA_HOST_DEVICE constexpr matrix_t identity() {
 
 /// Set input matrix as zero matrix
 template <typename derived_type>
-ALGEBRA_HOST_DEVICE constexpr void set_zero(Eigen::MatrixBase<derived_type> &m) {
+ALGEBRA_HOST_DEVICE constexpr void set_zero(
+    Eigen::MatrixBase<derived_type> &m) {
   m.setZero();
 }
 
@@ -66,18 +67,19 @@ transpose(const Eigen::MatrixBase<derived_type> &m) {
 
 /// @returns the determinant of @param m
 template <typename derived_type>
-ALGEBRA_HOST_DEVICE constexpr typename Eigen::MatrixBase<derived_type>::value_type
-determinant(const Eigen::MatrixBase<derived_type> &m) {
+ALGEBRA_HOST_DEVICE constexpr
+    typename Eigen::MatrixBase<derived_type>::value_type
+    determinant(const Eigen::MatrixBase<derived_type> &m) {
   return m.determinant();
 }
 
 /// @returns the inverse of @param m
 template <typename derived_type>
 ALGEBRA_HOST_DEVICE constexpr matrix_type<
-typename Eigen::MatrixBase<derived_type>::value_type,
-Eigen::MatrixBase<derived_type>::RowsAtCompileTime,
-Eigen::MatrixBase<derived_type>::ColsAtCompileTime> inverse(
-    const Eigen::MatrixBase<derived_type> &m) {
+    typename Eigen::MatrixBase<derived_type>::value_type,
+    Eigen::MatrixBase<derived_type>::RowsAtCompileTime,
+    Eigen::MatrixBase<derived_type>::ColsAtCompileTime>
+inverse(const Eigen::MatrixBase<derived_type> &m) {
   return m.inverse();
 }
 

--- a/math/eigen/include/algebra/math/impl/eigen_transform3.hpp
+++ b/math/eigen/include/algebra/math/impl/eigen_transform3.hpp
@@ -179,15 +179,21 @@ struct transform3 {
 
   /// This method retrieves x axis
   ALGEBRA_HOST_DEVICE
-  constexpr point3 x() const { return _data.matrix().template block<3, 1>(0, 0); }
+  constexpr point3 x() const {
+    return _data.matrix().template block<3, 1>(0, 0);
+  }
 
   /// This method retrieves y axis
   ALGEBRA_HOST_DEVICE
-  constexpr point3 y() const { return _data.matrix().template block<3, 1>(0, 1); }
+  constexpr point3 y() const {
+    return _data.matrix().template block<3, 1>(0, 1);
+  }
 
   /// This method retrieves z axis
   ALGEBRA_HOST_DEVICE
-  constexpr point3 z() const { return _data.matrix().template block<3, 1>(0, 2); }
+  constexpr point3 z() const {
+    return _data.matrix().template block<3, 1>(0, 2);
+  }
 
   /// This method retrieves the translation of a transform
   ALGEBRA_HOST_DEVICE
@@ -201,7 +207,9 @@ struct transform3 {
 
   /// This method retrieves the 4x4 matrix of an inverse transform
   ALGEBRA_HOST_DEVICE
-  constexpr const matrix44 &matrix_inverse() const { return _data_inv.matrix(); }
+  constexpr const matrix44 &matrix_inverse() const {
+    return _data_inv.matrix();
+  }
 
   /// This method transform from a point from the local 3D cartesian frame to
   /// the global 3D cartesian frame

--- a/math/eigen/include/algebra/math/impl/eigen_transform3.hpp
+++ b/math/eigen/include/algebra/math/impl/eigen_transform3.hpp
@@ -153,8 +153,7 @@ struct transform3 {
 
   /// Equality operator
   ALGEBRA_HOST_DEVICE
-  inline bool operator==(const transform3 &rhs) const {
-
+  constexpr bool operator==(const transform3 &rhs) const {
     return (_data.isApprox(rhs._data));
   }
 
@@ -166,46 +165,43 @@ struct transform3 {
   requires(Eigen::MatrixBase<derived_type>::RowsAtCompileTime == 3 &&
            Eigen::MatrixBase<derived_type>::ColsAtCompileTime ==
                1) ALGEBRA_HOST_DEVICE
-      static inline auto rotate(
+      static constexpr auto rotate(
           const Eigen::Transform<scalar_type, 3, Eigen::Affine> &m,
           const Eigen::MatrixBase<derived_type> &v) {
-
     return m.matrix().template block<3, 3>(0, 0) * v;
   }
 
   /// This method retrieves the rotation of a transform
   ALGEBRA_HOST_DEVICE
-  inline auto rotation() const {
-
+  constexpr auto rotation() const {
     return _data.matrix().template block<3, 3>(0, 0);
   }
 
   /// This method retrieves x axis
   ALGEBRA_HOST_DEVICE
-  inline point3 x() const { return _data.matrix().template block<3, 1>(0, 0); }
+  constexpr point3 x() const { return _data.matrix().template block<3, 1>(0, 0); }
 
   /// This method retrieves y axis
   ALGEBRA_HOST_DEVICE
-  inline point3 y() const { return _data.matrix().template block<3, 1>(0, 1); }
+  constexpr point3 y() const { return _data.matrix().template block<3, 1>(0, 1); }
 
   /// This method retrieves z axis
   ALGEBRA_HOST_DEVICE
-  inline point3 z() const { return _data.matrix().template block<3, 1>(0, 2); }
+  constexpr point3 z() const { return _data.matrix().template block<3, 1>(0, 2); }
 
   /// This method retrieves the translation of a transform
   ALGEBRA_HOST_DEVICE
-  inline point3 translation() const {
-
+  constexpr point3 translation() const {
     return _data.matrix().template block<3, 1>(0, 3);
   }
 
   /// This method retrieves the 4x4 matrix of a transform
   ALGEBRA_HOST_DEVICE
-  inline const matrix44 &matrix() const { return _data.matrix(); }
+  constexpr const matrix44 &matrix() const { return _data.matrix(); }
 
   /// This method retrieves the 4x4 matrix of an inverse transform
   ALGEBRA_HOST_DEVICE
-  inline const matrix44 &matrix_inverse() const { return _data_inv.matrix(); }
+  constexpr const matrix44 &matrix_inverse() const { return _data_inv.matrix(); }
 
   /// This method transform from a point from the local 3D cartesian frame to
   /// the global 3D cartesian frame
@@ -213,9 +209,8 @@ struct transform3 {
   requires(Eigen::MatrixBase<derived_type>::RowsAtCompileTime == 3 &&
            Eigen::MatrixBase<derived_type>::ColsAtCompileTime ==
                1) ALGEBRA_HOST_DEVICE
-      inline auto point_to_global(
+      constexpr auto point_to_global(
           const Eigen::MatrixBase<derived_type> &v) const {
-
     return (_data * v);
   }
 
@@ -225,9 +220,8 @@ struct transform3 {
   requires(Eigen::MatrixBase<derived_type>::RowsAtCompileTime == 3 &&
            Eigen::MatrixBase<derived_type>::ColsAtCompileTime ==
                1) ALGEBRA_HOST_DEVICE
-      inline auto point_to_local(
+      constexpr auto point_to_local(
           const Eigen::MatrixBase<derived_type> &v) const {
-
     return (_data_inv * v);
   }
 
@@ -237,9 +231,8 @@ struct transform3 {
   requires(Eigen::MatrixBase<derived_type>::RowsAtCompileTime == 3 &&
            Eigen::MatrixBase<derived_type>::ColsAtCompileTime ==
                1) ALGEBRA_HOST_DEVICE
-      inline auto vector_to_global(
+      constexpr auto vector_to_global(
           const Eigen::MatrixBase<derived_type> &v) const {
-
     return (_data.linear() * v);
   }
 
@@ -249,9 +242,8 @@ struct transform3 {
   requires(Eigen::MatrixBase<derived_type>::RowsAtCompileTime == 3 &&
            Eigen::MatrixBase<derived_type>::ColsAtCompileTime ==
                1) ALGEBRA_HOST_DEVICE
-      inline auto vector_to_local(
+      constexpr auto vector_to_local(
           const Eigen::MatrixBase<derived_type> &v) const {
-
     return (_data_inv.linear() * v);
   }
 };  // struct transform3

--- a/math/eigen/include/algebra/math/impl/eigen_vector.hpp
+++ b/math/eigen/include/algebra/math/impl/eigen_vector.hpp
@@ -30,19 +30,19 @@ namespace algebra::eigen::math {
 
 /// This method retrieves phi from a vector @param v
 template <typename derived_type>
-ALGEBRA_HOST_DEVICE inline auto phi(const Eigen::MatrixBase<derived_type> &v) {
+ALGEBRA_HOST_DEVICE constexpr auto phi(const Eigen::MatrixBase<derived_type> &v) {
   return algebra::math::atan2(v[1], v[0]);
 }
 
 /// This method retrieves the perpendicular magnitude of a vector @param v
 template <typename derived_type>
-ALGEBRA_HOST_DEVICE inline auto perp(const Eigen::MatrixBase<derived_type> &v) {
+ALGEBRA_HOST_DEVICE constexpr auto perp(const Eigen::MatrixBase<derived_type> &v) {
   return algebra::math::sqrt(algebra::math::fma(v[0], v[0], v[1] * v[1]));
 }
 
 /// This method retrieves theta from a vector @param v
 template <typename derived_type>
-ALGEBRA_HOST_DEVICE inline auto theta(
+ALGEBRA_HOST_DEVICE constexpr auto theta(
     const Eigen::MatrixBase<derived_type> &v) {
   return algebra::math::atan2(perp(v), v[2]);
 }
@@ -51,8 +51,7 @@ ALGEBRA_HOST_DEVICE inline auto theta(
 ///
 /// @param v the input vector
 template <typename derived_type>
-ALGEBRA_HOST_DEVICE inline auto norm(const Eigen::MatrixBase<derived_type> &v) {
-
+ALGEBRA_HOST_DEVICE constexpr auto norm(const Eigen::MatrixBase<derived_type> &v) {
   return v.norm();
 }
 
@@ -63,8 +62,7 @@ ALGEBRA_HOST_DEVICE inline auto norm(const Eigen::MatrixBase<derived_type> &v) {
 template <typename derived_type>
 requires(Eigen::MatrixBase<derived_type>::RowsAtCompileTime >=
          3) ALGEBRA_HOST_DEVICE
-    inline auto eta(const Eigen::MatrixBase<derived_type> &v) noexcept {
-
+    constexpr auto eta(const Eigen::MatrixBase<derived_type> &v) noexcept {
   return algebra::math::atanh(v[2] / v.norm());
 }
 
@@ -74,7 +72,7 @@ requires(Eigen::MatrixBase<derived_type>::RowsAtCompileTime >=
 ///
 /// @param v the input vector
 template <typename derived_type>
-ALGEBRA_HOST_DEVICE inline auto normalize(
+ALGEBRA_HOST_DEVICE constexpr auto normalize(
     const Eigen::MatrixBase<derived_type> &v) {
   return v.normalized();
 }
@@ -89,7 +87,7 @@ ALGEBRA_HOST_DEVICE inline auto normalize(
 ///
 /// @return the scalar dot product value
 template <typename derived_type_lhs, typename derived_type_rhs>
-ALGEBRA_HOST_DEVICE inline auto dot(
+ALGEBRA_HOST_DEVICE constexpr auto dot(
     const Eigen::MatrixBase<derived_type_lhs> &a,
     const Eigen::MatrixBase<derived_type_rhs> &b) {
   return a.dot(b);
@@ -105,7 +103,7 @@ ALGEBRA_HOST_DEVICE inline auto dot(
 ///
 /// @return a vector (expression) representing the cross product
 template <typename derived_type_lhs, typename derived_type_rhs>
-ALGEBRA_HOST_DEVICE inline auto cross(
+ALGEBRA_HOST_DEVICE constexpr auto cross(
     const Eigen::MatrixBase<derived_type_lhs> &a,
     const Eigen::MatrixBase<derived_type_rhs> &b) {
   return a.cross(b);

--- a/math/eigen/include/algebra/math/impl/eigen_vector.hpp
+++ b/math/eigen/include/algebra/math/impl/eigen_vector.hpp
@@ -30,13 +30,15 @@ namespace algebra::eigen::math {
 
 /// This method retrieves phi from a vector @param v
 template <typename derived_type>
-ALGEBRA_HOST_DEVICE constexpr auto phi(const Eigen::MatrixBase<derived_type> &v) {
+ALGEBRA_HOST_DEVICE constexpr auto phi(
+    const Eigen::MatrixBase<derived_type> &v) {
   return algebra::math::atan2(v[1], v[0]);
 }
 
 /// This method retrieves the perpendicular magnitude of a vector @param v
 template <typename derived_type>
-ALGEBRA_HOST_DEVICE constexpr auto perp(const Eigen::MatrixBase<derived_type> &v) {
+ALGEBRA_HOST_DEVICE constexpr auto perp(
+    const Eigen::MatrixBase<derived_type> &v) {
   return algebra::math::sqrt(algebra::math::fma(v[0], v[0], v[1] * v[1]));
 }
 
@@ -51,7 +53,8 @@ ALGEBRA_HOST_DEVICE constexpr auto theta(
 ///
 /// @param v the input vector
 template <typename derived_type>
-ALGEBRA_HOST_DEVICE constexpr auto norm(const Eigen::MatrixBase<derived_type> &v) {
+ALGEBRA_HOST_DEVICE constexpr auto norm(
+    const Eigen::MatrixBase<derived_type> &v) {
   return v.norm();
 }
 

--- a/math/fastor/include/algebra/math/impl/fastor_matrix.hpp
+++ b/math/fastor/include/algebra/math/impl/fastor_matrix.hpp
@@ -24,13 +24,13 @@ namespace algebra::fastor::math {
 
 /// Create zero matrix
 template <concepts::matrix matrix_t>
-ALGEBRA_HOST_DEVICE inline matrix_t zero() {
+ALGEBRA_HOST_DEVICE constexpr matrix_t zero() {
   return matrix_t(0);
 }
 
 /// Create identity matrix
 template <concepts::matrix matrix_t>
-ALGEBRA_HOST_DEVICE inline matrix_t identity() {
+ALGEBRA_HOST_DEVICE constexpr matrix_t identity() {
   using scalar_t = algebra::traits::value_t<matrix_t>;
   constexpr auto rows{algebra::traits::rows<matrix_t>};
   constexpr auto cols{algebra::traits::columns<matrix_t>};
@@ -50,13 +50,13 @@ ALGEBRA_HOST_DEVICE inline matrix_t identity() {
 
 /// Set input matrix as zero matrix
 template <std::size_t ROWS, std::size_t COLS, concepts::scalar scalar_t>
-ALGEBRA_HOST_DEVICE inline void set_zero(matrix_type<scalar_t, ROWS, COLS> &m) {
+ALGEBRA_HOST_DEVICE constexpr void set_zero(matrix_type<scalar_t, ROWS, COLS> &m) {
   m.zeros();
 }
 
 /// Set input matrix as identity matrix
 template <std::size_t ROWS, std::size_t COLS, concepts::scalar scalar_t>
-ALGEBRA_HOST_DEVICE inline void set_identity(
+ALGEBRA_HOST_DEVICE constexpr void set_identity(
     matrix_type<scalar_t, ROWS, COLS> &m) {
 
   m = identity<matrix_type<scalar_t, ROWS, COLS>>();
@@ -64,7 +64,7 @@ ALGEBRA_HOST_DEVICE inline void set_identity(
 
 /// Create transpose matrix
 template <std::size_t ROWS, std::size_t COLS, concepts::scalar scalar_t>
-ALGEBRA_HOST_DEVICE inline matrix_type<scalar_t, COLS, ROWS> transpose(
+ALGEBRA_HOST_DEVICE constexpr matrix_type<scalar_t, COLS, ROWS> transpose(
     const matrix_type<scalar_t, ROWS, COLS> &m) {
 
   return Fastor::transpose(m);
@@ -72,7 +72,7 @@ ALGEBRA_HOST_DEVICE inline matrix_type<scalar_t, COLS, ROWS> transpose(
 
 /// @returns the determinant of @param m
 template <std::size_t N, concepts::scalar scalar_t>
-ALGEBRA_HOST_DEVICE inline scalar_t determinant(
+ALGEBRA_HOST_DEVICE constexpr scalar_t determinant(
     const matrix_type<scalar_t, N, N> &m) {
 
   return Fastor::determinant(m);
@@ -80,7 +80,7 @@ ALGEBRA_HOST_DEVICE inline scalar_t determinant(
 
 /// @returns the inverse of @param m
 template <std::size_t ROWS, std::size_t COLS, concepts::scalar scalar_t>
-ALGEBRA_HOST_DEVICE inline matrix_type<scalar_t, COLS, ROWS> inverse(
+ALGEBRA_HOST_DEVICE constexpr matrix_type<scalar_t, COLS, ROWS> inverse(
     const matrix_type<scalar_t, ROWS, COLS> &m) {
 
   return Fastor::inverse(m);

--- a/math/fastor/include/algebra/math/impl/fastor_matrix.hpp
+++ b/math/fastor/include/algebra/math/impl/fastor_matrix.hpp
@@ -50,7 +50,8 @@ ALGEBRA_HOST_DEVICE constexpr matrix_t identity() {
 
 /// Set input matrix as zero matrix
 template <std::size_t ROWS, std::size_t COLS, concepts::scalar scalar_t>
-ALGEBRA_HOST_DEVICE constexpr void set_zero(matrix_type<scalar_t, ROWS, COLS> &m) {
+ALGEBRA_HOST_DEVICE constexpr void set_zero(
+    matrix_type<scalar_t, ROWS, COLS> &m) {
   m.zeros();
 }
 

--- a/math/fastor/include/algebra/math/impl/fastor_transform3.hpp
+++ b/math/fastor/include/algebra/math/impl/fastor_transform3.hpp
@@ -139,14 +139,14 @@ struct transform3 {
 
   /// Equality operator
   ALGEBRA_HOST
-  inline bool operator==(const transform3 &rhs) const {
+  constexpr bool operator==(const transform3 &rhs) const {
 
     return Fastor::isequal(_data, rhs._data);
   }
 
   /// This method retrieves the rotation of a transform
   ALGEBRA_HOST
-  inline auto rotation() const {
+  constexpr auto rotation() const {
 
     return Fastor::Tensor<scalar_t, 3, 3>(
         _data(Fastor::fseq<0, 3>(), Fastor::fseq<0, 3>()));
@@ -154,32 +154,32 @@ struct transform3 {
 
   /// This method retrieves x axis
   ALGEBRA_HOST_DEVICE
-  inline point3 x() const { return _data(Fastor::fseq<0, 3>(), 0); }
+  constexpr point3 x() const { return _data(Fastor::fseq<0, 3>(), 0); }
 
   /// This method retrieves y axis
   ALGEBRA_HOST_DEVICE
-  inline point3 y() const { return _data(Fastor::fseq<0, 3>(), 1); }
+  constexpr point3 y() const { return _data(Fastor::fseq<0, 3>(), 1); }
 
   /// This method retrieves z axis
   ALGEBRA_HOST_DEVICE
-  inline point3 z() const { return _data(Fastor::fseq<0, 3>(), 2); }
+  constexpr point3 z() const { return _data(Fastor::fseq<0, 3>(), 2); }
 
   /// This method retrieves the translation of a transform
   ALGEBRA_HOST
-  inline vector3 translation() const { return _data(Fastor::fseq<0, 3>(), 3); }
+  constexpr vector3 translation() const { return _data(Fastor::fseq<0, 3>(), 3); }
 
   /// This method retrieves the 4x4 matrix of a transform
   ALGEBRA_HOST
-  inline matrix44 matrix() const { return _data; }
+  constexpr matrix44 matrix() const { return _data; }
 
   /// This method retrieves the 4x4 matrix of an inverse transform
   ALGEBRA_HOST
-  inline matrix44 matrix_inverse() const { return _data_inv; }
+  constexpr matrix44 matrix_inverse() const { return _data_inv; }
 
   /// This method transform from a point from the local 3D cartesian frame to
   /// the global 3D cartesian frame
   ALGEBRA_HOST
-  inline point3 point_to_global(const point3 &v) const {
+  constexpr point3 point_to_global(const point3 &v) const {
 
     Fastor::Tensor<scalar_type, 4> vector_4;
     vector_4(Fastor::fseq<0, 3>()) = v;
@@ -191,7 +191,7 @@ struct transform3 {
   /// This method transform from a vector from the global 3D cartesian frame
   /// into the local 3D cartesian frame
   ALGEBRA_HOST
-  inline point3 point_to_local(const point3 &v) const {
+  constexpr point3 point_to_local(const point3 &v) const {
 
     Fastor::Tensor<scalar_type, 4> vector_4;
     vector_4(Fastor::fseq<0, 3>()) = v;
@@ -203,7 +203,7 @@ struct transform3 {
   /// This method transform from a vector from the local 3D cartesian frame to
   /// the global 3D cartesian frame
   ALGEBRA_HOST
-  inline point3 vector_to_global(const vector3 &v) const {
+  constexpr point3 vector_to_global(const vector3 &v) const {
 
     Fastor::Tensor<scalar_type, 4> vector_4;
     vector_4(Fastor::fseq<0, 3>()) = v;
@@ -215,7 +215,7 @@ struct transform3 {
   /// This method transform from a vector from the global 3D cartesian frame
   /// into the local 3D cartesian frame
   ALGEBRA_HOST
-  inline point3 vector_to_local(const vector3 &v) const {
+  constexpr point3 vector_to_local(const vector3 &v) const {
 
     Fastor::Tensor<scalar_type, 4> vector_4;
     vector_4(Fastor::fseq<0, 3>()) = v;

--- a/math/fastor/include/algebra/math/impl/fastor_transform3.hpp
+++ b/math/fastor/include/algebra/math/impl/fastor_transform3.hpp
@@ -166,7 +166,9 @@ struct transform3 {
 
   /// This method retrieves the translation of a transform
   ALGEBRA_HOST
-  constexpr vector3 translation() const { return _data(Fastor::fseq<0, 3>(), 3); }
+  constexpr vector3 translation() const {
+    return _data(Fastor::fseq<0, 3>(), 3);
+  }
 
   /// This method retrieves the 4x4 matrix of a transform
   ALGEBRA_HOST

--- a/math/fastor/include/algebra/math/impl/fastor_vector.hpp
+++ b/math/fastor/include/algebra/math/impl/fastor_vector.hpp
@@ -24,7 +24,7 @@ namespace algebra::fastor::math {
 /// This method retrieves phi from a vector @param v
 template <concepts::scalar scalar_t, auto N>
 requires(N >= 2) ALGEBRA_HOST_DEVICE
-    inline auto phi(const Fastor::Tensor<scalar_t, N> &v) {
+    constexpr auto phi(const Fastor::Tensor<scalar_t, N> &v) {
   return algebra::math::atan2(v[1], v[0]);
 }
 
@@ -32,7 +32,7 @@ requires(N >= 2) ALGEBRA_HOST_DEVICE
 ///
 /// @param v the input vector
 template <concepts::scalar scalar_t, auto N>
-requires(N >= 3) ALGEBRA_HOST inline scalar_t
+requires(N >= 3) ALGEBRA_HOST constexpr scalar_t
     theta(const Fastor::Tensor<scalar_t, N> &v) noexcept {
 
   return algebra::math::atan2(Fastor::norm(v(Fastor::fseq<0, 2>())), v[2]);
@@ -42,7 +42,7 @@ requires(N >= 3) ALGEBRA_HOST inline scalar_t
 ///
 /// @param v the input vector
 template <concepts::scalar scalar_t, auto N>
-requires(N >= 2) ALGEBRA_HOST inline scalar_t
+requires(N >= 2) ALGEBRA_HOST constexpr scalar_t
     perp(const Fastor::Tensor<scalar_t, N> &v) noexcept {
 
   return algebra::math::sqrt(
@@ -53,7 +53,7 @@ requires(N >= 2) ALGEBRA_HOST inline scalar_t
 ///
 /// @param v the input vector
 template <concepts::scalar scalar_t, auto N>
-ALGEBRA_HOST inline scalar_t norm(const Fastor::Tensor<scalar_t, N> &v) {
+ALGEBRA_HOST constexpr scalar_t norm(const Fastor::Tensor<scalar_t, N> &v) {
 
   return Fastor::norm(v);
 }
@@ -63,7 +63,7 @@ ALGEBRA_HOST inline scalar_t norm(const Fastor::Tensor<scalar_t, N> &v) {
 ///
 /// @param v the input vector
 template <concepts::scalar scalar_t, auto N>
-requires(N >= 3) ALGEBRA_HOST inline scalar_t
+requires(N >= 3) ALGEBRA_HOST constexpr scalar_t
     eta(const Fastor::Tensor<scalar_t, N> &v) noexcept {
 
   return algebra::math::atanh(v[2] / Fastor::norm(v));
@@ -73,7 +73,7 @@ requires(N >= 3) ALGEBRA_HOST inline scalar_t
 ///
 /// @param v the input vector
 template <concepts::scalar scalar_t, auto N>
-ALGEBRA_HOST inline Fastor::Tensor<scalar_t, N> normalize(
+ALGEBRA_HOST constexpr Fastor::Tensor<scalar_t, N> normalize(
     const Fastor::Tensor<scalar_t, N> &v) {
 
   return (static_cast<scalar_t>(1.0) / Fastor::norm(v)) * v;
@@ -86,7 +86,7 @@ ALGEBRA_HOST inline Fastor::Tensor<scalar_t, N> normalize(
 ///
 /// @return the scalar dot product value
 template <concepts::scalar scalar_t, auto N>
-ALGEBRA_HOST_DEVICE inline scalar_t dot(const Fastor::Tensor<scalar_t, N> &a,
+ALGEBRA_HOST_DEVICE constexpr scalar_t dot(const Fastor::Tensor<scalar_t, N> &a,
                                         const Fastor::Tensor<scalar_t, N> &b) {
   return Fastor::inner(a, b);
 }
@@ -98,7 +98,7 @@ ALGEBRA_HOST_DEVICE inline scalar_t dot(const Fastor::Tensor<scalar_t, N> &a,
 ///
 /// @return the scalar dot product value
 template <concepts::scalar scalar_t, auto N>
-ALGEBRA_HOST inline scalar_t dot(const Fastor::Tensor<scalar_t, N> &a,
+ALGEBRA_HOST constexpr scalar_t dot(const Fastor::Tensor<scalar_t, N> &a,
                                  const Fastor::Tensor<scalar_t, N, 1> &b) {
 
   // We need to specify the type of the Tensor slice because Fastor by default
@@ -115,7 +115,7 @@ ALGEBRA_HOST inline scalar_t dot(const Fastor::Tensor<scalar_t, N> &a,
 ///
 /// @return the scalar dot product value
 template <concepts::scalar scalar_t, auto N>
-ALGEBRA_HOST inline scalar_t dot(const Fastor::Tensor<scalar_t, N, 1> &a,
+ALGEBRA_HOST constexpr scalar_t dot(const Fastor::Tensor<scalar_t, N, 1> &a,
                                  const Fastor::Tensor<scalar_t, N> &b) {
 
   return Fastor::inner(Fastor::Tensor<scalar_t, N>(a(Fastor::fseq<0, N>(), 0)),
@@ -129,7 +129,7 @@ ALGEBRA_HOST inline scalar_t dot(const Fastor::Tensor<scalar_t, N, 1> &a,
 ///
 /// @return the scalar dot product value
 template <concepts::scalar scalar_t, auto N>
-ALGEBRA_HOST inline scalar_t dot(const Fastor::Tensor<scalar_t, N, 1> &a,
+ALGEBRA_HOST constexpr scalar_t dot(const Fastor::Tensor<scalar_t, N, 1> &a,
                                  const Fastor::Tensor<scalar_t, N, 1> &b) {
 
   return Fastor::inner(Fastor::Tensor<scalar_t, N>(a(Fastor::fseq<0, 3>(), 0)),
@@ -143,7 +143,7 @@ ALGEBRA_HOST inline scalar_t dot(const Fastor::Tensor<scalar_t, N, 1> &a,
 ///
 /// @return a vector (expression) representing the cross product
 template <concepts::scalar scalar_t>
-ALGEBRA_HOST_DEVICE inline Fastor::Tensor<scalar_t, 3> cross(
+ALGEBRA_HOST_DEVICE constexpr Fastor::Tensor<scalar_t, 3> cross(
     const Fastor::Tensor<scalar_t, 3> &a,
     const Fastor::Tensor<scalar_t, 3> &b) {
   return Fastor::cross(a, b);
@@ -156,7 +156,7 @@ ALGEBRA_HOST_DEVICE inline Fastor::Tensor<scalar_t, 3> cross(
 ///
 /// @return a vector representing the cross product
 template <concepts::scalar scalar_t>
-ALGEBRA_HOST inline Fastor::Tensor<scalar_t, 3> cross(
+ALGEBRA_HOST constexpr Fastor::Tensor<scalar_t, 3> cross(
     const Fastor::Tensor<scalar_t, 3> &a,
     const Fastor::Tensor<scalar_t, 3, 1> &b) {
 
@@ -174,7 +174,7 @@ ALGEBRA_HOST inline Fastor::Tensor<scalar_t, 3> cross(
 ///
 /// @return a vector representing the cross product
 template <concepts::scalar scalar_t>
-ALGEBRA_HOST inline Fastor::Tensor<scalar_t, 3> cross(
+ALGEBRA_HOST constexpr Fastor::Tensor<scalar_t, 3> cross(
     const Fastor::Tensor<scalar_t, 3, 1> &a,
     const Fastor::Tensor<scalar_t, 3> &b) {
 
@@ -189,7 +189,7 @@ ALGEBRA_HOST inline Fastor::Tensor<scalar_t, 3> cross(
 ///
 /// @return a vector representing the cross product
 template <concepts::scalar scalar_t>
-ALGEBRA_HOST inline Fastor::Tensor<scalar_t, 3> cross(
+ALGEBRA_HOST constexpr Fastor::Tensor<scalar_t, 3> cross(
     const Fastor::Tensor<scalar_t, 3, 1> &a,
     const Fastor::Tensor<scalar_t, 3, 1> &b) {
 

--- a/math/fastor/include/algebra/math/impl/fastor_vector.hpp
+++ b/math/fastor/include/algebra/math/impl/fastor_vector.hpp
@@ -86,8 +86,9 @@ ALGEBRA_HOST constexpr Fastor::Tensor<scalar_t, N> normalize(
 ///
 /// @return the scalar dot product value
 template <concepts::scalar scalar_t, auto N>
-ALGEBRA_HOST_DEVICE constexpr scalar_t dot(const Fastor::Tensor<scalar_t, N> &a,
-                                        const Fastor::Tensor<scalar_t, N> &b) {
+ALGEBRA_HOST_DEVICE constexpr scalar_t dot(
+    const Fastor::Tensor<scalar_t, N> &a,
+    const Fastor::Tensor<scalar_t, N> &b) {
   return Fastor::inner(a, b);
 }
 
@@ -99,7 +100,7 @@ ALGEBRA_HOST_DEVICE constexpr scalar_t dot(const Fastor::Tensor<scalar_t, N> &a,
 /// @return the scalar dot product value
 template <concepts::scalar scalar_t, auto N>
 ALGEBRA_HOST constexpr scalar_t dot(const Fastor::Tensor<scalar_t, N> &a,
-                                 const Fastor::Tensor<scalar_t, N, 1> &b) {
+                                    const Fastor::Tensor<scalar_t, N, 1> &b) {
 
   // We need to specify the type of the Tensor slice because Fastor by default
   // is lazy, so it returns an intermediate type which does not play well with
@@ -116,7 +117,7 @@ ALGEBRA_HOST constexpr scalar_t dot(const Fastor::Tensor<scalar_t, N> &a,
 /// @return the scalar dot product value
 template <concepts::scalar scalar_t, auto N>
 ALGEBRA_HOST constexpr scalar_t dot(const Fastor::Tensor<scalar_t, N, 1> &a,
-                                 const Fastor::Tensor<scalar_t, N> &b) {
+                                    const Fastor::Tensor<scalar_t, N> &b) {
 
   return Fastor::inner(Fastor::Tensor<scalar_t, N>(a(Fastor::fseq<0, N>(), 0)),
                        b);
@@ -130,7 +131,7 @@ ALGEBRA_HOST constexpr scalar_t dot(const Fastor::Tensor<scalar_t, N, 1> &a,
 /// @return the scalar dot product value
 template <concepts::scalar scalar_t, auto N>
 ALGEBRA_HOST constexpr scalar_t dot(const Fastor::Tensor<scalar_t, N, 1> &a,
-                                 const Fastor::Tensor<scalar_t, N, 1> &b) {
+                                    const Fastor::Tensor<scalar_t, N, 1> &b) {
 
   return Fastor::inner(Fastor::Tensor<scalar_t, N>(a(Fastor::fseq<0, 3>(), 0)),
                        Fastor::Tensor<scalar_t, N>(b(Fastor::fseq<0, 3>(), 0)));

--- a/math/generic/include/algebra/math/algorithms/matrix/decomposition/partial_pivot_lud.hpp
+++ b/math/generic/include/algebra/math/algorithms/matrix/decomposition/partial_pivot_lud.hpp
@@ -41,7 +41,7 @@ struct partial_pivot_lud {
     int n_pivot = 0;
   };
 
-  ALGEBRA_HOST_DEVICE inline lud<algebra::traits::rank<matrix_t>> operator()(
+  ALGEBRA_HOST_DEVICE constexpr lud<algebra::traits::rank<matrix_t>> operator()(
       const matrix_t& m) const {
 
     constexpr size_type N{algebra::traits::rank<matrix_t>};

--- a/math/generic/include/algebra/math/algorithms/matrix/determinant/cofactor.hpp
+++ b/math/generic/include/algebra/math/algorithms/matrix/determinant/cofactor.hpp
@@ -27,7 +27,7 @@ struct cofactor {
   /// Function (object) used for accessing a matrix element
   using element_getter = element_getter_t;
 
-  ALGEBRA_HOST_DEVICE inline scalar_type operator()(const matrix_t &m) const {
+  ALGEBRA_HOST_DEVICE constexpr scalar_type operator()(const matrix_t &m) const {
     return determinant_getter_helper<algebra::traits::rank<matrix_t>>()(m);
   }
 
@@ -37,7 +37,7 @@ struct cofactor {
   template <size_type N>
   struct determinant_getter_helper<N, typename std::enable_if_t<N == 1>> {
     template <class input_matrix_type>
-    ALGEBRA_HOST_DEVICE inline scalar_type operator()(
+    ALGEBRA_HOST_DEVICE constexpr scalar_type operator()(
         const input_matrix_type &m) const {
       return element_getter()(m, 0, 0);
     }
@@ -47,7 +47,7 @@ struct cofactor {
   struct determinant_getter_helper<N, typename std::enable_if_t<N != 1>> {
 
     template <class input_matrix_type>
-    ALGEBRA_HOST_DEVICE inline scalar_type operator()(
+    ALGEBRA_HOST_DEVICE constexpr scalar_type operator()(
         const input_matrix_type &m) const {
 
       scalar_type D = 0;
@@ -73,7 +73,7 @@ struct cofactor {
     }
 
     template <class input_matrix_type>
-    ALGEBRA_HOST_DEVICE inline void get_cofactor(const input_matrix_type &m,
+    ALGEBRA_HOST_DEVICE constexpr void get_cofactor(const input_matrix_type &m,
                                                  matrix_t &temp, size_type p,
                                                  size_type q) const {
 

--- a/math/generic/include/algebra/math/algorithms/matrix/determinant/cofactor.hpp
+++ b/math/generic/include/algebra/math/algorithms/matrix/determinant/cofactor.hpp
@@ -27,7 +27,8 @@ struct cofactor {
   /// Function (object) used for accessing a matrix element
   using element_getter = element_getter_t;
 
-  ALGEBRA_HOST_DEVICE constexpr scalar_type operator()(const matrix_t &m) const {
+  ALGEBRA_HOST_DEVICE constexpr scalar_type operator()(
+      const matrix_t &m) const {
     return determinant_getter_helper<algebra::traits::rank<matrix_t>>()(m);
   }
 
@@ -74,8 +75,8 @@ struct cofactor {
 
     template <class input_matrix_type>
     ALGEBRA_HOST_DEVICE constexpr void get_cofactor(const input_matrix_type &m,
-                                                 matrix_t &temp, size_type p,
-                                                 size_type q) const {
+                                                    matrix_t &temp, size_type p,
+                                                    size_type q) const {
 
       size_type i = 0;
       size_type j = 0;

--- a/math/generic/include/algebra/math/algorithms/matrix/determinant/hard_coded.hpp
+++ b/math/generic/include/algebra/math/algorithms/matrix/determinant/hard_coded.hpp
@@ -29,8 +29,9 @@ struct hard_coded {
 
   // 2 X 2 matrix determinant
   template <typename M = matrix_t>
-  requires(algebra::traits::rank<M> == 2) ALGEBRA_HOST_DEVICE constexpr scalar_type
-  operator()(const matrix_t &m) const {
+  requires(algebra::traits::rank<M> == 2) ALGEBRA_HOST_DEVICE
+      constexpr scalar_type
+      operator()(const matrix_t &m) const {
 
     return element_getter()(m, 0, 0) * element_getter()(m, 1, 1) -
            element_getter()(m, 0, 1) * element_getter()(m, 1, 0);
@@ -38,8 +39,9 @@ struct hard_coded {
 
   // 4 X 4 matrix determinant
   template <typename M = matrix_t>
-  requires(algebra::traits::rank<M> == 4) ALGEBRA_HOST_DEVICE constexpr scalar_type
-  operator()(const matrix_t &m) const {
+  requires(algebra::traits::rank<M> == 4) ALGEBRA_HOST_DEVICE
+      constexpr scalar_type
+      operator()(const matrix_t &m) const {
 
     return element_getter()(m, 0, 3) * element_getter()(m, 1, 2) *
                element_getter()(m, 2, 1) * element_getter()(m, 3, 0) -

--- a/math/generic/include/algebra/math/algorithms/matrix/determinant/hard_coded.hpp
+++ b/math/generic/include/algebra/math/algorithms/matrix/determinant/hard_coded.hpp
@@ -29,7 +29,7 @@ struct hard_coded {
 
   // 2 X 2 matrix determinant
   template <typename M = matrix_t>
-  requires(algebra::traits::rank<M> == 2) ALGEBRA_HOST_DEVICE inline scalar_type
+  requires(algebra::traits::rank<M> == 2) ALGEBRA_HOST_DEVICE constexpr scalar_type
   operator()(const matrix_t &m) const {
 
     return element_getter()(m, 0, 0) * element_getter()(m, 1, 1) -
@@ -38,7 +38,7 @@ struct hard_coded {
 
   // 4 X 4 matrix determinant
   template <typename M = matrix_t>
-  requires(algebra::traits::rank<M> == 4) ALGEBRA_HOST_DEVICE inline scalar_type
+  requires(algebra::traits::rank<M> == 4) ALGEBRA_HOST_DEVICE constexpr scalar_type
   operator()(const matrix_t &m) const {
 
     return element_getter()(m, 0, 3) * element_getter()(m, 1, 2) *
@@ -90,6 +90,6 @@ struct hard_coded {
            element_getter()(m, 0, 0) * element_getter()(m, 1, 1) *
                element_getter()(m, 2, 2) * element_getter()(m, 3, 3);
   }
-};  // namespace algebra::generic::matrix::determinant
+};
 
 }  // namespace algebra::generic::matrix::determinant

--- a/math/generic/include/algebra/math/algorithms/matrix/determinant/partial_pivot_lud.hpp
+++ b/math/generic/include/algebra/math/algorithms/matrix/determinant/partial_pivot_lud.hpp
@@ -29,7 +29,7 @@ struct partial_pivot_lud {
       typename algebra::generic::matrix::decomposition::partial_pivot_lud<
           matrix_t, element_getter_t>;
 
-  ALGEBRA_HOST_DEVICE inline scalar_type operator()(const matrix_t& m) const {
+  ALGEBRA_HOST_DEVICE constexpr scalar_type operator()(const matrix_t& m) const {
 
     constexpr size_type N{algebra::traits::rank<matrix_t>};
 

--- a/math/generic/include/algebra/math/algorithms/matrix/determinant/partial_pivot_lud.hpp
+++ b/math/generic/include/algebra/math/algorithms/matrix/determinant/partial_pivot_lud.hpp
@@ -29,7 +29,8 @@ struct partial_pivot_lud {
       typename algebra::generic::matrix::decomposition::partial_pivot_lud<
           matrix_t, element_getter_t>;
 
-  ALGEBRA_HOST_DEVICE constexpr scalar_type operator()(const matrix_t& m) const {
+  ALGEBRA_HOST_DEVICE constexpr scalar_type operator()(
+      const matrix_t& m) const {
 
     constexpr size_type N{algebra::traits::rank<matrix_t>};
 

--- a/math/generic/include/algebra/math/algorithms/matrix/inverse/cofactor.hpp
+++ b/math/generic/include/algebra/math/algorithms/matrix/inverse/cofactor.hpp
@@ -30,7 +30,7 @@ struct cofactor {
   /// Function (object) used for accessing a matrix element
   using element_getter = element_getter_t;
 
-  ALGEBRA_HOST_DEVICE inline matrix_t operator()(const matrix_t &m) const {
+  ALGEBRA_HOST_DEVICE constexpr matrix_t operator()(const matrix_t &m) const {
     return adjoint_getter_helper<algebra::traits::rank<matrix_t>>()(m);
   }
 
@@ -39,7 +39,7 @@ struct cofactor {
 
   template <size_type N>
   struct adjoint_getter_helper<N, typename std::enable_if_t<N == 1>> {
-    ALGEBRA_HOST_DEVICE inline matrix_t operator()(
+    ALGEBRA_HOST_DEVICE constexpr matrix_t operator()(
         const matrix_t & /*m*/) const {
       matrix_t ret;
       element_getter()(ret, 0, 0) = 1;
@@ -53,7 +53,7 @@ struct cofactor {
     using determinant_getter =
         determinant::cofactor<matrix_t, element_getter_t>;
 
-    ALGEBRA_HOST_DEVICE inline matrix_t operator()(const matrix_t &m) const {
+    ALGEBRA_HOST_DEVICE constexpr matrix_t operator()(const matrix_t &m) const {
 
       matrix_t adj;
 
@@ -105,7 +105,7 @@ struct cofactor {
 
   using adjoint_getter = adjoint::cofactor<matrix_t, element_getter_t>;
 
-  ALGEBRA_HOST_DEVICE inline matrix_t operator()(const matrix_t &m) const {
+  ALGEBRA_HOST_DEVICE constexpr matrix_t operator()(const matrix_t &m) const {
 
     constexpr size_type N{algebra::traits::rank<matrix_t>};
 

--- a/math/generic/include/algebra/math/algorithms/matrix/inverse/hard_coded.hpp
+++ b/math/generic/include/algebra/math/algorithms/matrix/inverse/hard_coded.hpp
@@ -33,7 +33,7 @@ struct hard_coded {
 
   // 2 X 2 matrix inverse
   template <typename M = matrix_t>
-  requires(algebra::traits::rank<M> == 2) ALGEBRA_HOST_DEVICE inline matrix_t
+  requires(algebra::traits::rank<M> == 2) ALGEBRA_HOST_DEVICE constexpr matrix_t
   operator()(const matrix_t &m) const {
 
     matrix_t ret;
@@ -50,7 +50,7 @@ struct hard_coded {
 
   // 4 X 4 matrix inverse
   template <typename M = matrix_t>
-  requires(algebra::traits::rank<M> == 4) ALGEBRA_HOST_DEVICE inline matrix_t
+  requires(algebra::traits::rank<M> == 4) ALGEBRA_HOST_DEVICE constexpr matrix_t
   operator()(const matrix_t &m) const {
 
     matrix_t ret;
@@ -271,6 +271,6 @@ struct hard_coded {
     }
     return ret;
   }
-};  // namespace algebra::generic::matrix::inverse
+};
 
 }  // namespace algebra::generic::matrix::inverse

--- a/math/generic/include/algebra/math/algorithms/matrix/inverse/partial_pivot_lud.hpp
+++ b/math/generic/include/algebra/math/algorithms/matrix/inverse/partial_pivot_lud.hpp
@@ -29,7 +29,7 @@ struct partial_pivot_lud {
       typename algebra::generic::matrix::decomposition::partial_pivot_lud<
           matrix_t, element_getter_t>;
 
-  ALGEBRA_HOST_DEVICE inline matrix_t operator()(const matrix_t& m) const {
+  ALGEBRA_HOST_DEVICE constexpr matrix_t operator()(const matrix_t& m) const {
 
     constexpr size_type N{algebra::traits::rank<matrix_t>};
 

--- a/math/generic/include/algebra/math/impl/generic_matrix.hpp
+++ b/math/generic/include/algebra/math/impl/generic_matrix.hpp
@@ -17,7 +17,7 @@ namespace algebra::generic::math {
 
 /// Create zero matrix - generic transform3
 template <concepts::matrix M>
-ALGEBRA_HOST_DEVICE inline M zero() {
+ALGEBRA_HOST_DEVICE constexpr M zero() {
 
   using index_t = algebra::traits::index_t<M>;
   using element_getter_t = algebra::traits::element_getter_t<M>;
@@ -35,7 +35,7 @@ ALGEBRA_HOST_DEVICE inline M zero() {
 
 /// Create identity matrix - generic transform3
 template <concepts::matrix M>
-ALGEBRA_HOST_DEVICE inline M identity() {
+ALGEBRA_HOST_DEVICE constexpr M identity() {
 
   using index_t = algebra::traits::index_t<M>;
   using element_getter_t = algebra::traits::element_getter_t<M>;
@@ -51,19 +51,19 @@ ALGEBRA_HOST_DEVICE inline M identity() {
 
 /// Set @param m as zero matrix
 template <concepts::matrix M>
-ALGEBRA_HOST_DEVICE inline void set_zero(M &m) {
+ALGEBRA_HOST_DEVICE constexpr void set_zero(M &m) {
   m = zero<M>();
 }
 
 /// Set @param m as identity matrix
 template <concepts::matrix M>
-ALGEBRA_HOST_DEVICE inline void set_identity(M &m) {
+ALGEBRA_HOST_DEVICE constexpr void set_identity(M &m) {
   m = identity<M>();
 }
 
 /// @returns the transpose matrix of @param m
 template <concepts::matrix M>
-ALGEBRA_HOST_DEVICE inline auto transpose(const M &m) {
+ALGEBRA_HOST_DEVICE constexpr auto transpose(const M &m) {
 
   using index_t = algebra::traits::index_t<M>;
   using value_t = algebra::traits::value_t<M>;
@@ -85,7 +85,7 @@ ALGEBRA_HOST_DEVICE inline auto transpose(const M &m) {
 
 // Set matrix C to the product AB
 template <concepts::matrix MC, concepts::matrix MA, concepts::matrix MB>
-ALGEBRA_HOST_DEVICE inline void
+ALGEBRA_HOST_DEVICE constexpr void
 set_product(MC &C, const MA &A, const MB &B) requires(
     algebra::concepts::matrix_multipliable_into<MA, MB, MC>) {
   using index_t = algebra::traits::index_t<MC>;
@@ -107,7 +107,7 @@ set_product(MC &C, const MA &A, const MB &B) requires(
 
 // Set matrix C to the product A^TB
 template <concepts::matrix MC, concepts::matrix MA, concepts::matrix MB>
-ALGEBRA_HOST_DEVICE inline void
+ALGEBRA_HOST_DEVICE constexpr void
 set_product_left_transpose(MC &C, const MA &A, const MB &B) requires(
     algebra::concepts::matrix_multipliable_into<
         decltype(transpose(std::declval<MA>())), MB, MC>) {
@@ -130,7 +130,7 @@ set_product_left_transpose(MC &C, const MA &A, const MB &B) requires(
 
 // Set matrix C to the product AB^T
 template <concepts::matrix MC, concepts::matrix MA, concepts::matrix MB>
-ALGEBRA_HOST_DEVICE inline void
+ALGEBRA_HOST_DEVICE constexpr void
 set_product_right_transpose(MC &C, const MA &A, const MB &B) requires(
     algebra::concepts::matrix_multipliable_into<
         MA, decltype(transpose(std::declval<MB>())), MC>) {
@@ -153,7 +153,7 @@ set_product_right_transpose(MC &C, const MA &A, const MB &B) requires(
 
 // Set matrix A to the product AB in place
 template <concepts::matrix MA, concepts::matrix MB>
-ALGEBRA_HOST_DEVICE inline void
+ALGEBRA_HOST_DEVICE constexpr void
 set_inplace_product_right(MA &A, const MB &B) requires(
     algebra::concepts::matrix_multipliable_into<MA, MB, MA>) {
   using index_t = algebra::traits::index_t<MA>;
@@ -183,7 +183,7 @@ set_inplace_product_right(MA &A, const MB &B) requires(
 
 // Set matrix A to the product BA in place
 template <concepts::matrix MA, concepts::matrix MB>
-ALGEBRA_HOST_DEVICE inline void
+ALGEBRA_HOST_DEVICE constexpr void
 set_inplace_product_left(MA &A, const MB &B) requires(
     algebra::concepts::matrix_multipliable_into<MB, MA, MA>) {
   using index_t = algebra::traits::index_t<MA>;
@@ -213,7 +213,7 @@ set_inplace_product_left(MA &A, const MB &B) requires(
 
 // Set matrix A to the product AB^T in place
 template <concepts::matrix MA, concepts::matrix MB>
-ALGEBRA_HOST_DEVICE inline void
+ALGEBRA_HOST_DEVICE constexpr void
 set_inplace_product_right_transpose(MA &A, const MB &B) requires(
     algebra::concepts::matrix_multipliable_into<
         MA, decltype(transpose(std::declval<MB>())), MA>) {
@@ -244,7 +244,7 @@ set_inplace_product_right_transpose(MA &A, const MB &B) requires(
 
 // Set matrix A to the product B^TA in place
 template <concepts::matrix MA, concepts::matrix MB>
-ALGEBRA_HOST_DEVICE inline void
+ALGEBRA_HOST_DEVICE constexpr void
 set_inplace_product_left_transpose(MA &A, const MB &B) requires(
     algebra::concepts::matrix_multipliable_into<
         decltype(transpose(std::declval<MB>())), MA, MA>) {
@@ -275,7 +275,7 @@ set_inplace_product_left_transpose(MA &A, const MB &B) requires(
 
 /// @returns the determinant of @param m
 template <concepts::square_matrix M>
-ALGEBRA_HOST_DEVICE inline algebra::traits::scalar_t<M> determinant(
+ALGEBRA_HOST_DEVICE constexpr algebra::traits::scalar_t<M> determinant(
     const M &m) {
 
   return determinant_t<M>{}(m);
@@ -283,7 +283,7 @@ ALGEBRA_HOST_DEVICE inline algebra::traits::scalar_t<M> determinant(
 
 /// @returns the determinant of @param m
 template <concepts::square_matrix M>
-ALGEBRA_HOST_DEVICE inline M inverse(const M &m) {
+ALGEBRA_HOST_DEVICE constexpr M inverse(const M &m) {
 
   return inversion_t<M>{}(m);
 }

--- a/math/generic/include/algebra/math/impl/generic_transform3.hpp
+++ b/math/generic/include/algebra/math/impl/generic_transform3.hpp
@@ -285,13 +285,15 @@ struct transform3 {
 
   /// This method transform from a vector from the local 3D cartesian frame to
   /// the global 3D cartesian frame
-  ALGEBRA_HOST_DEVICE constexpr vector3 vector_to_global(const vector3 &v) const {
+  ALGEBRA_HOST_DEVICE constexpr vector3 vector_to_global(
+      const vector3 &v) const {
     return rotate(_data, v);
   }
 
   /// This method transform from a vector from the global 3D cartesian frame
   /// into the local 3D cartesian frame
-  ALGEBRA_HOST_DEVICE constexpr vector3 vector_to_local(const vector3 &v) const {
+  ALGEBRA_HOST_DEVICE constexpr vector3 vector_to_local(
+      const vector3 &v) const {
     return rotate(_data_inv, v);
   }
 

--- a/math/generic/include/algebra/math/impl/generic_transform3.hpp
+++ b/math/generic/include/algebra/math/impl/generic_transform3.hpp
@@ -171,7 +171,7 @@ struct transform3 {
 
   /// Equality operator
   ALGEBRA_HOST_DEVICE
-  inline bool operator==(const transform3 &rhs) const {
+  constexpr bool operator==(const transform3 &rhs) const {
 
     for (index_t j = 0; j < 4; j++) {
       // Check only the rows that can differ
@@ -191,7 +191,7 @@ struct transform3 {
   /// @param m is the rotation matrix
   /// @param v is the vector to be rotated
   ALGEBRA_HOST_DEVICE
-  static inline vector3 rotate(const matrix44 &m, const vector3 &v) {
+  static constexpr vector3 rotate(const matrix44 &m, const vector3 &v) {
 
     vector3 ret{0.f, 0.f, 0.f};
 
@@ -221,49 +221,49 @@ struct transform3 {
 
   /// This method retrieves the rotation of a transform
   ALGEBRA_HOST_DEVICE
-  auto inline rotation() const {
+  auto constexpr rotation() const {
     return block_getter{}.template operator()<3, 3>(_data, 0, 0);
   }
 
   /// This method retrieves x axis
   ALGEBRA_HOST_DEVICE
-  inline point3 x() const {
+  constexpr point3 x() const {
     return {element_getter{}(_data, 0, 0), element_getter{}(_data, 1, 0),
             element_getter{}(_data, 2, 0)};
   }
 
   /// This method retrieves y axis
   ALGEBRA_HOST_DEVICE
-  inline point3 y() const {
+  constexpr point3 y() const {
     return {element_getter{}(_data, 0, 1), element_getter{}(_data, 1, 1),
             element_getter{}(_data, 2, 1)};
   }
 
   /// This method retrieves z axis
   ALGEBRA_HOST_DEVICE
-  inline point3 z() const {
+  constexpr point3 z() const {
     return {element_getter{}(_data, 0, 2), element_getter{}(_data, 1, 2),
             element_getter{}(_data, 2, 2)};
   }
 
   /// This method retrieves the translation of a transform
   ALGEBRA_HOST_DEVICE
-  inline point3 translation() const {
+  constexpr point3 translation() const {
     return {element_getter{}(_data, 0, 3), element_getter{}(_data, 1, 3),
             element_getter{}(_data, 2, 3)};
   }
 
   /// This method retrieves the 4x4 matrix of a transform
   ALGEBRA_HOST_DEVICE
-  inline const matrix44 &matrix() const { return _data; }
+  constexpr const matrix44 &matrix() const { return _data; }
 
   /// This method retrieves the 4x4 matrix of an inverse transform
   ALGEBRA_HOST_DEVICE
-  inline const matrix44 &matrix_inverse() const { return _data_inv; }
+  constexpr const matrix44 &matrix_inverse() const { return _data_inv; }
 
   /// This method transform from a point from the local 3D cartesian frame to
   /// the global 3D cartesian frame
-  ALGEBRA_HOST_DEVICE inline point3 point_to_global(const point3 &v) const {
+  ALGEBRA_HOST_DEVICE constexpr point3 point_to_global(const point3 &v) const {
 
     const vector3 rg = rotate(_data, v);
 
@@ -274,7 +274,7 @@ struct transform3 {
 
   /// This method transform from a vector from the global 3D cartesian frame
   /// into the local 3D cartesian frame
-  ALGEBRA_HOST_DEVICE inline point3 point_to_local(const point3 &v) const {
+  ALGEBRA_HOST_DEVICE constexpr point3 point_to_local(const point3 &v) const {
 
     const vector3 rg = rotate(_data_inv, v);
 
@@ -285,13 +285,13 @@ struct transform3 {
 
   /// This method transform from a vector from the local 3D cartesian frame to
   /// the global 3D cartesian frame
-  ALGEBRA_HOST_DEVICE inline vector3 vector_to_global(const vector3 &v) const {
+  ALGEBRA_HOST_DEVICE constexpr vector3 vector_to_global(const vector3 &v) const {
     return rotate(_data, v);
   }
 
   /// This method transform from a vector from the global 3D cartesian frame
   /// into the local 3D cartesian frame
-  ALGEBRA_HOST_DEVICE inline vector3 vector_to_local(const vector3 &v) const {
+  ALGEBRA_HOST_DEVICE constexpr vector3 vector_to_local(const vector3 &v) const {
     return rotate(_data_inv, v);
   }
 

--- a/math/generic/include/algebra/math/impl/generic_vector.hpp
+++ b/math/generic/include/algebra/math/impl/generic_vector.hpp
@@ -69,7 +69,7 @@ requires(
         concepts::vector3D<vector2_t> ||
         concepts::column_matrix3D<vector2_t>)) ALGEBRA_HOST_DEVICE
     constexpr algebra::traits::vector_t<vector1_t> cross(const vector1_t &a,
-                                                      const vector2_t &b) {
+                                                         const vector2_t &b) {
 
   using element_getter_t = algebra::traits::element_getter_t<vector1_t>;
 
@@ -96,7 +96,7 @@ requires((concepts::vector<vector1_t> || concepts::column_matrix<vector1_t>)&&(
     concepts::vector<vector2_t> ||
     concepts::column_matrix<vector2_t>)) ALGEBRA_HOST_DEVICE
     constexpr algebra::traits::scalar_t<vector1_t> dot(const vector1_t &a,
-                                                    const vector2_t &b) {
+                                                       const vector2_t &b) {
 
   using scalar_t = algebra::traits::scalar_t<vector1_t>;
   using index_t = algebra::traits::index_t<vector1_t>;

--- a/math/generic/include/algebra/math/impl/generic_vector.hpp
+++ b/math/generic/include/algebra/math/impl/generic_vector.hpp
@@ -19,7 +19,7 @@ namespace algebra::generic::math {
 ///
 /// @param v the input vector
 template <concepts::vector vector_t>
-ALGEBRA_HOST_DEVICE inline algebra::traits::scalar_t<vector_t> phi(
+ALGEBRA_HOST_DEVICE constexpr algebra::traits::scalar_t<vector_t> phi(
     const vector_t &v) noexcept {
 
   using element_getter_t = algebra::traits::element_getter_t<vector_t>;
@@ -32,7 +32,7 @@ ALGEBRA_HOST_DEVICE inline algebra::traits::scalar_t<vector_t> phi(
 ///
 /// @param v the input vector
 template <concepts::vector vector_t>
-ALGEBRA_HOST_DEVICE inline algebra::traits::scalar_t<vector_t> perp(
+ALGEBRA_HOST_DEVICE constexpr algebra::traits::scalar_t<vector_t> perp(
     const vector_t &v) noexcept {
 
   using element_getter_t = algebra::traits::element_getter_t<vector_t>;
@@ -46,7 +46,7 @@ ALGEBRA_HOST_DEVICE inline algebra::traits::scalar_t<vector_t> perp(
 ///
 /// @param v the input vector
 template <concepts::vector vector_t>
-ALGEBRA_HOST_DEVICE inline algebra::traits::scalar_t<vector_t> theta(
+ALGEBRA_HOST_DEVICE constexpr algebra::traits::scalar_t<vector_t> theta(
     const vector_t &v) noexcept {
 
   using element_getter_t = algebra::traits::element_getter_t<vector_t>;
@@ -68,7 +68,7 @@ requires(
     (concepts::vector3D<vector1_t> || concepts::column_matrix3D<vector1_t>)&&(
         concepts::vector3D<vector2_t> ||
         concepts::column_matrix3D<vector2_t>)) ALGEBRA_HOST_DEVICE
-    inline algebra::traits::vector_t<vector1_t> cross(const vector1_t &a,
+    constexpr algebra::traits::vector_t<vector1_t> cross(const vector1_t &a,
                                                       const vector2_t &b) {
 
   using element_getter_t = algebra::traits::element_getter_t<vector1_t>;
@@ -95,7 +95,7 @@ template <typename vector1_t, typename vector2_t>
 requires((concepts::vector<vector1_t> || concepts::column_matrix<vector1_t>)&&(
     concepts::vector<vector2_t> ||
     concepts::column_matrix<vector2_t>)) ALGEBRA_HOST_DEVICE
-    inline algebra::traits::scalar_t<vector1_t> dot(const vector1_t &a,
+    constexpr algebra::traits::scalar_t<vector1_t> dot(const vector1_t &a,
                                                     const vector2_t &b) {
 
   using scalar_t = algebra::traits::scalar_t<vector1_t>;
@@ -115,7 +115,7 @@ requires((concepts::vector<vector1_t> || concepts::column_matrix<vector1_t>)&&(
 ///
 /// @param v the input vector
 template <concepts::vector vector_t>
-ALGEBRA_HOST_DEVICE inline algebra::traits::scalar_t<vector_t> norm(
+ALGEBRA_HOST_DEVICE constexpr algebra::traits::scalar_t<vector_t> norm(
     const vector_t &v) {
 
   return algebra::math::sqrt(dot(v, v));
@@ -126,7 +126,7 @@ ALGEBRA_HOST_DEVICE inline algebra::traits::scalar_t<vector_t> norm(
 ///
 /// @param v the input vector
 template <concepts::vector vector_t>
-ALGEBRA_HOST_DEVICE inline algebra::traits::scalar_t<vector_t> eta(
+ALGEBRA_HOST_DEVICE constexpr algebra::traits::scalar_t<vector_t> eta(
     const vector_t &v) noexcept {
 
   using element_getter_t = algebra::traits::element_getter_t<vector_t>;
@@ -142,7 +142,7 @@ ALGEBRA_HOST_DEVICE inline algebra::traits::scalar_t<vector_t> eta(
 ///
 /// @returns the normalized vector
 template <concepts::vector vector_t>
-ALGEBRA_HOST_DEVICE inline vector_t normalize(const vector_t &v) {
+ALGEBRA_HOST_DEVICE constexpr vector_t normalize(const vector_t &v) {
 
   using scalar_t = algebra::traits::scalar_t<vector_t>;
 

--- a/math/smatrix/include/algebra/math/impl/smatrix_matrix.hpp
+++ b/math/smatrix/include/algebra/math/impl/smatrix_matrix.hpp
@@ -19,40 +19,40 @@ namespace algebra::smatrix::math {
 
 /// Create zero matrix
 template <concepts::matrix matrix_t>
-ALGEBRA_HOST_DEVICE inline matrix_t zero() {
+ALGEBRA_HOST_DEVICE constexpr matrix_t zero() {
   return matrix_t();
 }
 
 /// Create identity matrix
 template <concepts::matrix matrix_t>
-ALGEBRA_HOST_DEVICE inline matrix_t identity() {
+ALGEBRA_HOST_DEVICE constexpr matrix_t identity() {
   return matrix_t(ROOT::Math::SMatrixIdentity());
 }
 
 /// Set input matrix as zero matrix
 template <unsigned int ROWS, unsigned int COLS, concepts::scalar scalar_t>
-ALGEBRA_HOST_DEVICE inline void set_zero(
+ALGEBRA_HOST_DEVICE constexpr void set_zero(
     ROOT::Math::SMatrix<scalar_t, ROWS, COLS> &m) {
   m = zero<ROOT::Math::SMatrix<scalar_t, ROWS, COLS>>();
 }
 
 /// Set input matrix as identity matrix
 template <unsigned int ROWS, unsigned int COLS, concepts::scalar scalar_t>
-ALGEBRA_HOST_DEVICE inline void set_identity(
+ALGEBRA_HOST_DEVICE constexpr void set_identity(
     ROOT::Math::SMatrix<scalar_t, ROWS, COLS> &m) {
   m = identity<ROOT::Math::SMatrix<scalar_t, ROWS, COLS>>();
 }
 
 /// Create transpose matrix
 template <unsigned int ROWS, unsigned int COLS, concepts::scalar scalar_t>
-ALGEBRA_HOST_DEVICE inline matrix_type<scalar_t, COLS, ROWS> transpose(
+ALGEBRA_HOST_DEVICE constexpr matrix_type<scalar_t, COLS, ROWS> transpose(
     const ROOT::Math::SMatrix<scalar_t, ROWS, COLS> &m) {
   return ROOT::Math::Transpose(m);
 }
 
 /// @returns the determinant of @param m
 template <unsigned int ROWS, unsigned int COLS, concepts::scalar scalar_t>
-ALGEBRA_HOST_DEVICE inline scalar_t determinant(
+ALGEBRA_HOST_DEVICE constexpr scalar_t determinant(
     const matrix_type<scalar_t, ROWS, COLS> &m) {
 
   scalar_t det;
@@ -63,7 +63,7 @@ ALGEBRA_HOST_DEVICE inline scalar_t determinant(
 
 /// @returns the inverse of @param m
 template <unsigned int ROWS, unsigned int COLS, concepts::scalar scalar_t>
-ALGEBRA_HOST_DEVICE inline matrix_type<scalar_t, COLS, ROWS> inverse(
+ALGEBRA_HOST_DEVICE constexpr matrix_type<scalar_t, COLS, ROWS> inverse(
     const matrix_type<scalar_t, ROWS, COLS> &m) {
 
   int ifail = 0;

--- a/math/smatrix/include/algebra/math/impl/smatrix_transform3.hpp
+++ b/math/smatrix/include/algebra/math/impl/smatrix_transform3.hpp
@@ -154,49 +154,49 @@ struct transform3 {
 
   /// Equality operator
   ALGEBRA_HOST
-  inline bool operator==(const transform3 &rhs) const {
+  constexpr bool operator==(const transform3 &rhs) const {
 
     return _data == rhs._data;
   }
 
   /// This method retrieves the rotation of a transform
   ALGEBRA_HOST
-  inline auto rotation() const {
+  constexpr auto rotation() const {
 
     return (_data.template Sub<ROOT::Math::SMatrix<scalar_type, 3, 3> >(0, 0));
   }
 
   /// This method retrieves x axis
   ALGEBRA_HOST_DEVICE
-  inline point3 x() const { return (_data.template SubCol<vector3>(0, 0)); }
+  constexpr point3 x() const { return (_data.template SubCol<vector3>(0, 0)); }
 
   /// This method retrieves y axis
   ALGEBRA_HOST_DEVICE
-  inline point3 y() const { return (_data.template SubCol<vector3>(1, 0)); }
+  constexpr point3 y() const { return (_data.template SubCol<vector3>(1, 0)); }
 
   /// This method retrieves z axis
   ALGEBRA_HOST_DEVICE
-  inline point3 z() const { return (_data.template SubCol<vector3>(2, 0)); }
+  constexpr point3 z() const { return (_data.template SubCol<vector3>(2, 0)); }
 
   /// This method retrieves the translation of a transform
   ALGEBRA_HOST
-  inline vector3 translation() const {
+  constexpr vector3 translation() const {
 
     return (_data.template SubCol<vector3>(3, 0));
   }
 
   /// This method retrieves the 4x4 matrix of a transform
   ALGEBRA_HOST
-  inline matrix44 matrix() const { return _data; }
+  constexpr matrix44 matrix() const { return _data; }
 
   /// This method retrieves the 4x4 matrix of an inverse transform
   ALGEBRA_HOST
-  inline matrix44 matrix_inverse() const { return _data_inv; }
+  constexpr matrix44 matrix_inverse() const { return _data_inv; }
 
   /// This method transform from a point from the local 3D cartesian frame to
   /// the global 3D cartesian frame
   ALGEBRA_HOST
-  inline point3 point_to_global(const point3 &v) const {
+  constexpr point3 point_to_global(const point3 &v) const {
 
     ROOT::Math::SVector<scalar_type, 4> vector_4;
     vector_4.Place_at(v, 0);
@@ -208,7 +208,7 @@ struct transform3 {
   /// This method transform from a vector from the global 3D cartesian frame
   /// into the local 3D cartesian frame
   ALGEBRA_HOST
-  inline point3 point_to_local(const point3 &v) const {
+  constexpr point3 point_to_local(const point3 &v) const {
 
     ROOT::Math::SVector<scalar_type, 4> vector_4;
     vector_4.Place_at(v, 0);
@@ -220,7 +220,7 @@ struct transform3 {
   /// This method transform from a vector from the local 3D cartesian frame to
   /// the global 3D cartesian frame
   ALGEBRA_HOST
-  inline point3 vector_to_global(const vector3 &v) const {
+  constexpr point3 vector_to_global(const vector3 &v) const {
 
     ROOT::Math::SVector<scalar_type, 4> vector_4;
     vector_4.Place_at(v, 0);
@@ -231,7 +231,7 @@ struct transform3 {
   /// This method transform from a vector from the global 3D cartesian frame
   /// into the local 3D cartesian frame
   ALGEBRA_HOST
-  inline point3 vector_to_local(const vector3 &v) const {
+  constexpr point3 vector_to_local(const vector3 &v) const {
 
     ROOT::Math::SVector<scalar_type, 4> vector_4;
     vector_4.Place_at(v, 0);

--- a/math/smatrix/include/algebra/math/impl/smatrix_vector.hpp
+++ b/math/smatrix/include/algebra/math/impl/smatrix_vector.hpp
@@ -22,14 +22,14 @@ namespace algebra::smatrix::math {
 ///
 /// @param v the input vector
 template <concepts::scalar scalar_t, auto N>
-requires(N >= 2) ALGEBRA_HOST inline scalar_t
+requires(N >= 2) ALGEBRA_HOST constexpr scalar_t
     phi(const ROOT::Math::SVector<scalar_t, N> &v) noexcept {
 
   return static_cast<scalar_t>(TMath::ATan2(v[1], v[0]));
 }
 
 template <concepts::scalar scalar_t, class A, auto N>
-requires(N >= 2) ALGEBRA_HOST inline scalar_t
+requires(N >= 2) ALGEBRA_HOST constexpr scalar_t
     phi(const ROOT::Math::VecExpr<A, scalar_t, N> &v) noexcept {
 
   return static_cast<scalar_t>(TMath::ATan2(v.apply(1), v.apply(0)));
@@ -39,7 +39,7 @@ requires(N >= 2) ALGEBRA_HOST inline scalar_t
 ///
 /// @param v the input vector
 template <concepts::scalar scalar_t, auto N>
-requires(N >= 3) ALGEBRA_HOST inline scalar_t
+requires(N >= 3) ALGEBRA_HOST constexpr scalar_t
     theta(const ROOT::Math::SVector<scalar_t, N> &v) noexcept {
 
   return static_cast<scalar_t>(
@@ -47,7 +47,7 @@ requires(N >= 3) ALGEBRA_HOST inline scalar_t
 }
 
 template <concepts::scalar scalar_t, class A, auto N>
-requires(N >= 3) ALGEBRA_HOST inline scalar_t
+requires(N >= 3) ALGEBRA_HOST constexpr scalar_t
     theta(const ROOT::Math::VecExpr<A, scalar_t, N> &v) noexcept {
 
   return static_cast<scalar_t>(TMath::ATan2(
@@ -59,13 +59,14 @@ requires(N >= 3) ALGEBRA_HOST inline scalar_t
 ///
 /// @param v the input vector
 template <concepts::scalar scalar_t, auto N>
-ALGEBRA_HOST inline scalar_t norm(const ROOT::Math::SVector<scalar_t, N> &v) {
+ALGEBRA_HOST constexpr scalar_t norm(
+    const ROOT::Math::SVector<scalar_t, N> &v) {
 
   return static_cast<scalar_t>(TMath::Sqrt(ROOT::Math::Dot(v, v)));
 }
 
 template <concepts::scalar scalar_t, class A, auto N>
-ALGEBRA_HOST inline scalar_t norm(
+ALGEBRA_HOST constexpr scalar_t norm(
     const ROOT::Math::VecExpr<A, scalar_t, N> &v) {
 
   return static_cast<scalar_t>(TMath::Sqrt(ROOT::Math::Dot(v, v)));
@@ -76,14 +77,14 @@ ALGEBRA_HOST inline scalar_t norm(
 ///
 /// @param v the input vector
 template <concepts::scalar scalar_t, auto N>
-requires(N >= 3) ALGEBRA_HOST inline scalar_t
+requires(N >= 3) ALGEBRA_HOST constexpr scalar_t
     eta(const ROOT::Math::SVector<scalar_t, N> &v) noexcept {
 
   return static_cast<scalar_t>(TMath::ATanH(v[2] / norm(v)));
 }
 
 template <concepts::scalar scalar_t, class A, auto N>
-requires(N >= 3) ALGEBRA_HOST inline scalar_t
+requires(N >= 3) ALGEBRA_HOST constexpr scalar_t
     eta(const ROOT::Math::VecExpr<A, scalar_t, N> &v) noexcept {
 
   return static_cast<scalar_t>(TMath::ATanH(v.apply(2) / norm(v)));
@@ -93,14 +94,14 @@ requires(N >= 3) ALGEBRA_HOST inline scalar_t
 ///
 /// @param v the input vector
 template <concepts::scalar scalar_t, auto N>
-requires(N >= 2) ALGEBRA_HOST inline scalar_t
+requires(N >= 2) ALGEBRA_HOST constexpr scalar_t
     perp(const ROOT::Math::SVector<scalar_t, N> &v) noexcept {
 
   return static_cast<scalar_t>(TMath::Sqrt(v[0] * v[0] + v[1] * v[1]));
 }
 
 template <concepts::scalar scalar_t, class A, auto N>
-requires(N >= 2) ALGEBRA_HOST inline scalar_t
+requires(N >= 2) ALGEBRA_HOST constexpr scalar_t
     perp(const ROOT::Math::VecExpr<A, scalar_t, N> &v) noexcept {
 
   return static_cast<scalar_t>(
@@ -111,7 +112,7 @@ requires(N >= 2) ALGEBRA_HOST inline scalar_t
 ///
 /// @param v the input vector
 template <concepts::scalar scalar_t, auto N>
-ALGEBRA_HOST inline ROOT::Math::SVector<scalar_t, N> normalize(
+ALGEBRA_HOST constexpr ROOT::Math::SVector<scalar_t, N> normalize(
     const ROOT::Math::SVector<scalar_t, N> &v) {
 
   return ROOT::Math::Unit(v);
@@ -121,7 +122,7 @@ ALGEBRA_HOST inline ROOT::Math::SVector<scalar_t, N> normalize(
 ///
 /// @param v the input vector
 template <concepts::scalar scalar_t, class A, auto N>
-ALGEBRA_HOST inline ROOT::Math::SVector<scalar_t, N> normalize(
+ALGEBRA_HOST constexpr ROOT::Math::SVector<scalar_t, N> normalize(
     const ROOT::Math::VecExpr<A, scalar_t, N> &v) {
 
   return ROOT::Math::Unit(v);
@@ -134,8 +135,8 @@ ALGEBRA_HOST inline ROOT::Math::SVector<scalar_t, N> normalize(
 ///
 /// @return the scalar dot product value
 template <concepts::scalar scalar_t, auto N>
-ALGEBRA_HOST inline scalar_t dot(const ROOT::Math::SVector<scalar_t, N> &a,
-                                 const ROOT::Math::SVector<scalar_t, N> &b) {
+ALGEBRA_HOST constexpr scalar_t dot(const ROOT::Math::SVector<scalar_t, N> &a,
+                                    const ROOT::Math::SVector<scalar_t, N> &b) {
 
   return ROOT::Math::Dot(a, b);
 }
@@ -147,8 +148,9 @@ ALGEBRA_HOST inline scalar_t dot(const ROOT::Math::SVector<scalar_t, N> &a,
 ///
 /// @return the scalar dot product value
 template <concepts::scalar scalar_t, class A, auto N>
-ALGEBRA_HOST inline scalar_t dot(const ROOT::Math::SVector<scalar_t, N> &a,
-                                 const ROOT::Math::VecExpr<A, scalar_t, N> &b) {
+ALGEBRA_HOST constexpr scalar_t dot(
+    const ROOT::Math::SVector<scalar_t, N> &a,
+    const ROOT::Math::VecExpr<A, scalar_t, N> &b) {
 
   return ROOT::Math::Dot(a, b);
 }
@@ -160,8 +162,9 @@ ALGEBRA_HOST inline scalar_t dot(const ROOT::Math::SVector<scalar_t, N> &a,
 ///
 /// @return the scalar dot product value
 template <concepts::scalar scalar_t, class A, auto N>
-ALGEBRA_HOST inline scalar_t dot(const ROOT::Math::VecExpr<A, scalar_t, N> &a,
-                                 const ROOT::Math::SVector<scalar_t, N> &b) {
+ALGEBRA_HOST constexpr scalar_t dot(
+    const ROOT::Math::VecExpr<A, scalar_t, N> &a,
+    const ROOT::Math::SVector<scalar_t, N> &b) {
 
   return ROOT::Math::Dot(a, b);
 }
@@ -173,8 +176,9 @@ ALGEBRA_HOST inline scalar_t dot(const ROOT::Math::VecExpr<A, scalar_t, N> &a,
 ///
 /// @return the scalar dot product value
 template <concepts::scalar scalar_t, class A, auto N>
-ALGEBRA_HOST inline scalar_t dot(const ROOT::Math::VecExpr<A, scalar_t, N> &a,
-                                 const ROOT::Math::VecExpr<A, scalar_t, N> &b) {
+ALGEBRA_HOST constexpr scalar_t dot(
+    const ROOT::Math::VecExpr<A, scalar_t, N> &a,
+    const ROOT::Math::VecExpr<A, scalar_t, N> &b) {
 
   return ROOT::Math::Dot(a, b);
 }
@@ -186,8 +190,9 @@ ALGEBRA_HOST inline scalar_t dot(const ROOT::Math::VecExpr<A, scalar_t, N> &a,
 ///
 /// @return the scalar dot product value
 template <concepts::scalar scalar_t, class A, auto N>
-ALGEBRA_HOST inline scalar_t dot(const ROOT::Math::SMatrix<scalar_t, N, 1> &a,
-                                 const ROOT::Math::VecExpr<A, scalar_t, N> &b) {
+ALGEBRA_HOST constexpr scalar_t dot(
+    const ROOT::Math::SMatrix<scalar_t, N, 1> &a,
+    const ROOT::Math::VecExpr<A, scalar_t, N> &b) {
 
   return ROOT::Math::Dot(a.Col(0), b);
 }
@@ -199,8 +204,9 @@ ALGEBRA_HOST inline scalar_t dot(const ROOT::Math::SMatrix<scalar_t, N, 1> &a,
 ///
 /// @return the scalar dot product value
 template <concepts::scalar scalar_t, class A, auto N>
-ALGEBRA_HOST inline scalar_t dot(const ROOT::Math::VecExpr<A, scalar_t, N> &a,
-                                 const ROOT::Math::SMatrix<scalar_t, N, 1> &b) {
+ALGEBRA_HOST constexpr scalar_t dot(
+    const ROOT::Math::VecExpr<A, scalar_t, N> &a,
+    const ROOT::Math::SMatrix<scalar_t, N, 1> &b) {
   return dot(b, a);
 }
 
@@ -211,8 +217,9 @@ ALGEBRA_HOST inline scalar_t dot(const ROOT::Math::VecExpr<A, scalar_t, N> &a,
 ///
 /// @return the scalar dot product value
 template <concepts::scalar scalar_t, auto N>
-ALGEBRA_HOST inline scalar_t dot(const ROOT::Math::SMatrix<scalar_t, N, 1> &a,
-                                 const ROOT::Math::SVector<scalar_t, N> &b) {
+ALGEBRA_HOST constexpr scalar_t dot(
+    const ROOT::Math::SMatrix<scalar_t, N, 1> &a,
+    const ROOT::Math::SVector<scalar_t, N> &b) {
 
   return ROOT::Math::Dot(a.Col(0), b);
 }
@@ -224,8 +231,9 @@ ALGEBRA_HOST inline scalar_t dot(const ROOT::Math::SMatrix<scalar_t, N, 1> &a,
 ///
 /// @return the scalar dot product value
 template <concepts::scalar scalar_t, auto N>
-ALGEBRA_HOST inline scalar_t dot(const ROOT::Math::SVector<scalar_t, N> &a,
-                                 const ROOT::Math::SMatrix<scalar_t, N, 1> &b) {
+ALGEBRA_HOST constexpr scalar_t dot(
+    const ROOT::Math::SVector<scalar_t, N> &a,
+    const ROOT::Math::SMatrix<scalar_t, N, 1> &b) {
   return dot(b, a);
 }
 
@@ -236,7 +244,7 @@ ALGEBRA_HOST inline scalar_t dot(const ROOT::Math::SVector<scalar_t, N> &a,
 ///
 /// @return a vector (expression) representing the cross product
 template <concepts::scalar scalar_t>
-ALGEBRA_HOST inline ROOT::Math::SVector<scalar_t, 3> cross(
+ALGEBRA_HOST constexpr ROOT::Math::SVector<scalar_t, 3> cross(
     const ROOT::Math::SVector<scalar_t, 3> &a,
     const ROOT::Math::SVector<scalar_t, 3> &b) {
 
@@ -250,7 +258,7 @@ ALGEBRA_HOST inline ROOT::Math::SVector<scalar_t, 3> cross(
 ///
 /// @return a vector (expression) representing the cross product
 template <concepts::scalar scalar_t, class A>
-ALGEBRA_HOST inline ROOT::Math::SVector<scalar_t, 3> cross(
+ALGEBRA_HOST constexpr ROOT::Math::SVector<scalar_t, 3> cross(
     const ROOT::Math::SVector<scalar_t, 3> &a,
     const ROOT::Math::VecExpr<A, scalar_t, 3> &b) {
 
@@ -264,7 +272,7 @@ ALGEBRA_HOST inline ROOT::Math::SVector<scalar_t, 3> cross(
 ///
 /// @return a vector (expression) representing the cross product
 template <concepts::scalar scalar_t, class A>
-ALGEBRA_HOST inline ROOT::Math::SVector<scalar_t, 3> cross(
+ALGEBRA_HOST constexpr ROOT::Math::SVector<scalar_t, 3> cross(
     const ROOT::Math::VecExpr<A, scalar_t, 3> &a,
     const ROOT::Math::SVector<scalar_t, 3> &b) {
 
@@ -278,7 +286,7 @@ ALGEBRA_HOST inline ROOT::Math::SVector<scalar_t, 3> cross(
 ///
 /// @return a vector (expression) representing the cross product
 template <concepts::scalar scalar_t, class A>
-ALGEBRA_HOST inline ROOT::Math::SVector<scalar_t, 3> cross(
+ALGEBRA_HOST constexpr ROOT::Math::SVector<scalar_t, 3> cross(
     const ROOT::Math::VecExpr<A, scalar_t, 3> &a,
     const ROOT::Math::VecExpr<A, scalar_t, 3> &b) {
 
@@ -292,7 +300,7 @@ ALGEBRA_HOST inline ROOT::Math::SVector<scalar_t, 3> cross(
 ///
 /// @return a vector (expression) representing the cross product
 template <concepts::scalar scalar_t>
-ALGEBRA_HOST inline ROOT::Math::SVector<scalar_t, 3> cross(
+ALGEBRA_HOST constexpr ROOT::Math::SVector<scalar_t, 3> cross(
     const ROOT::Math::SVector<scalar_t, 3> &a,
     const ROOT::Math::SMatrix<scalar_t, 3, 1> &b) {
 
@@ -306,7 +314,7 @@ ALGEBRA_HOST inline ROOT::Math::SVector<scalar_t, 3> cross(
 ///
 /// @return a vector (expression) representing the cross product
 template <concepts::scalar scalar_t>
-ALGEBRA_HOST inline ROOT::Math::SVector<scalar_t, 3> cross(
+ALGEBRA_HOST constexpr ROOT::Math::SVector<scalar_t, 3> cross(
     const ROOT::Math::SMatrix<scalar_t, 3, 1> &a,
     const ROOT::Math::SVector<scalar_t, 3> &b) {
 
@@ -320,7 +328,7 @@ ALGEBRA_HOST inline ROOT::Math::SVector<scalar_t, 3> cross(
 ///
 /// @return a vector (expression) representing the cross product
 template <concepts::scalar scalar_t>
-ALGEBRA_HOST inline ROOT::Math::SVector<scalar_t, 3> cross(
+ALGEBRA_HOST constexpr ROOT::Math::SVector<scalar_t, 3> cross(
     const ROOT::Math::SMatrix<scalar_t, 3, 1> &a,
     const ROOT::Math::SMatrix<scalar_t, 3, 1> &b) {
 

--- a/math/vc_aos/include/algebra/math/impl/vc_aos_transform3.hpp
+++ b/math/vc_aos/include/algebra/math/impl/vc_aos_transform3.hpp
@@ -156,11 +156,11 @@ struct transform3 {
 
   /// Matrix access operator
   ALGEBRA_HOST_DEVICE
-  inline const scalar_type &operator()(std::size_t row, std::size_t col) const {
+  constexpr const scalar_type &operator()(std::size_t row, std::size_t col) const {
     return _data[col][row];
   }
   ALGEBRA_HOST_DEVICE
-  inline scalar_type &operator()(std::size_t row, std::size_t col) {
+  constexpr scalar_type &operator()(std::size_t row, std::size_t col) {
     return _data[col][row];
   }
 
@@ -235,7 +235,7 @@ struct transform3 {
 
   /// This method retrieves the rotation of a transform
   ALGEBRA_HOST_DEVICE
-  inline auto rotation() const {
+  constexpr auto rotation() const {
 
     using matrix_t = storage::matrix<array_t, scalar_type, 3u, 3u>;
 
@@ -248,27 +248,27 @@ struct transform3 {
 
   /// This method retrieves the new x-axis
   ALGEBRA_HOST_DEVICE
-  inline const auto &x() const { return _data[e_x]; }
+  constexpr const auto &x() const { return _data[e_x]; }
 
   /// This method retrieves the new y-axis
   ALGEBRA_HOST_DEVICE
-  inline const auto &y() const { return _data[e_y]; }
+  constexpr const auto &y() const { return _data[e_y]; }
 
   /// This method retrieves the new z-axis
   ALGEBRA_HOST_DEVICE
-  inline const auto &z() const { return _data[e_z]; }
+  constexpr const auto &z() const { return _data[e_z]; }
 
   /// This method retrieves the translation
   ALGEBRA_HOST_DEVICE
-  inline const auto &translation() const { return _data[e_t]; }
+  constexpr const auto &translation() const { return _data[e_t]; }
 
   /// This method retrieves the 4x4 matrix of a transform
   ALGEBRA_HOST_DEVICE
-  inline const matrix44 &matrix() const { return _data; }
+  constexpr const matrix44 &matrix() const { return _data; }
 
   /// This method retrieves the 4x4 matrix of an inverse transform
   ALGEBRA_HOST_DEVICE
-  inline const matrix44 &matrix_inverse() const { return _data_inv; }
+  constexpr const matrix44 &matrix_inverse() const { return _data_inv; }
 
   /// This method transform from a point from the local 3D cartesian frame
   ///  to the global 3D cartesian frame
@@ -279,8 +279,7 @@ struct transform3 {
   ///
   /// @return a global point
   template <concepts::point3D point3_type>
-  ALGEBRA_HOST_DEVICE inline auto point_to_global(const point3_type &p) const {
-
+  ALGEBRA_HOST_DEVICE constexpr auto point_to_global(const point3_type &p) const {
     return rotate(_data, p) + _data[e_t];
   }
 
@@ -293,8 +292,7 @@ struct transform3 {
   ///
   /// @return a local point
   template <concepts::point3D point3_type>
-  ALGEBRA_HOST_DEVICE inline auto point_to_local(const point3_type &p) const {
-
+  ALGEBRA_HOST_DEVICE constexpr auto point_to_local(const point3_type &p) const {
     return rotate(_data_inv, p) + _data_inv[e_t];
   }
 
@@ -307,9 +305,8 @@ struct transform3 {
   ///
   /// @return a vector in global coordinates
   template <concepts::vector3D vector3_type>
-  ALGEBRA_HOST_DEVICE inline auto vector_to_global(
+  ALGEBRA_HOST_DEVICE constexpr auto vector_to_global(
       const vector3_type &v) const {
-
     return rotate(_data, v);
   }
 
@@ -322,8 +319,7 @@ struct transform3 {
   ///
   /// @return a vector in global coordinates
   template <concepts::vector3D vector3_type>
-  ALGEBRA_HOST_DEVICE inline auto vector_to_local(const vector3_type &v) const {
-
+  ALGEBRA_HOST_DEVICE constexpr auto vector_to_local(const vector3_type &v) const {
     return rotate(_data_inv, v);
   }
 };  // struct transform3

--- a/math/vc_aos/include/algebra/math/impl/vc_aos_transform3.hpp
+++ b/math/vc_aos/include/algebra/math/impl/vc_aos_transform3.hpp
@@ -156,7 +156,8 @@ struct transform3 {
 
   /// Matrix access operator
   ALGEBRA_HOST_DEVICE
-  constexpr const scalar_type &operator()(std::size_t row, std::size_t col) const {
+  constexpr const scalar_type &operator()(std::size_t row,
+                                          std::size_t col) const {
     return _data[col][row];
   }
   ALGEBRA_HOST_DEVICE
@@ -279,7 +280,8 @@ struct transform3 {
   ///
   /// @return a global point
   template <concepts::point3D point3_type>
-  ALGEBRA_HOST_DEVICE constexpr auto point_to_global(const point3_type &p) const {
+  ALGEBRA_HOST_DEVICE constexpr auto point_to_global(
+      const point3_type &p) const {
     return rotate(_data, p) + _data[e_t];
   }
 
@@ -292,7 +294,8 @@ struct transform3 {
   ///
   /// @return a local point
   template <concepts::point3D point3_type>
-  ALGEBRA_HOST_DEVICE constexpr auto point_to_local(const point3_type &p) const {
+  ALGEBRA_HOST_DEVICE constexpr auto point_to_local(
+      const point3_type &p) const {
     return rotate(_data_inv, p) + _data_inv[e_t];
   }
 
@@ -319,7 +322,8 @@ struct transform3 {
   ///
   /// @return a vector in global coordinates
   template <concepts::vector3D vector3_type>
-  ALGEBRA_HOST_DEVICE constexpr auto vector_to_local(const vector3_type &v) const {
+  ALGEBRA_HOST_DEVICE constexpr auto vector_to_local(
+      const vector3_type &v) const {
     return rotate(_data_inv, v);
   }
 };  // struct transform3

--- a/math/vc_aos/include/algebra/math/impl/vc_aos_vector.hpp
+++ b/math/vc_aos/include/algebra/math/impl/vc_aos_vector.hpp
@@ -31,19 +31,19 @@ namespace algebra::vc_aos::math {
 
 /// This method retrieves phi from a vector @param v
 template <algebra::concepts::vc_aos_vector vector_t>
-ALGEBRA_HOST_DEVICE inline auto phi(const vector_t &v) {
+ALGEBRA_HOST_DEVICE constexpr auto phi(const vector_t &v) {
   return algebra::math::atan2(v[1], v[0]);
 }
 
 /// This method retrieves the perpendicular magnitude of a vector @param v
 template <algebra::concepts::vc_aos_vector vector_t>
-ALGEBRA_HOST_DEVICE inline auto perp(const vector_t &v) {
+ALGEBRA_HOST_DEVICE constexpr auto perp(const vector_t &v) {
   return algebra::math::sqrt(algebra::math::fma(v[0], v[0], v[1] * v[1]));
 }
 
 /// This method retrieves theta from a vector @param v
 template <algebra::concepts::vc_aos_vector vector_t>
-ALGEBRA_HOST_DEVICE inline auto theta(const vector_t &v) {
+ALGEBRA_HOST_DEVICE constexpr auto theta(const vector_t &v) {
   return algebra::math::atan2(perp(v), v[2]);
 }
 
@@ -57,7 +57,7 @@ ALGEBRA_HOST_DEVICE inline auto theta(const vector_t &v) {
 /// @return the scalar dot product value
 template <algebra::concepts::vc_aos_vector vector_t1,
           algebra::concepts::vc_aos_vector vector_t2>
-ALGEBRA_HOST_DEVICE inline auto dot(const vector_t1 &a, const vector_t2 &b) {
+ALGEBRA_HOST_DEVICE constexpr auto dot(const vector_t1 &a, const vector_t2 &b) {
 
   return (a * b).sum();
 }
@@ -66,7 +66,7 @@ ALGEBRA_HOST_DEVICE inline auto dot(const vector_t1 &a, const vector_t2 &b) {
 ///
 /// @param v the input vector
 template <algebra::concepts::vc_aos_vector vector_t>
-ALGEBRA_HOST_DEVICE inline auto norm(const vector_t &v) {
+ALGEBRA_HOST_DEVICE constexpr auto norm(const vector_t &v) {
 
   return algebra::math::sqrt(dot(v, v));
 }
@@ -77,7 +77,7 @@ ALGEBRA_HOST_DEVICE inline auto norm(const vector_t &v) {
 ///
 /// @param v the input vector
 template <algebra::concepts::vc_aos_vector vector_t>
-ALGEBRA_HOST_DEVICE inline auto normalize(const vector_t &v) {
+ALGEBRA_HOST_DEVICE constexpr auto normalize(const vector_t &v) {
 
   return v / norm(v);
 }
@@ -87,7 +87,7 @@ ALGEBRA_HOST_DEVICE inline auto normalize(const vector_t &v) {
 ///
 /// @param v the input vector
 template <algebra::concepts::vc_aos_vector vector_t>
-ALGEBRA_HOST_DEVICE inline auto eta(const vector_t &v) noexcept {
+ALGEBRA_HOST_DEVICE constexpr auto eta(const vector_t &v) noexcept {
 
   return algebra::math::atanh(v[2] / norm(v));
 }
@@ -102,7 +102,7 @@ ALGEBRA_HOST_DEVICE inline auto eta(const vector_t &v) noexcept {
 /// @return a vector representing the cross product
 template <algebra::concepts::vc_aos_vector vector_t1,
           algebra::concepts::vc_aos_vector vector_t2>
-ALGEBRA_HOST_DEVICE inline auto cross(const vector_t1 &a, const vector_t2 &b)
+ALGEBRA_HOST_DEVICE constexpr auto cross(const vector_t1 &a, const vector_t2 &b)
     -> decltype(a * b - b * a) {
 
   return {algebra::math::fma(a[1], b[2], -b[1] * a[2]),
@@ -118,7 +118,7 @@ ALGEBRA_HOST_DEVICE inline auto cross(const vector_t1 &a, const vector_t2 &b)
 ///
 /// @return the sum of the elements
 template <algebra::concepts::vc_aos_vector vector_t>
-ALGEBRA_HOST_DEVICE inline auto sum(const vector_t &v) {
+ALGEBRA_HOST_DEVICE constexpr auto sum(const vector_t &v) {
   return v.get().sum();
 }
 

--- a/math/vc_soa/include/algebra/math/impl/vc_soa_boolean.hpp
+++ b/math/vc_soa/include/algebra/math/impl/vc_soa_boolean.hpp
@@ -31,17 +31,17 @@ using algebra::boolean::none_of;
 /// Vc overloads of boolean utilities
 /// @{
 template <typename T>
-requires Vc::Traits::is_simd_mask<T>::value inline bool any_of(T &&mask) {
+requires Vc::Traits::is_simd_mask<T>::value constexpr bool any_of(T &&mask) {
   return Vc::any_of(std::forward<T>(mask));
 }
 
 template <typename T>
-requires Vc::Traits::is_simd_mask<T>::value inline bool all_of(T &&mask) {
+requires Vc::Traits::is_simd_mask<T>::value constexpr bool all_of(T &&mask) {
   return Vc::all_of(std::forward<T>(mask));
 }
 
 template <typename T>
-requires Vc::Traits::is_simd_mask<T>::value inline bool none_of(T &&mask) {
+requires Vc::Traits::is_simd_mask<T>::value constexpr bool none_of(T &&mask) {
   return Vc::none_of(std::forward<T>(mask));
 }
 /// @}

--- a/math/vc_soa/include/algebra/math/impl/vc_soa_math.hpp
+++ b/math/vc_soa/include/algebra/math/impl/vc_soa_math.hpp
@@ -58,79 +58,79 @@ using std::tanh;
 /// Vc overloads of common math functions
 /// @{
 template <algebra::concepts::vc_simd_vector T>
-inline decltype(auto) abs(T &&vec) {
+constexpr decltype(auto) abs(T &&vec) {
   return Vc::abs(std::forward<T>(vec));
 }
 
 template <algebra::concepts::vc_simd_vector T>
-inline decltype(auto) fabs(T &&vec) {
+constexpr decltype(auto) fabs(T &&vec) {
   return Vc::abs(std::forward<T>(vec));
 }
 
 template <algebra::concepts::vc_simd_vector T>
-inline decltype(auto) sqrt(T &&vec) {
+constexpr decltype(auto) sqrt(T &&vec) {
   return Vc::sqrt(std::forward<T>(vec));
 }
 
 template <algebra::concepts::vc_simd_vector T>
-inline decltype(auto) exp(T &&vec) {
+constexpr decltype(auto) exp(T &&vec) {
   return Vc::exp(std::forward<T>(vec));
 }
 
 template <algebra::concepts::vc_simd_vector T>
-inline decltype(auto) log(T &&vec) {
+constexpr decltype(auto) log(T &&vec) {
   return Vc::log(std::forward<T>(vec));
 }
 
 template <algebra::concepts::vc_simd_vector T>
-inline decltype(auto) sin(T &&vec) {
+constexpr decltype(auto) sin(T &&vec) {
   return Vc::sin(std::forward<T>(vec));
 }
 
 template <algebra::concepts::vc_simd_vector T>
-inline decltype(auto) asin(T &&vec) {
+constexpr decltype(auto) asin(T &&vec) {
   return Vc::asin(std::forward<T>(vec));
 }
 
 template <algebra::concepts::vc_simd_vector T>
-inline decltype(auto) cos(T &&vec) {
+constexpr decltype(auto) cos(T &&vec) {
   return Vc::cos(std::forward<T>(vec));
 }
 
 template <algebra::concepts::vc_simd_vector T>
-inline decltype(auto) tan(T &&vec) {
+constexpr decltype(auto) tan(T &&vec) {
   // It seems there is no dedicated @c Vc::tan function ?
   return Vc::sin(std::forward<T>(vec)) / Vc::cos(std::forward<T>(vec));
 }
 
 template <algebra::concepts::vc_simd_vector T>
-inline decltype(auto) atan(T &&vec) {
+constexpr decltype(auto) atan(T &&vec) {
   return Vc::atan(std::forward<T>(vec));
 }
 
 template <algebra::concepts::vc_simd_vector T,
           algebra::concepts::vc_simd_vector S>
-inline decltype(auto) copysign(T &&mag, S &&sgn) {
+constexpr decltype(auto) copysign(T &&mag, S &&sgn) {
   return Vc::copysign(std::forward<T>(mag), std::forward<S>(sgn));
 }
 
 template <algebra::concepts::vc_simd_vector T>
-inline decltype(auto) min(T &&vec) {
+constexpr decltype(auto) min(T &&vec) {
   return Vc::min(std::forward<T>(vec));
 }
 
 template <algebra::concepts::vc_simd_vector T>
-inline decltype(auto) max(T &&vec) {
+constexpr decltype(auto) max(T &&vec) {
   return Vc::max(std::forward<T>(vec));
 }
 
 template <algebra::concepts::vc_simd_vector T>
-inline decltype(auto) signbit(T &&vec) {
+constexpr decltype(auto) signbit(T &&vec) {
   return Vc::isnegative(std::forward<T>(vec));
 }
 
 template <algebra::concepts::vc_simd_vector T>
-inline decltype(auto) fma(T &&x, T &&y, T &&z) {
+constexpr decltype(auto) fma(T &&x, T &&y, T &&z) {
   return Vc::fma(std::forward<T>(x), std::forward<T>(y), std::forward<T>(z));
 }
 /// @}

--- a/math/vc_soa/include/algebra/math/impl/vc_soa_matrix.hpp
+++ b/math/vc_soa/include/algebra/math/impl/vc_soa_matrix.hpp
@@ -24,7 +24,7 @@ using storage::zero;
 template <std::size_t ROW, std::size_t COL, concepts::simd_scalar scalar_t,
           template <typename, std::size_t> class array_t>
 ALGEBRA_HOST_DEVICE constexpr scalar_t determinant(
-    const storage::matrix<array_t, scalar_t, ROW, COL> &m) noexcept {
+    const storage::matrix<array_t, scalar_t, ROW, COL> &) noexcept {
   // @TODO: Implement
   return scalar_t(0);
 }

--- a/math/vc_soa/include/algebra/math/impl/vc_soa_matrix.hpp
+++ b/math/vc_soa/include/algebra/math/impl/vc_soa_matrix.hpp
@@ -21,18 +21,18 @@ using storage::set_zero;
 using storage::transpose;
 using storage::zero;
 
-template <std::size_t ROW, std::size_t COL, concepts::value value_t,
+template <std::size_t ROW, std::size_t COL, concepts::simd_scalar scalar_t,
           template <typename, std::size_t> class array_t>
-ALGEBRA_HOST_DEVICE constexpr value_t determinant(
-    const storage::matrix<array_t, value_t, ROW, COL> &) noexcept {
+ALGEBRA_HOST_DEVICE constexpr scalar_t determinant(
+    const storage::matrix<array_t, scalar_t, ROW, COL> &m) noexcept {
   // @TODO: Implement
-  return value_t(0);
+  return scalar_t(0);
 }
 
-template <std::size_t ROW, std::size_t COL, concepts::value value_t,
+template <std::size_t ROW, std::size_t COL, concepts::simd_scalar scalar_t,
           template <typename, std::size_t> class array_t>
-ALGEBRA_HOST_DEVICE constexpr storage::matrix<array_t, value_t, ROW, COL>
-inverse(const storage::matrix<array_t, value_t, ROW, COL> &m) noexcept {
+ALGEBRA_HOST_DEVICE constexpr storage::matrix<array_t, scalar_t, ROW, COL>
+inverse(const storage::matrix<array_t, scalar_t, ROW, COL> &m) noexcept {
   // @TODO: Implement
   return m;
 }

--- a/math/vc_soa/include/algebra/math/impl/vc_soa_vector.hpp
+++ b/math/vc_soa/include/algebra/math/impl/vc_soa_vector.hpp
@@ -33,8 +33,8 @@ namespace algebra::vc_soa::math {
 /// @param v the input vector
 template <std::size_t N, concepts::value value_t,
           template <typename, std::size_t> class array_t>
-requires(N >= 2) ALGEBRA_HOST_DEVICE
-    constexpr auto phi(const storage::vector<N, Vc::Vector<value_t>, array_t> &v) {
+requires(N >= 2) ALGEBRA_HOST_DEVICE constexpr auto phi(
+    const storage::vector<N, Vc::Vector<value_t>, array_t> &v) {
 
   return Vc::atan2(v[1], v[0]);
 }
@@ -161,8 +161,8 @@ normalize(const storage::vector<N, Vc::Vector<value_t>, array_t> &v) {
 /// @param v the input vector
 template <std::size_t N, concepts::value value_t,
           template <typename, std::size_t> class array_t>
-requires(N >= 3) ALGEBRA_HOST_DEVICE
-    constexpr auto eta(const storage::vector<N, Vc::Vector<value_t>, array_t> &v) {
+requires(N >= 3) ALGEBRA_HOST_DEVICE constexpr auto eta(
+    const storage::vector<N, Vc::Vector<value_t>, array_t> &v) {
 
   // atanh does not exist in Vc
   auto atanh_func = [](value_t e) { return std::atanh(e); };

--- a/math/vc_soa/include/algebra/math/impl/vc_soa_vector.hpp
+++ b/math/vc_soa/include/algebra/math/impl/vc_soa_vector.hpp
@@ -34,7 +34,7 @@ namespace algebra::vc_soa::math {
 template <std::size_t N, concepts::value value_t,
           template <typename, std::size_t> class array_t>
 requires(N >= 2) ALGEBRA_HOST_DEVICE
-    inline auto phi(const storage::vector<N, Vc::Vector<value_t>, array_t> &v) {
+    constexpr auto phi(const storage::vector<N, Vc::Vector<value_t>, array_t> &v) {
 
   return Vc::atan2(v[1], v[0]);
 }
@@ -48,7 +48,7 @@ requires(N >= 2) ALGEBRA_HOST_DEVICE
 /// @param v the input vector
 template <std::size_t N, concepts::value value_t,
           template <typename, std::size_t> class array_t>
-requires(N >= 2) ALGEBRA_HOST_DEVICE inline auto perp(
+requires(N >= 2) ALGEBRA_HOST_DEVICE constexpr auto perp(
     const storage::vector<N, Vc::Vector<value_t>, array_t> &v) {
 
   return Vc::sqrt(Vc::fma(v[0], v[0], v[1] * v[1]));
@@ -63,7 +63,7 @@ requires(N >= 2) ALGEBRA_HOST_DEVICE inline auto perp(
 /// @param v the input vector
 template <std::size_t N, concepts::value value_t,
           template <typename, std::size_t> class array_t>
-requires(N >= 3) ALGEBRA_HOST_DEVICE inline auto theta(
+requires(N >= 3) ALGEBRA_HOST_DEVICE constexpr auto theta(
     const storage::vector<N, Vc::Vector<value_t>, array_t> &v) {
 
   return Vc::atan2(perp(v), v[2]);
@@ -82,7 +82,7 @@ requires(N >= 3) ALGEBRA_HOST_DEVICE inline auto theta(
 template <std::size_t N, concepts::value value_t,
           template <typename, std::size_t> class array_t>
 requires(N == 3) ALGEBRA_HOST_DEVICE
-    inline storage::vector<N, Vc::Vector<value_t>, array_t> cross(
+    constexpr storage::vector<N, Vc::Vector<value_t>, array_t> cross(
         const storage::vector<N, Vc::Vector<value_t>, array_t> &a,
         const storage::vector<N, Vc::Vector<value_t>, array_t> &b) {
 
@@ -102,7 +102,7 @@ requires(N == 3) ALGEBRA_HOST_DEVICE
 /// @return the scalar dot product value
 template <std::size_t N, concepts::value value_t,
           template <typename, std::size_t> class array_t>
-ALGEBRA_HOST_DEVICE inline Vc::Vector<value_t> dot(
+ALGEBRA_HOST_DEVICE constexpr Vc::Vector<value_t> dot(
     const storage::vector<N, Vc::Vector<value_t>, array_t> &a,
     const storage::vector<N, Vc::Vector<value_t>, array_t> &b) {
 
@@ -124,7 +124,7 @@ ALGEBRA_HOST_DEVICE inline Vc::Vector<value_t> dot(
 /// @param v the input vector
 template <std::size_t N, concepts::value value_t,
           template <typename, std::size_t> class array_t>
-ALGEBRA_HOST_DEVICE inline auto norm(
+ALGEBRA_HOST_DEVICE constexpr auto norm(
     const storage::vector<N, Vc::Vector<value_t>, array_t> &v) {
 
   return Vc::sqrt(dot(v, v));
@@ -139,7 +139,7 @@ ALGEBRA_HOST_DEVICE inline auto norm(
 /// @param v the input vector
 template <std::size_t N, concepts::value value_t,
           template <typename, std::size_t> class array_t>
-ALGEBRA_HOST_DEVICE inline storage::vector<N, Vc::Vector<value_t>, array_t>
+ALGEBRA_HOST_DEVICE constexpr storage::vector<N, Vc::Vector<value_t>, array_t>
 normalize(const storage::vector<N, Vc::Vector<value_t>, array_t> &v) {
 
   return (Vc::Vector<value_t>::One() / norm(v)) * v;
@@ -162,7 +162,7 @@ normalize(const storage::vector<N, Vc::Vector<value_t>, array_t> &v) {
 template <std::size_t N, concepts::value value_t,
           template <typename, std::size_t> class array_t>
 requires(N >= 3) ALGEBRA_HOST_DEVICE
-    inline auto eta(const storage::vector<N, Vc::Vector<value_t>, array_t> &v) {
+    constexpr auto eta(const storage::vector<N, Vc::Vector<value_t>, array_t> &v) {
 
   // atanh does not exist in Vc
   auto atanh_func = [](value_t e) { return std::atanh(e); };
@@ -187,7 +187,7 @@ requires(N >= 3) ALGEBRA_HOST_DEVICE
 /// @return the sum of the elements
 template <std::size_t N, concepts::value value_t,
           template <typename, std::size_t> class array_t>
-ALGEBRA_HOST_DEVICE inline Vc::Vector<value_t> sum(
+ALGEBRA_HOST_DEVICE constexpr Vc::Vector<value_t> sum(
     const storage::vector<N, Vc::Vector<value_t>, array_t> &v) {
 
   Vc::Vector<value_t> res{v[0]};

--- a/storage/cmath/include/algebra/storage/impl/cmath_getter.hpp
+++ b/storage/cmath/include/algebra/storage/impl/cmath_getter.hpp
@@ -25,7 +25,7 @@ struct element_getter {
   /// Operator getting a reference to one element of a non-const matrix
   template <std::size_t ROWS, std::size_t COLS, concepts::scalar scalar_t,
             template <typename, std::size_t> class array_t>
-  ALGEBRA_HOST_DEVICE inline scalar_t &operator()(
+  ALGEBRA_HOST_DEVICE constexpr scalar_t &operator()(
       array_t<array_t<scalar_t, ROWS>, COLS> &m, std::size_t row,
       std::size_t col) const {
 
@@ -37,7 +37,7 @@ struct element_getter {
   /// Operator getting one value of a const matrix
   template <std::size_t ROWS, std::size_t COLS, concepts::scalar scalar_t,
             template <typename, std::size_t> class array_t>
-  ALGEBRA_HOST_DEVICE inline scalar_t operator()(
+  ALGEBRA_HOST_DEVICE constexpr scalar_t operator()(
       const array_t<array_t<scalar_t, ROWS>, COLS> &m, std::size_t row,
       std::size_t col) const {
 
@@ -49,7 +49,7 @@ struct element_getter {
   /// Operator getting a reference to one element of a non-const matrix
   template <std::size_t N, concepts::scalar scalar_t,
             template <typename, std::size_t> class array_t>
-  ALGEBRA_HOST_DEVICE inline scalar_t &operator()(
+  ALGEBRA_HOST_DEVICE constexpr scalar_t &operator()(
       array_t<array_t<scalar_t, N>, 1> &m, std::size_t row) const {
 
     assert(row < N);
@@ -59,7 +59,7 @@ struct element_getter {
   /// Operator getting a reference to one element of a const matrix
   template <std::size_t N, concepts::scalar scalar_t,
             template <typename, std::size_t> class array_t>
-  ALGEBRA_HOST_DEVICE inline scalar_t operator()(
+  ALGEBRA_HOST_DEVICE constexpr scalar_t operator()(
       const array_t<array_t<scalar_t, N>, 1> &m, std::size_t row) const {
 
     assert(row < N);
@@ -69,7 +69,7 @@ struct element_getter {
   /// Operator getting a reference to one element of a non-const matrix
   template <std::size_t N, concepts::scalar scalar_t,
             template <typename, std::size_t> class array_t>
-  ALGEBRA_HOST_DEVICE inline scalar_t &operator()(array_t<scalar_t, N> &m,
+  ALGEBRA_HOST_DEVICE constexpr scalar_t &operator()(array_t<scalar_t, N> &m,
                                                   std::size_t row) const {
 
     assert(row < N);
@@ -79,7 +79,7 @@ struct element_getter {
   /// Operator getting a reference to one element of a const matrix
   template <std::size_t N, concepts::scalar scalar_t,
             template <typename, std::size_t> class array_t>
-  ALGEBRA_HOST_DEVICE inline scalar_t operator()(const array_t<scalar_t, N> &m,
+  ALGEBRA_HOST_DEVICE constexpr scalar_t operator()(const array_t<scalar_t, N> &m,
                                                  std::size_t row) const {
 
     assert(row < N);
@@ -91,7 +91,7 @@ struct element_getter {
 /// Function extracting an element from a matrix (const)
 template <template <typename, std::size_t> class array_t,
           concepts::scalar scalar_t, std::size_t ROWS, std::size_t COLS>
-ALGEBRA_HOST_DEVICE inline scalar_t element(
+ALGEBRA_HOST_DEVICE constexpr scalar_t element(
     const array_t<array_t<scalar_t, ROWS>, COLS> &m, std::size_t row,
     std::size_t col) {
 
@@ -101,7 +101,7 @@ ALGEBRA_HOST_DEVICE inline scalar_t element(
 /// Function extracting an element from a matrix (non-const)
 template <template <typename, std::size_t> class array_t,
           concepts::scalar scalar_t, std::size_t ROWS, std::size_t COLS>
-ALGEBRA_HOST_DEVICE inline scalar_t &element(
+ALGEBRA_HOST_DEVICE constexpr scalar_t &element(
     array_t<array_t<scalar_t, ROWS>, COLS> &m, std::size_t row,
     std::size_t col) {
 
@@ -111,7 +111,7 @@ ALGEBRA_HOST_DEVICE inline scalar_t &element(
 /// Function extracting an element from a matrix (const)
 template <template <typename, std::size_t> class array_t,
           concepts::scalar scalar_t, std::size_t N>
-ALGEBRA_HOST_DEVICE inline scalar_t element(
+ALGEBRA_HOST_DEVICE constexpr scalar_t element(
     const array_t<array_t<scalar_t, N>, 1> &m, std::size_t row) {
 
   return element_getter()(m, row);
@@ -120,7 +120,7 @@ ALGEBRA_HOST_DEVICE inline scalar_t element(
 /// Function extracting an element from a matrix (non-const)
 template <template <typename, std::size_t> class array_t,
           concepts::scalar scalar_t, std::size_t N>
-ALGEBRA_HOST_DEVICE inline scalar_t &element(
+ALGEBRA_HOST_DEVICE constexpr scalar_t &element(
     array_t<array_t<scalar_t, N>, 1> &m, std::size_t row) {
 
   return element_getter()(m, row);
@@ -129,7 +129,7 @@ ALGEBRA_HOST_DEVICE inline scalar_t &element(
 /// Function extracting an element from a vector (const)
 template <template <typename, std::size_t> class array_t,
           concepts::scalar scalar_t, std::size_t N>
-ALGEBRA_HOST_DEVICE inline scalar_t element(const array_t<scalar_t, N> &v,
+ALGEBRA_HOST_DEVICE constexpr scalar_t element(const array_t<scalar_t, N> &v,
                                             std::size_t row) {
 
   return element_getter()(v, row);
@@ -138,7 +138,7 @@ ALGEBRA_HOST_DEVICE inline scalar_t element(const array_t<scalar_t, N> &v,
 /// Function extracting an element from a vector (non-const)
 template <template <typename, std::size_t> class array_t,
           concepts::scalar scalar_t, std::size_t N>
-ALGEBRA_HOST_DEVICE inline scalar_t &element(array_t<scalar_t, N> &v,
+ALGEBRA_HOST_DEVICE constexpr scalar_t &element(array_t<scalar_t, N> &v,
                                              std::size_t row) {
 
   return element_getter()(v, row);
@@ -151,7 +151,7 @@ struct block_getter {
   template <std::size_t ROWS, std::size_t COLS, std::size_t oROWS,
             std::size_t oCOLS, concepts::scalar scalar_t,
             template <typename, std::size_t> class array_t>
-  ALGEBRA_HOST_DEVICE auto operator()(
+  ALGEBRA_HOST_DEVICE constexpr auto operator()(
       const array_t<array_t<scalar_t, oROWS>, oCOLS> &m, std::size_t row,
       std::size_t col) const {
 
@@ -169,7 +169,7 @@ struct block_getter {
   template <std::size_t SIZE, std::size_t ROWS, std::size_t COLS,
             concepts::scalar scalar_t,
             template <typename, std::size_t> class array_t>
-  ALGEBRA_HOST_DEVICE inline array_t<scalar_t, SIZE> vector(
+  ALGEBRA_HOST_DEVICE constexpr array_t<scalar_t, SIZE> vector(
       const array_t<array_t<scalar_t, ROWS>, COLS> &m, std::size_t row,
       std::size_t col) {
 
@@ -190,7 +190,7 @@ struct block_getter {
 /// the submatrix of @param m beginning at row @param row and column
 /// @param col
 template <std::size_t ROWS, std::size_t COLS, class input_matrix_type>
-ALGEBRA_HOST_DEVICE decltype(auto) block(const input_matrix_type &m,
+ALGEBRA_HOST_DEVICE constexpr decltype(auto) block(const input_matrix_type &m,
                                          std::size_t row, std::size_t col) {
 
   return block_getter().template operator()<ROWS, COLS>(m, row, col);
@@ -200,7 +200,7 @@ ALGEBRA_HOST_DEVICE decltype(auto) block(const input_matrix_type &m,
 template <std::size_t SIZE, std::size_t ROWS, std::size_t COLS,
           concepts::scalar scalar_t,
           template <typename, std::size_t> class array_t>
-ALGEBRA_HOST_DEVICE inline array_t<scalar_t, SIZE> vector(
+ALGEBRA_HOST_DEVICE constexpr array_t<scalar_t, SIZE> vector(
     const array_t<array_t<scalar_t, ROWS>, COLS> &m, std::size_t row,
     std::size_t col) {
 
@@ -212,7 +212,7 @@ ALGEBRA_HOST_DEVICE inline array_t<scalar_t, SIZE> vector(
 template <std::size_t ROWS, std::size_t COLS, class input_matrix_type,
           concepts::scalar scalar_t,
           template <typename, std::size_t> class array_t>
-ALGEBRA_HOST_DEVICE void set_block(
+ALGEBRA_HOST_DEVICE constexpr void set_block(
     input_matrix_type &m, const array_t<array_t<scalar_t, ROWS>, COLS> &b,
     std::size_t row, std::size_t col) {
   for (std::size_t j = 0u; j < COLS; ++j) {
@@ -227,7 +227,7 @@ ALGEBRA_HOST_DEVICE void set_block(
 template <std::size_t ROWS, concepts::scalar scalar_t,
           template <typename, std::size_t> class vector_t,
           class input_matrix_type>
-ALGEBRA_HOST_DEVICE void set_block(input_matrix_type &m,
+ALGEBRA_HOST_DEVICE constexpr void set_block(input_matrix_type &m,
                                    const vector_t<scalar_t, ROWS> &b,
                                    std::size_t row, std::size_t col) {
   for (std::size_t i = 0; i < ROWS; ++i) {

--- a/storage/cmath/include/algebra/storage/impl/cmath_getter.hpp
+++ b/storage/cmath/include/algebra/storage/impl/cmath_getter.hpp
@@ -70,7 +70,7 @@ struct element_getter {
   template <std::size_t N, concepts::scalar scalar_t,
             template <typename, std::size_t> class array_t>
   ALGEBRA_HOST_DEVICE constexpr scalar_t &operator()(array_t<scalar_t, N> &m,
-                                                  std::size_t row) const {
+                                                     std::size_t row) const {
 
     assert(row < N);
     return m[row];
@@ -79,8 +79,8 @@ struct element_getter {
   /// Operator getting a reference to one element of a const matrix
   template <std::size_t N, concepts::scalar scalar_t,
             template <typename, std::size_t> class array_t>
-  ALGEBRA_HOST_DEVICE constexpr scalar_t operator()(const array_t<scalar_t, N> &m,
-                                                 std::size_t row) const {
+  ALGEBRA_HOST_DEVICE constexpr scalar_t operator()(
+      const array_t<scalar_t, N> &m, std::size_t row) const {
 
     assert(row < N);
     return m[row];
@@ -130,7 +130,7 @@ ALGEBRA_HOST_DEVICE constexpr scalar_t &element(
 template <template <typename, std::size_t> class array_t,
           concepts::scalar scalar_t, std::size_t N>
 ALGEBRA_HOST_DEVICE constexpr scalar_t element(const array_t<scalar_t, N> &v,
-                                            std::size_t row) {
+                                               std::size_t row) {
 
   return element_getter()(v, row);
 }
@@ -139,7 +139,7 @@ ALGEBRA_HOST_DEVICE constexpr scalar_t element(const array_t<scalar_t, N> &v,
 template <template <typename, std::size_t> class array_t,
           concepts::scalar scalar_t, std::size_t N>
 ALGEBRA_HOST_DEVICE constexpr scalar_t &element(array_t<scalar_t, N> &v,
-                                             std::size_t row) {
+                                                std::size_t row) {
 
   return element_getter()(v, row);
 }
@@ -191,7 +191,8 @@ struct block_getter {
 /// @param col
 template <std::size_t ROWS, std::size_t COLS, class input_matrix_type>
 ALGEBRA_HOST_DEVICE constexpr decltype(auto) block(const input_matrix_type &m,
-                                         std::size_t row, std::size_t col) {
+                                                   std::size_t row,
+                                                   std::size_t col) {
 
   return block_getter().template operator()<ROWS, COLS>(m, row, col);
 }
@@ -228,8 +229,8 @@ template <std::size_t ROWS, concepts::scalar scalar_t,
           template <typename, std::size_t> class vector_t,
           class input_matrix_type>
 ALGEBRA_HOST_DEVICE constexpr void set_block(input_matrix_type &m,
-                                   const vector_t<scalar_t, ROWS> &b,
-                                   std::size_t row, std::size_t col) {
+                                             const vector_t<scalar_t, ROWS> &b,
+                                             std::size_t row, std::size_t col) {
   for (std::size_t i = 0; i < ROWS; ++i) {
     m[col][i + row] = b[i];
   }

--- a/storage/common/include/algebra/storage/matrix.hpp
+++ b/storage/common/include/algebra/storage/matrix.hpp
@@ -153,7 +153,8 @@ ALGEBRA_HOST_DEVICE constexpr void set_zero(matrix_t &m) noexcept {
 }
 
 /// Build an identity matrix
-template <concepts::matrix matrix_t, std::size_t R =algebra::traits::rank<matrix_t>>
+template <concepts::matrix matrix_t,
+          std::size_t R = algebra::traits::rank<matrix_t>>
 ALGEBRA_HOST_DEVICE constexpr matrix_t identity() noexcept {
 
   // Zero initialized

--- a/storage/common/include/algebra/storage/matrix.hpp
+++ b/storage/common/include/algebra/storage/matrix.hpp
@@ -20,7 +20,7 @@ namespace algebra::storage {
 /// Generic matrix type that can take vectors as columns
 template <template <typename, std::size_t> class array_t,
           concepts::scalar scalar_t, std::size_t ROW, std::size_t COL>
-struct alignas(alignof(storage::vector<ROW, scalar_t, array_t>)) matrix {
+struct ALGEBRA_ALIGN(alignof(storage::vector<ROW, scalar_t, array_t>)) matrix {
 
   // The matrix consists of column vectors
   using vector_type = storage::vector<ROW, scalar_t, array_t>;
@@ -132,12 +132,13 @@ struct alignas(alignof(storage::vector<ROW, scalar_t, array_t>)) matrix {
 };  // struct matrix
 
 /// Get a zero-initialized matrix
-template <concepts::matrix matrix_t>
+template <concepts::matrix matrix_t, std::size_t COLS = matrix_t::columns()>
 ALGEBRA_HOST_DEVICE constexpr matrix_t zero() noexcept {
 
   matrix_t m;
 
-  for (std::size_t j = 0u; j < matrix_t::columns(); ++j) {
+  ALGEBRA_UNROLL_N(COLS)
+  for (std::size_t j = 0u; j < COLS; ++j) {
     // Fill zero initialized vector
     m[j] = typename matrix_t::vector_type{};
   }
@@ -152,13 +153,14 @@ ALGEBRA_HOST_DEVICE constexpr void set_zero(matrix_t &m) noexcept {
 }
 
 /// Build an identity matrix
-template <concepts::matrix matrix_t>
+template <concepts::matrix matrix_t, std::size_t R =algebra::traits::rank<matrix_t>>
 ALGEBRA_HOST_DEVICE constexpr matrix_t identity() noexcept {
 
   // Zero initialized
   matrix_t m{zero<matrix_t>()};
 
-  for (std::size_t i = 0u; i < algebra::traits::rank<matrix_t>; ++i) {
+  ALGEBRA_UNROLL_N(R)
+  for (std::size_t i = 0u; i < R; ++i) {
     m[i][i] = typename matrix_t::scalar_type(1);
   }
 
@@ -183,6 +185,7 @@ ALGEBRA_HOST_DEVICE constexpr auto transpose(
 
   matrix_T_t res_m;
 
+  ALGEBRA_UNROLL_N(ROW)
   for (std::size_t j = 0u; j < ROW; ++j) {
     res_m[j] = column_t{m[I][j]...};
   }
@@ -285,6 +288,7 @@ ALGEBRA_HOST_DEVICE constexpr decltype(auto) operator*(
   vector<ROW, scalar_t, array_t> res_v{v[0] * lhs[0]};
 
   // Add the rest per column
+  ALGEBRA_UNROLL_N(COL)
   for (std::size_t j = 1u; j < COL; ++j) {
     // fma
     res_v = res_v + v[j] * lhs[j];
@@ -303,11 +307,13 @@ ALGEBRA_HOST_DEVICE constexpr decltype(auto) operator*(
 
   matrix<array_t, scalar_t, LROW, RCOL> res_m;
 
+  ALGEBRA_UNROLL_N(RCOL)
   for (std::size_t j = 0u; j < RCOL; ++j) {
     // Init column j
     res_m[j] = rhs[j][0] * lhs[0];
 
     // Add the rest per column
+    ALGEBRA_UNROLL_N(COL)
     for (std::size_t i = 1u; i < COL; ++i) {
       // fma
       res_m[j] = res_m[j] + rhs[j][i] * lhs[i];

--- a/storage/common/include/algebra/storage/matrix_getter.hpp
+++ b/storage/common/include/algebra/storage/matrix_getter.hpp
@@ -22,7 +22,7 @@ struct element_getter {
   /// Get const access to a matrix element
   template <template <typename, std::size_t> class array_t,
             concepts::scalar scalar_t, std::size_t ROW, std::size_t COL>
-  ALGEBRA_HOST_DEVICE inline decltype(auto) operator()(
+  ALGEBRA_HOST_DEVICE constexpr decltype(auto) operator()(
       const matrix<array_t, scalar_t, ROW, COL> &m, std::size_t row,
       std::size_t col) const {
 
@@ -37,7 +37,7 @@ struct element_getter {
   /// Get non-const access to a matrix element
   template <template <typename, std::size_t> class array_t,
             concepts::scalar scalar_t, std::size_t ROW, std::size_t COL>
-  ALGEBRA_HOST_DEVICE inline decltype(auto) operator()(
+  ALGEBRA_HOST_DEVICE constexpr decltype(auto) operator()(
       matrix<array_t, scalar_t, ROW, COL> &m, std::size_t row,
       std::size_t col) const {
     assert(row < ROW);
@@ -49,7 +49,7 @@ struct element_getter {
   /// Get const access to a matrix element
   template <template <typename, std::size_t> class array_t,
             concepts::scalar scalar_t, std::size_t ROW>
-  ALGEBRA_HOST_DEVICE inline decltype(auto) operator()(
+  ALGEBRA_HOST_DEVICE constexpr decltype(auto) operator()(
       const matrix<array_t, scalar_t, ROW, 1> &m, std::size_t row) const {
 
     assert(row < ROW);
@@ -59,7 +59,7 @@ struct element_getter {
   /// Get non-const access to a matrix element
   template <template <typename, std::size_t> class array_t,
             concepts::scalar scalar_t, std::size_t ROW>
-  ALGEBRA_HOST_DEVICE inline decltype(auto) operator()(
+  ALGEBRA_HOST_DEVICE constexpr decltype(auto) operator()(
       matrix<array_t, scalar_t, ROW, 1> &m, std::size_t row) const {
 
     assert(row < ROW);
@@ -69,7 +69,7 @@ struct element_getter {
   /// Get const access to a vector element
   template <template <typename, std::size_t> class array_t,
             concepts::scalar scalar_t, std::size_t N>
-  ALGEBRA_HOST_DEVICE inline decltype(auto) operator()(
+  ALGEBRA_HOST_DEVICE constexpr decltype(auto) operator()(
       const vector<N, scalar_t, array_t> &v, std::size_t row) const {
 
     assert(row < N);
@@ -79,7 +79,7 @@ struct element_getter {
   /// Get non-const access to a vector element
   template <template <typename, std::size_t> class array_t,
             concepts::scalar scalar_t, std::size_t N>
-  ALGEBRA_HOST_DEVICE inline decltype(auto) operator()(
+  ALGEBRA_HOST_DEVICE constexpr decltype(auto) operator()(
       vector<N, scalar_t, array_t> &v, std::size_t row) const {
 
     assert(row < N);
@@ -91,7 +91,7 @@ struct element_getter {
 /// Function extracting an element from a matrix (const)
 template <std::size_t ROW, std::size_t COL, concepts::scalar scalar_t,
           template <typename, std::size_t> class array_t>
-ALGEBRA_HOST_DEVICE inline decltype(auto) element(
+ALGEBRA_HOST_DEVICE constexpr decltype(auto) element(
     const matrix<array_t, scalar_t, ROW, COL> &m, std::size_t row,
     std::size_t col) {
   return element_getter{}(m, row, col);
@@ -100,7 +100,7 @@ ALGEBRA_HOST_DEVICE inline decltype(auto) element(
 /// Function extracting an element from a matrix (non-const)
 template <std::size_t ROW, std::size_t COL, concepts::scalar scalar_t,
           template <typename, std::size_t> class array_t>
-ALGEBRA_HOST_DEVICE inline decltype(auto) element(
+ALGEBRA_HOST_DEVICE constexpr decltype(auto) element(
     matrix<array_t, scalar_t, ROW, COL> &m, std::size_t row, std::size_t col) {
   return element_getter{}(m, row, col);
 }
@@ -108,7 +108,7 @@ ALGEBRA_HOST_DEVICE inline decltype(auto) element(
 /// Function extracting an element from a 1D matrix (const)
 template <std::size_t ROW, concepts::scalar scalar_t,
           template <typename, std::size_t> class array_t>
-ALGEBRA_HOST_DEVICE inline decltype(auto) element(
+ALGEBRA_HOST_DEVICE constexpr decltype(auto) element(
     const matrix<array_t, scalar_t, ROW, 1> &m, std::size_t row) {
   return element_getter{}(m, row);
 }
@@ -116,7 +116,7 @@ ALGEBRA_HOST_DEVICE inline decltype(auto) element(
 /// Function extracting an element from a 1D matrix (non-const)
 template <std::size_t ROW, concepts::scalar scalar_t,
           template <typename, std::size_t> class array_t>
-ALGEBRA_HOST_DEVICE inline decltype(auto) element(
+ALGEBRA_HOST_DEVICE constexpr decltype(auto) element(
     matrix<array_t, scalar_t, ROW, 1> &m, std::size_t row) {
   return element_getter{}(m, row);
 }
@@ -124,7 +124,7 @@ ALGEBRA_HOST_DEVICE inline decltype(auto) element(
 /// Function extracting an element from a vector (const)
 template <std::size_t N, concepts::scalar scalar_t,
           template <typename, std::size_t> class array_t>
-ALGEBRA_HOST_DEVICE inline decltype(auto) element(
+ALGEBRA_HOST_DEVICE constexpr decltype(auto) element(
     const vector<N, scalar_t, array_t> &v, std::size_t row) {
   return element_getter{}(v, row);
 }
@@ -132,7 +132,7 @@ ALGEBRA_HOST_DEVICE inline decltype(auto) element(
 /// Function extracting an element from a vector (non-const)
 template <std::size_t N, concepts::scalar scalar_t,
           template <typename, std::size_t> class array_t>
-ALGEBRA_HOST_DEVICE inline decltype(auto) element(
+ALGEBRA_HOST_DEVICE constexpr decltype(auto) element(
     vector<N, scalar_t, array_t> &v, std::size_t row) {
   return element_getter{}(v, row);
 }

--- a/storage/common/include/algebra/storage/vector.hpp
+++ b/storage/common/include/algebra/storage/vector.hpp
@@ -47,7 +47,7 @@ consteval std::size_t nearest_power_of_two(std::size_t min_value,
 /// SIMD vector.
 template <std::size_t N, concepts::scalar scalar_t,
           template <typename, std::size_t> class array_t>
-class alignas(
+class ALGEBRA_ALIGN(
     alignof(array_t<scalar_t, detail::nearest_power_of_two(N, 2u)>)) vector {
 
  public:
@@ -181,6 +181,7 @@ class alignas(
     const auto comp = lhs.compare(rhs);
     bool is_full = false;
 
+    ALGEBRA_UNROLL_N(N)
     for (unsigned int i{0u}; i < N; ++i) {
       // Ducktyping the Vc::Vector::MaskType
       is_full |= comp[i].isFull();
@@ -205,6 +206,7 @@ class alignas(
 
     std::array<result_t, N> comp;
 
+    ALGEBRA_UNROLL_N(N)
     for (unsigned int i{0u}; i < N; ++i) {
       comp[i] = (m_data[i] == rhs[i]);
     }
@@ -228,19 +230,19 @@ class alignas(
 #define DECLARE_VECTOR_OPERATORS(OP)                                           \
   template <std::size_t N, concepts::scalar scalar_t, concepts::value value_t, \
             template <typename, std::size_t> class array_t>                    \
-  ALGEBRA_HOST_DEVICE inline constexpr decltype(auto) operator OP(             \
+  ALGEBRA_HOST_DEVICE constexpr decltype(auto) operator OP(                    \
       const vector<N, scalar_t, array_t> &lhs, value_t rhs) noexcept {         \
     return lhs.m_data OP static_cast<scalar_t>(rhs);                           \
   }                                                                            \
   template <std::size_t N, concepts::scalar scalar_t, concepts::value value_t, \
             template <typename, std::size_t> class array_t>                    \
-  ALGEBRA_HOST_DEVICE inline decltype(auto) operator OP(                       \
+  ALGEBRA_HOST_DEVICE constexpr decltype(auto) operator OP(                    \
       value_t lhs, const vector<N, scalar_t, array_t> &rhs) noexcept {         \
     return static_cast<scalar_t>(lhs) OP rhs.m_data;                           \
   }                                                                            \
   template <std::size_t N, concepts::scalar scalar_t,                          \
             template <typename, std::size_t> class array_t>                    \
-  ALGEBRA_HOST_DEVICE inline constexpr decltype(auto) operator OP(             \
+  ALGEBRA_HOST_DEVICE constexpr decltype(auto) operator OP(                    \
       const vector<N, scalar_t, array_t> &lhs,                                 \
       const vector<N, scalar_t, array_t> &rhs) noexcept {                      \
     return lhs.m_data OP rhs.m_data;                                           \
@@ -248,7 +250,7 @@ class alignas(
   template <std::size_t N, concepts::scalar scalar_t,                          \
             template <typename, std::size_t> class array_t, typename other_t>  \
   requires(concepts::vector<other_t> || concepts::simd_scalar<other_t>)        \
-      ALGEBRA_HOST_DEVICE inline constexpr decltype(auto)                      \
+      ALGEBRA_HOST_DEVICE constexpr decltype(auto)                             \
       operator OP(const vector<N, scalar_t, array_t> &lhs,                     \
                   const other_t &rhs) noexcept {                               \
     return lhs.m_data OP rhs;                                                  \
@@ -256,7 +258,7 @@ class alignas(
   template <std::size_t N, concepts::scalar scalar_t,                          \
             template <typename, std::size_t> class array_t, typename other_t>  \
   requires(concepts::vector<other_t> || concepts::simd_scalar<other_t>)        \
-      ALGEBRA_HOST_DEVICE inline constexpr decltype(auto)                      \
+      ALGEBRA_HOST_DEVICE constexpr decltype(auto)                             \
       operator OP(const other_t &lhs,                                          \
                   const vector<N, scalar_t, array_t> &rhs) noexcept {          \
     return lhs OP rhs.m_data;                                                  \
@@ -286,7 +288,7 @@ struct is_storage_vector<storage::vector<N, scalar_t, array_t>>
     : public std::true_type {};
 
 template <typename T>
-inline constexpr bool is_storage_vector_v = is_storage_vector<T>::value;
+constexpr bool is_storage_vector_v = is_storage_vector<T>::value;
 
 }  // namespace detail
 

--- a/storage/common/include/algebra/storage/vector.hpp
+++ b/storage/common/include/algebra/storage/vector.hpp
@@ -288,7 +288,7 @@ struct is_storage_vector<storage::vector<N, scalar_t, array_t>>
     : public std::true_type {};
 
 template <typename T>
-constexpr bool is_storage_vector_v = is_storage_vector<T>::value;
+inline constexpr bool is_storage_vector_v = is_storage_vector<T>::value;
 
 }  // namespace detail
 

--- a/storage/eigen/include/algebra/storage/impl/eigen_getter.hpp
+++ b/storage/eigen/include/algebra/storage/impl/eigen_getter.hpp
@@ -41,7 +41,7 @@ struct element_getter {
   requires std::is_base_of_v<
       Eigen::DenseCoeffsBase<derived_type, Eigen::WriteAccessors>,
       Eigen::MatrixBase<derived_type> >
-      ALGEBRA_HOST_DEVICE inline auto &operator()(
+      ALGEBRA_HOST_DEVICE constexpr auto &operator()(
           Eigen::MatrixBase<derived_type> &m, size_type_1 row,
           size_type_2 col) const {
 
@@ -50,7 +50,7 @@ struct element_getter {
   /// Get const access to a matrix element
   template <typename derived_type, concepts::index size_type_1,
             concepts::index size_type_2>
-  ALGEBRA_HOST_DEVICE inline auto operator()(
+  ALGEBRA_HOST_DEVICE constexpr auto operator()(
       const Eigen::MatrixBase<derived_type> &m, size_type_1 row,
       size_type_2 col) const {
 
@@ -61,14 +61,14 @@ struct element_getter {
   requires std::is_base_of_v<
       Eigen::DenseCoeffsBase<derived_type, Eigen::WriteAccessors>,
       Eigen::MatrixBase<derived_type> >
-      ALGEBRA_HOST_DEVICE inline auto &operator()(
+      ALGEBRA_HOST_DEVICE constexpr auto &operator()(
           Eigen::MatrixBase<derived_type> &m, size_type row) const {
 
     return m(static_cast<Eigen::Index>(row));
   }
   /// Get const access to a matrix element
   template <typename derived_type, concepts::index size_type>
-  ALGEBRA_HOST_DEVICE inline auto operator()(
+  ALGEBRA_HOST_DEVICE constexpr auto operator()(
       const Eigen::MatrixBase<derived_type> &m, size_type row) const {
 
     return m(static_cast<Eigen::Index>(row));
@@ -77,7 +77,7 @@ struct element_getter {
 
 /// Function extracting an element from a matrix (const)
 template <typename derived_type>
-ALGEBRA_HOST_DEVICE inline decltype(auto) element(
+ALGEBRA_HOST_DEVICE constexpr decltype(auto) element(
     const Eigen::MatrixBase<derived_type> &m, std::size_t row,
     std::size_t col) {
 
@@ -90,7 +90,7 @@ template <typename derived_type>
 requires std::is_base_of_v<
     Eigen::DenseCoeffsBase<derived_type, Eigen::WriteAccessors>,
     Eigen::MatrixBase<derived_type> >
-    ALGEBRA_HOST_DEVICE inline decltype(auto) element(
+    ALGEBRA_HOST_DEVICE constexpr decltype(auto) element(
         Eigen::MatrixBase<derived_type> &m, std::size_t row, std::size_t col) {
 
   return element_getter()(m, static_cast<Eigen::Index>(row),
@@ -99,7 +99,7 @@ requires std::is_base_of_v<
 
 /// Function extracting an element from a matrix (const)
 template <typename derived_type>
-ALGEBRA_HOST_DEVICE inline decltype(auto) element(
+ALGEBRA_HOST_DEVICE constexpr decltype(auto) element(
     const Eigen::MatrixBase<derived_type> &m, std::size_t row) {
 
   return element_getter()(m, static_cast<Eigen::Index>(row));
@@ -110,7 +110,7 @@ template <typename derived_type>
 requires std::is_base_of_v<
     Eigen::DenseCoeffsBase<derived_type, Eigen::WriteAccessors>,
     Eigen::MatrixBase<derived_type> >
-    ALGEBRA_HOST_DEVICE inline decltype(auto) element(
+    ALGEBRA_HOST_DEVICE constexpr decltype(auto) element(
         Eigen::MatrixBase<derived_type> &m, std::size_t row) {
 
   return element_getter()(m, static_cast<Eigen::Index>(row));
@@ -176,7 +176,7 @@ ALGEBRA_HOST_DEVICE decltype(auto) block(Eigen::MatrixBase<derived_type> &m,
 
 /// Function extracting a slice from the matrix
 template <int SIZE, typename derived_type>
-ALGEBRA_HOST_DEVICE inline decltype(auto) vector(
+ALGEBRA_HOST_DEVICE constexpr decltype(auto) vector(
     const Eigen::MatrixBase<derived_type> &m, std::size_t row,
     std::size_t col) {
 

--- a/storage/fastor/include/algebra/storage/impl/fastor_getter.hpp
+++ b/storage/fastor/include/algebra/storage/impl/fastor_getter.hpp
@@ -109,8 +109,8 @@ ALGEBRA_HOST_DEVICE constexpr scalar_t element(
 
 /// Function extracting an element from a matrix (non-const)
 template <concepts::scalar scalar_t, std::size_t N>
-ALGEBRA_HOST_DEVICE constexpr scalar_t &element(Fastor::Tensor<scalar_t, N, 1> &m,
-                                             std::size_t row) {
+ALGEBRA_HOST_DEVICE constexpr scalar_t &element(
+    Fastor::Tensor<scalar_t, N, 1> &m, std::size_t row) {
   return element_getter()(m, row);
 }
 
@@ -124,7 +124,7 @@ ALGEBRA_HOST_DEVICE constexpr scalar_t element(
 /// Function extracting an element from a vector (non-const)
 template <concepts::scalar scalar_t, std::size_t N>
 ALGEBRA_HOST_DEVICE constexpr scalar_t &element(Fastor::Tensor<scalar_t, N> &m,
-                                             std::size_t row) {
+                                                std::size_t row) {
   return element_getter()(m, row);
 }
 

--- a/storage/fastor/include/algebra/storage/impl/fastor_getter.hpp
+++ b/storage/fastor/include/algebra/storage/impl/fastor_getter.hpp
@@ -32,7 +32,7 @@ namespace algebra::fastor::storage {
 struct element_getter {
 
   template <std::size_t ROWS, std::size_t COLS, concepts::scalar scalar_t>
-  ALGEBRA_HOST_DEVICE inline scalar_t &operator()(
+  ALGEBRA_HOST_DEVICE constexpr scalar_t &operator()(
       Fastor::Tensor<scalar_t, ROWS, COLS> &m, std::size_t row,
       std::size_t col) const {
 
@@ -42,7 +42,7 @@ struct element_getter {
   }
 
   template <std::size_t ROWS, std::size_t COLS, concepts::scalar scalar_t>
-  ALGEBRA_HOST_DEVICE inline scalar_t operator()(
+  ALGEBRA_HOST_DEVICE constexpr scalar_t operator()(
       const Fastor::Tensor<scalar_t, ROWS, COLS> &m, std::size_t row,
       std::size_t col) const {
 
@@ -52,7 +52,7 @@ struct element_getter {
   }
 
   template <std::size_t N, concepts::scalar scalar_t>
-  ALGEBRA_HOST_DEVICE inline scalar_t &operator()(
+  ALGEBRA_HOST_DEVICE constexpr scalar_t &operator()(
       Fastor::Tensor<scalar_t, N, 1> &m, std::size_t row) const {
 
     assert(row < N);
@@ -60,7 +60,7 @@ struct element_getter {
   }
 
   template <std::size_t N, concepts::scalar scalar_t>
-  ALGEBRA_HOST_DEVICE inline scalar_t operator()(
+  ALGEBRA_HOST_DEVICE constexpr scalar_t operator()(
       const Fastor::Tensor<scalar_t, N, 1> &m, std::size_t row) const {
 
     assert(row < N);
@@ -68,7 +68,7 @@ struct element_getter {
   }
 
   template <std::size_t N, concepts::scalar scalar_t>
-  ALGEBRA_HOST_DEVICE inline scalar_t &operator()(
+  ALGEBRA_HOST_DEVICE constexpr scalar_t &operator()(
       Fastor::Tensor<scalar_t, N> &m, std::size_t row) const {
 
     assert(row < N);
@@ -76,7 +76,7 @@ struct element_getter {
   }
 
   template <std::size_t N, concepts::scalar scalar_t>
-  ALGEBRA_HOST_DEVICE inline scalar_t operator()(
+  ALGEBRA_HOST_DEVICE constexpr scalar_t operator()(
       const Fastor::Tensor<scalar_t, N> &m, std::size_t row) const {
 
     assert(row < N);
@@ -87,7 +87,7 @@ struct element_getter {
 
 /// Function extracting an element from a matrix (const)
 template <concepts::scalar scalar_t, std::size_t ROWS, std::size_t COLS>
-ALGEBRA_HOST_DEVICE inline scalar_t element(
+ALGEBRA_HOST_DEVICE constexpr scalar_t element(
     const Fastor::Tensor<scalar_t, ROWS, COLS> &m, std::size_t row,
     std::size_t col) {
   return element_getter()(m, row, col);
@@ -95,35 +95,35 @@ ALGEBRA_HOST_DEVICE inline scalar_t element(
 
 /// Function extracting an element from a matrix (non-const)
 template <concepts::scalar scalar_t, std::size_t ROWS, std::size_t COLS>
-ALGEBRA_HOST_DEVICE inline scalar_t &element(
+ALGEBRA_HOST_DEVICE constexpr scalar_t &element(
     Fastor::Tensor<scalar_t, ROWS, COLS> &m, std::size_t row, std::size_t col) {
   return element_getter()(m, row, col);
 }
 
 /// Function extracting an element from a matrix (const)
 template <concepts::scalar scalar_t, std::size_t N>
-ALGEBRA_HOST_DEVICE inline scalar_t element(
+ALGEBRA_HOST_DEVICE constexpr scalar_t element(
     const Fastor::Tensor<scalar_t, N, 1> &m, std::size_t row) {
   return element_getter()(m, row);
 }
 
 /// Function extracting an element from a matrix (non-const)
 template <concepts::scalar scalar_t, std::size_t N>
-ALGEBRA_HOST_DEVICE inline scalar_t &element(Fastor::Tensor<scalar_t, N, 1> &m,
+ALGEBRA_HOST_DEVICE constexpr scalar_t &element(Fastor::Tensor<scalar_t, N, 1> &m,
                                              std::size_t row) {
   return element_getter()(m, row);
 }
 
 /// Function extracting an element from a vector (const)
 template <concepts::scalar scalar_t, std::size_t N>
-ALGEBRA_HOST_DEVICE inline scalar_t element(
+ALGEBRA_HOST_DEVICE constexpr scalar_t element(
     const Fastor::Tensor<scalar_t, N> &m, std::size_t row) {
   return element_getter()(m, row);
 }
 
 /// Function extracting an element from a vector (non-const)
 template <concepts::scalar scalar_t, std::size_t N>
-ALGEBRA_HOST_DEVICE inline scalar_t &element(Fastor::Tensor<scalar_t, N> &m,
+ALGEBRA_HOST_DEVICE constexpr scalar_t &element(Fastor::Tensor<scalar_t, N> &m,
                                              std::size_t row) {
   return element_getter()(m, row);
 }
@@ -166,7 +166,7 @@ ALGEBRA_HOST_DEVICE decltype(auto) block(
 /// Function extracting a slice from the matrix
 template <std::size_t SIZE, std::size_t ROWS, std::size_t COLS,
           concepts::scalar scalar_t>
-ALGEBRA_HOST_DEVICE inline decltype(auto) vector(
+ALGEBRA_HOST_DEVICE constexpr decltype(auto) vector(
     const Fastor::Tensor<scalar_t, ROWS, COLS> &m, std::size_t row,
     std::size_t col) {
 

--- a/storage/fastor/include/algebra/storage/impl/fastor_matrix.hpp
+++ b/storage/fastor/include/algebra/storage/impl/fastor_matrix.hpp
@@ -57,7 +57,7 @@ class Matrix : public Fastor::Tensor<T, M1, N> {
   /// The `static_cast` is there to signal both to the compiler and the reader
   /// that we wish to interpret the `Matrix` object as a `Fastor::Tensor` here.
   template <concepts::scalar U, std::size_t M2>
-  inline Matrix<T, M1, M2> operator*(const Matrix<U, N, M2>& other) const {
+  constexpr Matrix<T, M1, M2> operator*(const Matrix<U, N, M2>& other) const {
     return Fastor::matmul(static_cast<Fastor::Tensor<T, M1, N>>(*this),
                           static_cast<Fastor::Tensor<T, N, M2>>(other));
   }
@@ -74,7 +74,7 @@ class Matrix : public Fastor::Tensor<T, M1, N> {
   /// The `static_cast` is there to signal both to the compiler and the reader
   /// that we wish to interpret the `Matrix` object as a `Fastor::Tensor` here.
   template <concepts::scalar U>
-  inline Fastor::Tensor<T, M1> operator*(
+  constexpr Fastor::Tensor<T, M1> operator*(
       const Fastor::Tensor<U, N>& other) const {
     return Fastor::matmul(static_cast<Fastor::Tensor<T, M1, N>>(*this),
                           static_cast<Fastor::Tensor<T, N>>(other));

--- a/storage/smatrix/include/algebra/storage/impl/smatrix_getter.hpp
+++ b/storage/smatrix/include/algebra/storage/impl/smatrix_getter.hpp
@@ -27,7 +27,7 @@ namespace algebra::smatrix::storage {
 struct element_getter {
 
   template <unsigned int ROWS, unsigned int COLS, concepts::scalar scalar_t>
-  ALGEBRA_HOST_DEVICE inline scalar_t &operator()(
+  ALGEBRA_HOST_DEVICE constexpr scalar_t &operator()(
       ROOT::Math::SMatrix<scalar_t, ROWS, COLS> &m, unsigned int row,
       unsigned int col) const {
     assert(row < ROWS);
@@ -36,7 +36,7 @@ struct element_getter {
   }
 
   template <unsigned int ROWS, unsigned int COLS, concepts::scalar scalar_t>
-  ALGEBRA_HOST_DEVICE inline scalar_t operator()(
+  ALGEBRA_HOST_DEVICE constexpr scalar_t operator()(
       const ROOT::Math::SMatrix<scalar_t, ROWS, COLS> &m, unsigned int row,
       unsigned int col) const {
     assert(row < ROWS);
@@ -45,28 +45,28 @@ struct element_getter {
   }
 
   template <unsigned int N, concepts::scalar scalar_t>
-  ALGEBRA_HOST_DEVICE inline scalar_t &operator()(
+  ALGEBRA_HOST_DEVICE constexpr scalar_t &operator()(
       ROOT::Math::SMatrix<scalar_t, N, 1> &m, unsigned int row) const {
     assert(row < N);
     return m(row);
   }
 
   template <unsigned int N, concepts::scalar scalar_t>
-  ALGEBRA_HOST_DEVICE inline scalar_t operator()(
+  ALGEBRA_HOST_DEVICE constexpr scalar_t operator()(
       const ROOT::Math::SMatrix<scalar_t, N, 1> &m, unsigned int row) const {
     assert(row < N);
     return m(row, 0);
   }
 
   template <concepts::scalar scalar_t, unsigned int N>
-  ALGEBRA_HOST_DEVICE inline scalar_t &operator()(
+  ALGEBRA_HOST_DEVICE constexpr scalar_t &operator()(
       ROOT::Math::SVector<scalar_t, N> &m, unsigned int row) const {
     assert(row < N);
     return m(row);
   }
 
   template <unsigned int N, concepts::scalar scalar_t>
-  ALGEBRA_HOST_DEVICE inline scalar_t operator()(
+  ALGEBRA_HOST_DEVICE constexpr scalar_t operator()(
       const ROOT::Math::SVector<scalar_t, N> &m, unsigned int row) const {
     assert(row < N);
     return m(row);
@@ -75,7 +75,7 @@ struct element_getter {
 
 /// Function extracting an element from a matrix (const)
 template <concepts::scalar scalar_t, unsigned int ROWS, unsigned int COLS>
-ALGEBRA_HOST_DEVICE inline scalar_t element(
+ALGEBRA_HOST_DEVICE constexpr scalar_t element(
     const ROOT::Math::SMatrix<scalar_t, ROWS, COLS> &m, std::size_t row,
     std::size_t col) {
   return element_getter()(m, static_cast<unsigned int>(row),
@@ -84,7 +84,7 @@ ALGEBRA_HOST_DEVICE inline scalar_t element(
 
 /// Function extracting an element from a matrix (non-const)
 template <concepts::scalar scalar_t, unsigned int ROWS, unsigned int COLS>
-ALGEBRA_HOST_DEVICE inline scalar_t &element(
+ALGEBRA_HOST_DEVICE constexpr scalar_t &element(
     ROOT::Math::SMatrix<scalar_t, ROWS, COLS> &m, std::size_t row,
     std::size_t col) {
   return element_getter()(m, static_cast<unsigned int>(row),
@@ -93,28 +93,28 @@ ALGEBRA_HOST_DEVICE inline scalar_t &element(
 
 /// Function extracting an element from a matrix (const)
 template <concepts::scalar scalar_t, unsigned int N>
-ALGEBRA_HOST_DEVICE inline scalar_t element(
+ALGEBRA_HOST_DEVICE constexpr scalar_t element(
     const ROOT::Math::SMatrix<scalar_t, N, 1> &m, std::size_t row) {
   return element_getter()(m, static_cast<unsigned int>(row));
 }
 
 /// Function extracting an element from a matrix (non-const)
 template <concepts::scalar scalar_t, unsigned int N>
-ALGEBRA_HOST_DEVICE inline scalar_t &element(
+ALGEBRA_HOST_DEVICE constexpr scalar_t &element(
     ROOT::Math::SMatrix<scalar_t, N, 1> &m, std::size_t row) {
   return element_getter()(m, static_cast<unsigned int>(row));
 }
 
 /// Function extracting an element from a matrix (const)
 template <concepts::scalar scalar_t, unsigned int N>
-ALGEBRA_HOST_DEVICE inline scalar_t element(
+ALGEBRA_HOST_DEVICE constexpr scalar_t element(
     const ROOT::Math::SVector<scalar_t, N> &m, std::size_t row) {
   return element_getter()(m, static_cast<unsigned int>(row));
 }
 
 /// Function extracting an element from a matrix (non-const)
 template <concepts::scalar scalar_t, unsigned int N>
-ALGEBRA_HOST_DEVICE inline scalar_t &element(
+ALGEBRA_HOST_DEVICE constexpr scalar_t &element(
     ROOT::Math::SVector<scalar_t, N> &m, std::size_t row) {
   return element_getter()(m, static_cast<unsigned int>(row));
 }
@@ -167,7 +167,7 @@ ALGEBRA_HOST_DEVICE ROOT::Math::SMatrix<scalar_t, ROWS, COLS> block(
 /// @c algebra::smatrix::transform3
 template <unsigned int SIZE, unsigned int ROWS, unsigned int COLS,
           concepts::scalar scalar_t>
-ALGEBRA_HOST_DEVICE inline auto vector(
+ALGEBRA_HOST_DEVICE constexpr auto vector(
     const ROOT::Math::SMatrix<scalar_t, ROWS, COLS> &m, std::size_t row,
     std::size_t col) {
 


### PR DESCRIPTION
Forces the compiler to apply loop unrolling in the Vc plugins, which seems to help performance (the array plugin seems to be optimized that way already). For this, a new macro was added to the qualifiers header to do this per compiler (however, I could not find anything for MSVC so far). I think it is OK to mandate loop unrolling at some loops that seem to make sense, since we don't have large matrices to run

Since `constexpr` implies `inline` most functions were switched to `constexpr` now.