### PR TITLE
Minor fixes and improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ set( CMAKE_ARCHIVE_OUTPUT_DIRECTORY
 option( ALGEBRA_PLUGINS_INCLUDE_EIGEN
    "Include Eigen types in Algebra Plugins" FALSE )
 option( ALGEBRA_PLUGINS_INCLUDE_SMATRIX
-   "Include Smatrix types in Algebra Plugins" FALSE )
+   "Include SMatrix types in Algebra Plugins" FALSE )
 option( ALGEBRA_PLUGINS_INCLUDE_VC
    "Include Vc types in Algebra Plugins" FALSE )
 option( ALGEBRA_PLUGINS_INCLUDE_FASTOR

--- a/README.md
+++ b/README.md
@@ -48,3 +48,5 @@ Available options:
     [FetchContent](https://cmake.org/cmake/help/latest/module/FetchContent.html).
 - `ALGEBRA_PLUGINS_BUILD_TESTING`: Turn the build/setup of the unit tests on/off
   (`ON` by default)
+- `ALGEBRA_PLUGINS_BUILD_BENCHMARKS`: Turn the build/setup of the benchmarks on/off
+  (`OFF` by default)

--- a/benchmarks/array/array_getter.cpp
+++ b/benchmarks/array/array_getter.cpp
@@ -14,7 +14,7 @@
 #include <benchmark/benchmark.h>
 
 // System include(s)
-#include <string>
+#include <iostream>
 
 using namespace algebra;
 

--- a/benchmarks/array/array_transform3.cpp
+++ b/benchmarks/array/array_transform3.cpp
@@ -14,6 +14,9 @@
 // Benchmark include
 #include <benchmark/benchmark.h>
 
+// System include(s)
+#include <iostream>
+
 using namespace algebra;
 
 /// Run vector benchmarks
@@ -28,7 +31,7 @@ int main(int argc, char** argv) {
   using trf_f_t = transform3_bm<array::transform3<float>>;
   using trf_d_t = transform3_bm<array::transform3<double>>;
 
-  std::cout << "-----------------------------------------------\n"
+  std::cout << "---------------------------------------------------\n"
             << "Algebra-Plugins 'transform3' benchmark (std::array)\n"
             << "---------------------------------------------------\n\n"
             << cfg;

--- a/benchmarks/array/array_vector.cpp
+++ b/benchmarks/array/array_vector.cpp
@@ -14,7 +14,7 @@
 #include <benchmark/benchmark.h>
 
 // System include(s)
-#include <string>
+#include <iostream>
 
 using namespace algebra;
 

--- a/benchmarks/eigen/eigen_getter.cpp
+++ b/benchmarks/eigen/eigen_getter.cpp
@@ -14,7 +14,7 @@
 #include <benchmark/benchmark.h>
 
 // System include(s)
-#include <string>
+#include <iostream>
 
 using namespace algebra;
 

--- a/benchmarks/eigen/eigen_matrix.cpp
+++ b/benchmarks/eigen/eigen_matrix.cpp
@@ -106,8 +106,8 @@ int main(int argc, char** argv) {
                                          eigen::vector_type<double, 8>>;
 
   std::cout << "------------------------------------------\n"
-            << "Algebra-Plugins 'matrix' benchmark (Eigen3)\n"
-            << "-------------------------------------------\n\n"
+            << "Algebra-Plugins 'matrix' benchmark (Eigen)\n"
+            << "------------------------------------------\n\n"
             << cfg;
 
   //

--- a/benchmarks/eigen/eigen_transform3.cpp
+++ b/benchmarks/eigen/eigen_transform3.cpp
@@ -14,6 +14,9 @@
 // Benchmark include
 #include <benchmark/benchmark.h>
 
+// System include(s)
+#include <iostream>
+
 using namespace algebra;
 
 /// Run vector benchmarks
@@ -28,9 +31,9 @@ int main(int argc, char** argv) {
   using trf_f_t = transform3_bm<eigen::transform3<float>>;
   using trf_d_t = transform3_bm<eigen::transform3<double>>;
 
-  std::cout << "------------------------------------------\n"
-            << "Algebra-Plugins 'transform3' benchmark (Eigen3)\n"
-            << "-----------------------------------------------\n\n"
+  std::cout << "----------------------------------------------\n"
+            << "Algebra-Plugins 'transform3' benchmark (Eigen)\n"
+            << "----------------------------------------------\n\n"
             << cfg;
 
   //

--- a/benchmarks/eigen/eigen_vector.cpp
+++ b/benchmarks/eigen/eigen_vector.cpp
@@ -14,7 +14,7 @@
 #include <benchmark/benchmark.h>
 
 // System include(s)
-#include <string>
+#include <iostream>
 
 using namespace algebra;
 

--- a/benchmarks/vc_aos/vc_aos_getter.cpp
+++ b/benchmarks/vc_aos/vc_aos_getter.cpp
@@ -14,7 +14,7 @@
 #include <benchmark/benchmark.h>
 
 // System include(s)
-#include <string>
+#include <iostream>
 
 using namespace algebra;
 

--- a/benchmarks/vc_aos/vc_aos_matrix.cpp
+++ b/benchmarks/vc_aos/vc_aos_matrix.cpp
@@ -105,7 +105,7 @@ int main(int argc, char** argv) {
   using mat88_vec_d_t = matrix_vector_bm<vc_aos::matrix_type<double, 8, 8>,
                                          vc_aos::vector_type<double, 8>>;
 
-  std::cout << "------------------------------------------\n"
+  std::cout << "-------------------------------------------\n"
             << "Algebra-Plugins 'matrix' benchmark (Vc AoS)\n"
             << "-------------------------------------------\n\n"
             << cfg;

--- a/benchmarks/vc_aos/vc_aos_transform3.cpp
+++ b/benchmarks/vc_aos/vc_aos_transform3.cpp
@@ -14,6 +14,9 @@
 // Benchmark include
 #include <benchmark/benchmark.h>
 
+// System include(s)
+#include <iostream>
+
 using namespace algebra;
 
 /// Run vector benchmarks
@@ -28,9 +31,9 @@ int main(int argc, char** argv) {
   using trf_f_t = transform3_bm<vc_aos::transform3<float>>;
   using trf_d_t = transform3_bm<vc_aos::transform3<double>>;
 
-  std::cout << "-------------------------------------------\n"
+  std::cout << "-----------------------------------------------\n"
             << "Algebra-Plugins 'transform3' benchmark (Vc AoS)\n"
-            << "-------------------------------------------\n\n"
+            << "-----------------------------------------------\n\n"
             << cfg;
 
   //

--- a/benchmarks/vc_aos/vc_aos_vector.cpp
+++ b/benchmarks/vc_aos/vc_aos_vector.cpp
@@ -13,6 +13,9 @@
 // Benchmark include
 #include <benchmark/benchmark.h>
 
+// System include(s)
+#include <iostream>
+
 using namespace algebra;
 
 /// Run vector benchmarks

--- a/benchmarks/vc_soa/vc_soa_getter.cpp
+++ b/benchmarks/vc_soa/vc_soa_getter.cpp
@@ -15,7 +15,7 @@
 #include <benchmark/benchmark.h>
 
 // System include(s)
-#include <string>
+#include <iostream>
 
 using namespace algebra;
 

--- a/benchmarks/vc_soa/vc_soa_transform3.cpp
+++ b/benchmarks/vc_soa/vc_soa_transform3.cpp
@@ -14,6 +14,9 @@
 // Benchmark include
 #include <benchmark/benchmark.h>
 
+// System include(s)
+#include <iostream>
+
 using namespace algebra;
 
 /// Run vector benchmarks

--- a/benchmarks/vc_soa/vc_soa_vector.cpp
+++ b/benchmarks/vc_soa/vc_soa_vector.cpp
@@ -14,6 +14,9 @@
 // Benchmark include
 #include <benchmark/benchmark.h>
 
+// System include(s)
+#include <iostream>
+
 using namespace algebra;
 
 /// Run vector benchmarks

--- a/math/fastor/include/algebra/math/impl/fastor_vector.hpp
+++ b/math/fastor/include/algebra/math/impl/fastor_vector.hpp
@@ -38,7 +38,7 @@ requires(N >= 3) ALGEBRA_HOST inline scalar_t
   return algebra::math::atan2(Fastor::norm(v(Fastor::fseq<0, 2>())), v[2]);
 }
 
-/// This method retrieves the perpenticular magnitude of a vector with rows >= 2
+/// This method retrieves the perpendicular magnitude of a vector with rows >= 2
 ///
 /// @param v the input vector
 template <concepts::scalar scalar_t, auto N>

--- a/math/vc_soa/include/algebra/math/impl/vc_soa_vector.hpp
+++ b/math/vc_soa/include/algebra/math/impl/vc_soa_vector.hpp
@@ -39,7 +39,7 @@ requires(N >= 2) ALGEBRA_HOST_DEVICE
   return Vc::atan2(v[1], v[0]);
 }
 
-/// This method retrieves the perpenticular magnitude of a vector with rows >= 2
+/// This method retrieves the perpendicular magnitude of a vector with rows >= 2
 ///
 /// @tparam N dimension of the vector
 /// @tparam value_t value type in the simd vectors


### PR DESCRIPTION
I updated the README to reflect the `ALGEBRA_PLUGINS_BUILD_BENCHMARKS` CMake option.

A bunch of the benchmarking code source files either used `#include <string>` or had no `#include` whatsoever, but was using `std::cout`. I changed all of those to `#include <iostream>`.

Half of the Eigen benchmarks called the library "Eigen3" and the other half called it "Eigen". I changed it so that all of them just say "Eigen".