### PR TITLE
Added Fastor to the benchmark suite

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -111,3 +111,28 @@ if( ALGEBRA_PLUGINS_INCLUDE_VC )
       LINK_LIBRARIES benchmark::benchmark algebra::bench_common
                      algebra_bench_vc_soa algebra::vc_soa )
 endif()
+
+if( ALGEBRA_PLUGINS_INCLUDE_FASTOR )
+   add_library( algebra_bench_fastor INTERFACE )
+   message(STATUS "Include directory: ${CMAKE_CURRENT_SOURCE_DIR}/fastor/include")
+   target_include_directories( algebra_bench_fastor INTERFACE
+      "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/fastor/include>" )
+   target_link_libraries(algebra_bench_fastor INTERFACE algebra::fastor_fastor
+                                                    algebra::common_storage)
+   # algebra_add_benchmark( fastor_getter
+   #    "fastor/fastor_getter.cpp"
+   #    LINK_LIBRARIES benchmark::benchmark algebra::bench_common
+   #                   algebra_bench_fastor algebra::fastor_fastor )
+   algebra_add_benchmark( fastor_vector
+      "fastor/fastor_vector.cpp"
+      LINK_LIBRARIES benchmark::benchmark algebra::bench_common
+                     algebra_bench_fastor algebra::fastor_fastor )
+   # algebra_add_benchmark( fastor_transform3
+   #    "fastor/fastor_transform3.cpp"
+   #    LINK_LIBRARIES benchmark::benchmark algebra::bench_common
+   #                   algebra_bench_fastor algebra::fastor_fastor )
+   # algebra_add_benchmark( fastor_matrix
+   #    "fastor/fastor_matrix.cpp"
+   #    LINK_LIBRARIES benchmark::benchmark algebra::bench_common
+   #                   algebra_bench_fastor algebra::fastor_fastor )
+endif()

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -119,10 +119,10 @@ if( ALGEBRA_PLUGINS_INCLUDE_FASTOR )
       "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/fastor/include>" )
    target_link_libraries(algebra_bench_fastor INTERFACE algebra::fastor_fastor
                                                     algebra::common_storage)
-   # algebra_add_benchmark( fastor_getter
-   #    "fastor/fastor_getter.cpp"
-   #    LINK_LIBRARIES benchmark::benchmark algebra::bench_common
-   #                   algebra_bench_fastor algebra::fastor_fastor )
+   algebra_add_benchmark( fastor_getter
+      "fastor/fastor_getter.cpp"
+      LINK_LIBRARIES benchmark::benchmark algebra::bench_common
+                     algebra_bench_fastor algebra::fastor_fastor )
    algebra_add_benchmark( fastor_vector
       "fastor/fastor_vector.cpp"
       LINK_LIBRARIES benchmark::benchmark algebra::bench_common

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -127,10 +127,10 @@ if( ALGEBRA_PLUGINS_INCLUDE_FASTOR )
       "fastor/fastor_vector.cpp"
       LINK_LIBRARIES benchmark::benchmark algebra::bench_common
                      algebra_bench_fastor algebra::fastor_fastor )
-   # algebra_add_benchmark( fastor_transform3
-   #    "fastor/fastor_transform3.cpp"
-   #    LINK_LIBRARIES benchmark::benchmark algebra::bench_common
-   #                   algebra_bench_fastor algebra::fastor_fastor )
+   algebra_add_benchmark( fastor_transform3
+      "fastor/fastor_transform3.cpp"
+      LINK_LIBRARIES benchmark::benchmark algebra::bench_common
+                     algebra_bench_fastor algebra::fastor_fastor )
    algebra_add_benchmark( fastor_matrix
       "fastor/fastor_matrix.cpp"
       LINK_LIBRARIES benchmark::benchmark algebra::bench_common

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -131,8 +131,8 @@ if( ALGEBRA_PLUGINS_INCLUDE_FASTOR )
    #    "fastor/fastor_transform3.cpp"
    #    LINK_LIBRARIES benchmark::benchmark algebra::bench_common
    #                   algebra_bench_fastor algebra::fastor_fastor )
-   # algebra_add_benchmark( fastor_matrix
-   #    "fastor/fastor_matrix.cpp"
-   #    LINK_LIBRARIES benchmark::benchmark algebra::bench_common
-   #                   algebra_bench_fastor algebra::fastor_fastor )
+   algebra_add_benchmark( fastor_matrix
+      "fastor/fastor_matrix.cpp"
+      LINK_LIBRARIES benchmark::benchmark algebra::bench_common
+                     algebra_bench_fastor algebra::fastor_fastor )
 endif()

--- a/benchmarks/fastor/fastor_getter.cpp
+++ b/benchmarks/fastor/fastor_getter.cpp
@@ -1,0 +1,41 @@
+/** Algebra plugins library, part of the ACTS project
+ *
+ * (c) 2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Project include(s)
+#include "algebra/fastor_fastor.hpp"
+#include "benchmark/common/benchmark_getter.hpp"
+#include "benchmark/fastor/data_generator.hpp"
+
+// Benchmark include
+#include <benchmark/benchmark.h>
+
+// System include(s)
+#include <iostream>
+
+using namespace algebra;
+
+/// Run vector benchmarks
+int main(int argc, char** argv) {
+
+  //
+  // Prepare benchmarks
+  //
+  algebra::benchmark_base::configuration cfg{};
+  cfg.n_samples(100000);
+
+  std::cout << "------------------------------------------\n"
+            << "Algebra-Plugins 'getter' benchmark (Fastor)\n"
+            << "------------------------------------------\n\n"
+            << cfg;
+
+  //
+  // Register all benchmarks
+  //
+  ::benchmark::Initialize(&argc, argv);
+  ::benchmark::RunSpecifiedBenchmarks();
+  ::benchmark::Shutdown();
+}

--- a/benchmarks/fastor/fastor_matrix.cpp
+++ b/benchmarks/fastor/fastor_matrix.cpp
@@ -1,0 +1,121 @@
+/** Algebra plugins library, part of the ACTS project
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Project include(s)
+#include "algebra/fastor_fastor.hpp"
+#include "benchmark/common/benchmark_matrix.hpp"
+#include "benchmark/fastor/data_generator.hpp"
+
+// Benchmark include
+#include <benchmark/benchmark.h>
+
+// System include(s)
+#include <iostream>
+
+using namespace algebra;
+
+/// Run vector benchmarks
+int main(int argc, char** argv) {
+
+  //
+  // Prepare benchmarks
+  //
+  algebra::benchmark_base::configuration cfg{};
+  cfg.n_samples(100000);
+
+  using mat44_transp_f_t =
+      matrix_unaryOP_bm<fastor::matrix_type<float, 4, 4>, bench_op::transpose>;
+  using mat44_transp_d_t =
+      matrix_unaryOP_bm<fastor::matrix_type<double, 4, 4>, bench_op::transpose>;
+  using mat66_transp_f_t =
+      matrix_unaryOP_bm<fastor::matrix_type<float, 6, 6>, bench_op::transpose>;
+  using mat66_transp_d_t =
+      matrix_unaryOP_bm<fastor::matrix_type<double, 6, 6>, bench_op::transpose>;
+  using mat88_transp_f_t =
+      matrix_unaryOP_bm<fastor::matrix_type<float, 8, 8>, bench_op::transpose>;
+  using mat88_transp_d_t =
+      matrix_unaryOP_bm<fastor::matrix_type<double, 8, 8>, bench_op::transpose>;
+
+  using mat44_inv_f_t =
+      matrix_unaryOP_bm<fastor::matrix_type<float, 4, 4>, bench_op::invert>;
+  using mat44_inv_d_t =
+      matrix_unaryOP_bm<fastor::matrix_type<double, 4, 4>, bench_op::invert>;
+  using mat66_inv_f_t =
+      matrix_unaryOP_bm<fastor::matrix_type<float, 6, 6>, bench_op::invert>;
+  using mat66_inv_d_t =
+      matrix_unaryOP_bm<fastor::matrix_type<double, 6, 6>, bench_op::invert>;
+  using mat88_inv_f_t =
+      matrix_unaryOP_bm<fastor::matrix_type<float, 8, 8>, bench_op::invert>;
+  using mat88_inv_d_t =
+      matrix_unaryOP_bm<fastor::matrix_type<double, 8, 8>, bench_op::invert>;
+
+  using mat44_det_f_t =
+      matrix_unaryOP_bm<fastor::matrix_type<float, 4, 4>, bench_op::determinant>;
+  using mat44_det_d_t = matrix_unaryOP_bm<fastor::matrix_type<double, 4, 4>,
+                                          bench_op::determinant>;
+  using mat66_det_f_t =
+      matrix_unaryOP_bm<fastor::matrix_type<float, 6, 6>, bench_op::determinant>;
+  using mat66_det_d_t = matrix_unaryOP_bm<fastor::matrix_type<double, 6, 6>,
+                                          bench_op::determinant>;
+  using mat88_det_f_t =
+      matrix_unaryOP_bm<fastor::matrix_type<float, 8, 8>, bench_op::determinant>;
+  using mat88_det_d_t = matrix_unaryOP_bm<fastor::matrix_type<double, 8, 8>,
+                                          bench_op::determinant>;
+
+  using mat44_add_f_t =
+      matrix_binaryOP_bm<fastor::matrix_type<float, 4, 4>, bench_op::add>;
+  using mat44_add_d_t =
+      matrix_binaryOP_bm<fastor::matrix_type<double, 4, 4>, bench_op::add>;
+  using mat66_add_f_t =
+      matrix_binaryOP_bm<fastor::matrix_type<float, 6, 6>, bench_op::add>;
+  using mat66_add_d_t =
+      matrix_binaryOP_bm<fastor::matrix_type<double, 6, 6>, bench_op::add>;
+  using mat88_add_f_t =
+      matrix_binaryOP_bm<fastor::matrix_type<float, 8, 8>, bench_op::add>;
+  using mat88_add_d_t =
+      matrix_binaryOP_bm<fastor::matrix_type<double, 8, 8>, bench_op::add>;
+
+  using mat44_mul_f_t =
+      matrix_binaryOP_bm<fastor::matrix_type<float, 4, 4>, bench_op::mul>;
+  using mat44_mul_d_t =
+      matrix_binaryOP_bm<fastor::matrix_type<double, 4, 4>, bench_op::mul>;
+  using mat66_mul_f_t =
+      matrix_binaryOP_bm<fastor::matrix_type<float, 6, 6>, bench_op::mul>;
+  using mat66_mul_d_t =
+      matrix_binaryOP_bm<fastor::matrix_type<double, 6, 6>, bench_op::mul>;
+  using mat88_mul_f_t =
+      matrix_binaryOP_bm<fastor::matrix_type<float, 8, 8>, bench_op::mul>;
+  using mat88_mul_d_t =
+      matrix_binaryOP_bm<fastor::matrix_type<double, 8, 8>, bench_op::mul>;
+
+  using mat44_vec_f_t = matrix_vector_bm<fastor::matrix_type<float, 4, 4>,
+                                         fastor::vector_type<float, 4>>;
+  using mat44_vec_d_t = matrix_vector_bm<fastor::matrix_type<double, 4, 4>,
+                                         fastor::vector_type<double, 4>>;
+  using mat66_vec_f_t = matrix_vector_bm<fastor::matrix_type<float, 6, 6>,
+                                         fastor::vector_type<float, 6>>;
+  using mat66_vec_d_t = matrix_vector_bm<fastor::matrix_type<double, 6, 6>,
+                                         fastor::vector_type<double, 6>>;
+  using mat88_vec_f_t = matrix_vector_bm<fastor::matrix_type<float, 8, 8>,
+                                         fastor::vector_type<float, 8>>;
+  using mat88_vec_d_t = matrix_vector_bm<fastor::matrix_type<double, 8, 8>,
+                                         fastor::vector_type<double, 8>>;
+
+  std::cout << "------------------------------------------\n"
+            << "Algebra-Plugins 'matrix' benchmark (Fastor)\n"
+            << "-------------------------------------------\n\n"
+            << cfg;
+
+  //
+  // Register all benchmarks
+  //
+  ALGEBRA_PLUGINS_REGISTER_MATRIX_BENCH(cfg)
+
+  ::benchmark::Initialize(&argc, argv);
+  ::benchmark::RunSpecifiedBenchmarks();
+  ::benchmark::Shutdown();
+}

--- a/benchmarks/fastor/fastor_matrix.cpp
+++ b/benchmarks/fastor/fastor_matrix.cpp
@@ -53,16 +53,16 @@ int main(int argc, char** argv) {
   using mat88_inv_d_t =
       matrix_unaryOP_bm<fastor::matrix_type<double, 8, 8>, bench_op::invert>;
 
-  using mat44_det_f_t =
-      matrix_unaryOP_bm<fastor::matrix_type<float, 4, 4>, bench_op::determinant>;
+  using mat44_det_f_t = matrix_unaryOP_bm<fastor::matrix_type<float, 4, 4>,
+                                          bench_op::determinant>;
   using mat44_det_d_t = matrix_unaryOP_bm<fastor::matrix_type<double, 4, 4>,
                                           bench_op::determinant>;
-  using mat66_det_f_t =
-      matrix_unaryOP_bm<fastor::matrix_type<float, 6, 6>, bench_op::determinant>;
+  using mat66_det_f_t = matrix_unaryOP_bm<fastor::matrix_type<float, 6, 6>,
+                                          bench_op::determinant>;
   using mat66_det_d_t = matrix_unaryOP_bm<fastor::matrix_type<double, 6, 6>,
                                           bench_op::determinant>;
-  using mat88_det_f_t =
-      matrix_unaryOP_bm<fastor::matrix_type<float, 8, 8>, bench_op::determinant>;
+  using mat88_det_f_t = matrix_unaryOP_bm<fastor::matrix_type<float, 8, 8>,
+                                          bench_op::determinant>;
   using mat88_det_d_t = matrix_unaryOP_bm<fastor::matrix_type<double, 8, 8>,
                                           bench_op::determinant>;
 

--- a/benchmarks/fastor/fastor_transform3.cpp
+++ b/benchmarks/fastor/fastor_transform3.cpp
@@ -1,0 +1,45 @@
+/** Algebra plugins library, part of the ACTS project
+ *
+ * (c) 2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Project include(s)
+#include "algebra/fastor_fastor.hpp"
+#include "benchmark/common/benchmark_transform3.hpp"
+#include "benchmark/common/register_benchmark.hpp"
+#include "benchmark/fastor/data_generator.hpp"
+
+// Benchmark include
+#include <benchmark/benchmark.h>
+
+using namespace algebra;
+
+/// Run vector benchmarks
+int main(int argc, char** argv) {
+
+  //
+  // Prepare benchmarks
+  //
+  algebra::benchmark_base::configuration cfg{};
+  cfg.n_samples(100000);
+
+  using trf_f_t = transform3_bm<fastor::transform3<float>>;
+  using trf_d_t = transform3_bm<fastor::transform3<double>>;
+
+  std::cout << "-----------------------------------------------\n"
+            << "Algebra-Plugins 'transform3' benchmark (Fastor)\n"
+            << "-----------------------------------------------\n\n"
+            << cfg;
+
+  //
+  // Register all benchmarks
+  //
+  algebra::register_benchmark<trf_f_t>(cfg, "_single");
+  algebra::register_benchmark<trf_d_t>(cfg, "_double");
+
+  ::benchmark::Initialize(&argc, argv);
+  ::benchmark::RunSpecifiedBenchmarks();
+  ::benchmark::Shutdown();
+}

--- a/benchmarks/fastor/fastor_vector.cpp
+++ b/benchmarks/fastor/fastor_vector.cpp
@@ -49,7 +49,8 @@ int main(int argc, char** argv) {
   using add_d_t = vector_binaryOP_bm<fastor::vector3, double, bench_op::add>;
   using sub_d_t = vector_binaryOP_bm<fastor::vector3, double, bench_op::sub>;
   using dot_d_t = vector_binaryOP_bm<fastor::vector3, double, bench_op::dot>;
-  using cross_d_t = vector_binaryOP_bm<fastor::vector3, double, bench_op::cross>;
+  using cross_d_t =
+      vector_binaryOP_bm<fastor::vector3, double, bench_op::cross>;
   using normlz_d_t =
       vector_unaryOP_bm<fastor::vector3, double, bench_op::normalize>;
 

--- a/benchmarks/fastor/fastor_vector.cpp
+++ b/benchmarks/fastor/fastor_vector.cpp
@@ -1,0 +1,69 @@
+/** Algebra plugins library, part of the ACTS project
+ *
+ * (c) 2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Project include(s)
+#include "algebra/fastor_fastor.hpp"
+#include "benchmark/common/benchmark_vector.hpp"
+#include "benchmark/fastor/data_generator.hpp"
+
+// Benchmark include
+#include <benchmark/benchmark.h>
+
+// System include(s)
+#include <iostream>
+
+using namespace algebra;
+
+/// Run vector benchmarks
+int main(int argc, char** argv) {
+
+  //
+  // Prepare benchmarks
+  //
+  algebra::benchmark_base::configuration cfg{};
+  cfg.n_samples(100000);
+
+  using phi_f_t = vector_unaryOP_bm<fastor::vector3, float, bench_op::phi>;
+  using theta_f_t = vector_unaryOP_bm<fastor::vector3, float, bench_op::theta>;
+  using perp_f_t = vector_unaryOP_bm<fastor::vector3, float, bench_op::perp>;
+  using norm_f_t = vector_unaryOP_bm<fastor::vector3, float, bench_op::norm>;
+  using eta_f_t = vector_unaryOP_bm<fastor::vector3, float, bench_op::eta>;
+
+  using add_f_t = vector_binaryOP_bm<fastor::vector3, float, bench_op::add>;
+  using sub_f_t = vector_binaryOP_bm<fastor::vector3, float, bench_op::sub>;
+  using dot_f_t = vector_binaryOP_bm<fastor::vector3, float, bench_op::dot>;
+  using cross_f_t = vector_binaryOP_bm<fastor::vector3, float, bench_op::cross>;
+  using normlz_f_t =
+      vector_unaryOP_bm<fastor::vector3, float, bench_op::normalize>;
+
+  using phi_d_t = vector_unaryOP_bm<fastor::vector3, double, bench_op::phi>;
+  using theta_d_t = vector_unaryOP_bm<fastor::vector3, double, bench_op::theta>;
+  using perp_d_t = vector_unaryOP_bm<fastor::vector3, double, bench_op::perp>;
+  using norm_d_t = vector_unaryOP_bm<fastor::vector3, double, bench_op::norm>;
+  using eta_d_t = vector_unaryOP_bm<fastor::vector3, double, bench_op::eta>;
+
+  using add_d_t = vector_binaryOP_bm<fastor::vector3, double, bench_op::add>;
+  using sub_d_t = vector_binaryOP_bm<fastor::vector3, double, bench_op::sub>;
+  using dot_d_t = vector_binaryOP_bm<fastor::vector3, double, bench_op::dot>;
+  using cross_d_t = vector_binaryOP_bm<fastor::vector3, double, bench_op::cross>;
+  using normlz_d_t =
+      vector_unaryOP_bm<fastor::vector3, double, bench_op::normalize>;
+
+  std::cout << "-------------------------------------------\n"
+            << "Algebra-Plugins 'vector' benchmark (Fastor)\n"
+            << "-------------------------------------------\n\n"
+            << cfg;
+
+  //
+  // Register all benchmarks
+  //
+  ALGEBRA_PLUGINS_REGISTER_VECTOR_BENCH(cfg)
+
+  ::benchmark::Initialize(&argc, argv);
+  ::benchmark::RunSpecifiedBenchmarks();
+  ::benchmark::Shutdown();
+}

--- a/benchmarks/fastor/include/benchmark/fastor/data_generator.hpp
+++ b/benchmarks/fastor/include/benchmark/fastor/data_generator.hpp
@@ -10,6 +10,10 @@
 // Project include(s)
 #include "algebra/fastor_fastor.hpp"
 
+// System include(s)
+#include <algorithm>
+#include <vector>
+
 namespace algebra {
 
 /// Fill an @c Fastor based vector with random values

--- a/benchmarks/fastor/include/benchmark/fastor/data_generator.hpp
+++ b/benchmarks/fastor/include/benchmark/fastor/data_generator.hpp
@@ -1,0 +1,35 @@
+/** Algebra plugins library, part of the ACTS project
+ *
+ * (c) 2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+ #pragma once
+
+ // Project include(s)
+ #include "algebra/fastor_fastor.hpp"
+
+namespace algebra {
+
+/// Fill an @c Fastor based vector with random values
+template <concepts::vector vector_t>
+inline void fill_random_vec(std::vector<vector_t> &collection) {
+
+auto rand_obj = [](vector_t& v) { return v.random(); };
+
+collection.resize(collection.capacity());
+std::ranges::for_each(collection, rand_obj);
+}
+
+/// Fill a @c Fastor based matrix with random values
+template <concepts::matrix matrix_t>
+inline void fill_random_matrix(std::vector<matrix_t> &collection) {
+
+auto rand_obj = [](matrix_t& m) { return m.random(); };
+
+collection.resize(collection.capacity());
+std::ranges::for_each(collection, rand_obj);
+}
+
+}

--- a/benchmarks/fastor/include/benchmark/fastor/data_generator.hpp
+++ b/benchmarks/fastor/include/benchmark/fastor/data_generator.hpp
@@ -16,17 +16,46 @@ namespace algebra {
 template <concepts::vector vector_t>
 inline void fill_random_vec(std::vector<vector_t> &collection) {
 
-auto rand_obj = [](vector_t& v) { return v.random(); };
+auto rand_obj = [](vector_t& v) { v.random(); };
 
 collection.resize(collection.capacity());
 std::ranges::for_each(collection, rand_obj);
+}
+
+/// Fill a @c Fastor based transform3 with random values
+template <concepts::transform3D transform3_t>
+inline void fill_random_trf(std::vector<transform3_t> &collection) {
+
+  using vector_t = typename transform3_t::vector3;
+
+  auto rand_obj = [](transform3_t& trf) {
+    vector_t x_axis;
+    vector_t z_axis;
+    vector_t t;
+
+    x_axis.random();
+    x_axis = vector::normalize(x_axis);
+    z_axis.random();
+    t.random();
+    t = vector::normalize(t);
+
+    // Gram-Schmidt projection
+    typename transform3_t::scalar_type coeff =
+        vector::dot(x_axis, z_axis) / vector::norm(x_axis);
+    z_axis = x_axis - coeff * z_axis;
+
+    trf = transform3_t{t, x_axis, vector::normalize(z_axis)};
+  };
+
+  collection.resize(collection.capacity());
+  std::ranges::for_each(collection, rand_obj);
 }
 
 /// Fill a @c Fastor based matrix with random values
 template <concepts::matrix matrix_t>
 inline void fill_random_matrix(std::vector<matrix_t> &collection) {
 
-auto rand_obj = [](matrix_t& m) { return m.random(); };
+auto rand_obj = [](matrix_t& m) { m.random(); };
 
 collection.resize(collection.capacity());
 std::ranges::for_each(collection, rand_obj);

--- a/benchmarks/fastor/include/benchmark/fastor/data_generator.hpp
+++ b/benchmarks/fastor/include/benchmark/fastor/data_generator.hpp
@@ -5,26 +5,26 @@
  * Mozilla Public License Version 2.0
  */
 
- #pragma once
+#pragma once
 
- // Project include(s)
- #include "algebra/fastor_fastor.hpp"
+// Project include(s)
+#include "algebra/fastor_fastor.hpp"
 
 namespace algebra {
 
 /// Fill an @c Fastor based vector with random values
 template <concepts::vector vector_t>
-inline void fill_random_vec(std::vector<vector_t> &collection) {
+inline void fill_random_vec(std::vector<vector_t>& collection) {
 
-auto rand_obj = [](vector_t& v) { v.random(); };
+  auto rand_obj = [](vector_t& v) { v.random(); };
 
-collection.resize(collection.capacity());
-std::ranges::for_each(collection, rand_obj);
+  collection.resize(collection.capacity());
+  std::ranges::for_each(collection, rand_obj);
 }
 
 /// Fill a @c Fastor based transform3 with random values
 template <concepts::transform3D transform3_t>
-inline void fill_random_trf(std::vector<transform3_t> &collection) {
+inline void fill_random_trf(std::vector<transform3_t>& collection) {
 
   using vector_t = typename transform3_t::vector3;
 
@@ -53,12 +53,12 @@ inline void fill_random_trf(std::vector<transform3_t> &collection) {
 
 /// Fill a @c Fastor based matrix with random values
 template <concepts::matrix matrix_t>
-inline void fill_random_matrix(std::vector<matrix_t> &collection) {
+inline void fill_random_matrix(std::vector<matrix_t>& collection) {
 
-auto rand_obj = [](matrix_t& m) { m.random(); };
+  auto rand_obj = [](matrix_t& m) { m.random(); };
 
-collection.resize(collection.capacity());
-std::ranges::for_each(collection, rand_obj);
+  collection.resize(collection.capacity());
+  std::ranges::for_each(collection, rand_obj);
 }
 
-}
+}  // namespace algebra


### PR DESCRIPTION
As the title states, I added Fastor to the benchmark suite so now, it emits all the `algebra_benchmark_fastor_{getter,transform3,matrix,vector}` binaries.