### PR TITLE
fix: algorithm selection for 4x4 matrices

### DIFF
--- a/frontend/array_cmath/include/algebra/array_cmath.hpp
+++ b/frontend/array_cmath/include/algebra/array_cmath.hpp
@@ -63,7 +63,8 @@ namespace generic {
 
 // Determinant algorithms
 template <concepts::scalar T, auto ROWS, auto COLS>
-struct determinant_selector<4, array::matrix_type<T, ROWS, COLS>> {
+struct determinant_selector<4, array::matrix_type<T, ROWS, COLS>,
+                            array::element_getter> {
   using type =
       matrix::determinant::hard_coded<array::matrix_type<T, ROWS, COLS>,
                                       array::element_getter>;
@@ -71,7 +72,8 @@ struct determinant_selector<4, array::matrix_type<T, ROWS, COLS>> {
 
 // Inversion algorithms
 template <concepts::scalar T, auto ROWS, auto COLS>
-struct inversion_selector<4, array::matrix_type<T, ROWS, COLS>> {
+struct inversion_selector<4, array::matrix_type<T, ROWS, COLS>,
+                          array::element_getter> {
   using type = matrix::inverse::hard_coded<array::matrix_type<T, ROWS, COLS>,
                                            array::element_getter>;
 };

--- a/frontend/vc_aos/include/algebra/vc_aos.hpp
+++ b/frontend/vc_aos/include/algebra/vc_aos.hpp
@@ -51,6 +51,28 @@ using vc_aos::math::theta;
 
 }  // namespace vector
 
+// Use special algorithms for 4 dimensional matrices
+namespace generic {
+
+// Determinant algorithms
+template <concepts::scalar T, auto ROWS, auto COLS>
+struct determinant_selector<4, vc_aos::matrix_type<T, ROWS, COLS>,
+                            vc_aos::element_getter> {
+  using type =
+      matrix::determinant::hard_coded<vc_aos::matrix_type<T, ROWS, COLS>,
+                                      vc_aos::element_getter>;
+};
+
+// Inversion algorithms
+template <concepts::scalar T, auto ROWS, auto COLS>
+struct inversion_selector<4, vc_aos::matrix_type<T, ROWS, COLS>,
+                          vc_aos::element_getter> {
+  using type = matrix::inverse::hard_coded<vc_aos::matrix_type<T, ROWS, COLS>,
+                                           vc_aos::element_getter>;
+};
+
+}  // namespace generic
+
 namespace matrix {
 
 /// @name Matrix functions on @c algebra::vc_aos types


### PR DESCRIPTION
Fix the algorithm selector specification, which was lacking the element getter type, and add it to the Vc AoS plugin as well. This will now select the hard coded inversion and determinant algorithms for the 4x4 matrices correctly again.