### PR TITLE
feat: Algebra type casts

### DIFF
--- a/frontend/vc_soa/include/algebra/vc_soa.hpp
+++ b/frontend/vc_soa/include/algebra/vc_soa.hpp
@@ -8,7 +8,7 @@
 #pragma once
 
 // Project include(s).
-#include "algebra/math/generic.hpp"
+#include "algebra/math/impl/generic_matrix.hpp"
 #include "algebra/math/impl/vc_aos_transform3.hpp"
 #include "algebra/math/vc_soa.hpp"
 #include "algebra/storage/vc_soa.hpp"

--- a/math/eigen/CMakeLists.txt
+++ b/math/eigen/CMakeLists.txt
@@ -11,7 +11,7 @@ algebra_add_library(algebra_eigen_math eigen_math
    "include/algebra/math/impl/eigen_transform3.hpp"
    "include/algebra/math/impl/eigen_vector.hpp")
 target_link_libraries(algebra_eigen_math
-   INTERFACE Eigen3::Eigen algebra::common algebra::common_math
+   INTERFACE Eigen3::Eigen algebra::common algebra::utils algebra::common_math
              algebra::eigen_storage)
 algebra_test_public_headers( algebra_eigen_math
    "algebra/math/eigen.hpp" )

--- a/math/eigen/include/algebra/math/impl/eigen_transform3.hpp
+++ b/math/eigen/include/algebra/math/impl/eigen_transform3.hpp
@@ -60,6 +60,10 @@ struct transform3 {
   using matrix44 =
       typename Eigen::Transform<scalar_type, 3, Eigen::Affine>::MatrixType;
 
+  /// Helper type to cast this to another floating point precision
+  template <concepts::scalar o_scalar_t>
+  using other_type = transform3<o_scalar_t>;
+
   /// @}
 
   /// @name Data objects
@@ -127,6 +131,14 @@ struct transform3 {
 
     _data_inv = _data.inverse();
   }
+
+  /// Constructor with arguments: matrix and its inverse
+  ///
+  /// @param m is the full 4x4 matrix
+  /// @param m_inv is the inverse to m
+  ALGEBRA_HOST_DEVICE
+  transform3(const matrix44 &m, const matrix44 &m_inv)
+      : _data{m}, _data_inv{m_inv} {}
 
   /// Constructor with arguments: matrix as std::aray of scalar
   ///

--- a/math/fastor/CMakeLists.txt
+++ b/math/fastor/CMakeLists.txt
@@ -11,7 +11,7 @@ algebra_add_library(algebra_fastor_math fastor_math
    "include/algebra/math/impl/fastor_transform3.hpp"
    "include/algebra/math/impl/fastor_vector.hpp")
 target_link_libraries(algebra_fastor_math
-   INTERFACE Fastor::Fastor algebra::common algebra::common_math
+   INTERFACE Fastor::Fastor algebra::common algebra::utils algebra::common_math
              algebra::fastor_storage)
 algebra_test_public_headers( algebra_fastor_math
    "algebra/math/fastor.hpp" )

--- a/math/fastor/include/algebra/math/impl/fastor_transform3.hpp
+++ b/math/fastor/include/algebra/math/impl/fastor_transform3.hpp
@@ -48,6 +48,10 @@ struct transform3 {
   /// 4x4 matrix type
   using matrix44 = fastor::Matrix<scalar_type, 4UL, 4UL>;
 
+  /// Helper type to cast this to another floating point precision
+  template <concepts::scalar o_scalar_t>
+  using other_type = transform3<o_scalar_t>;
+
   /// @}
 
   /// @name Data objects
@@ -116,20 +120,24 @@ struct transform3 {
   ///
   /// @param m is the full 4x4 matrix
   ALGEBRA_HOST
-  explicit transform3(const matrix44 &m) {
-    _data = m;
-
+  explicit transform3(const matrix44 &m) : _data{m} {
     _data_inv = Fastor::inverse(_data);
   }
+
+  /// Constructor with arguments: matrix and its inverse
+  ///
+  /// @param m is the full 4x4 matrix
+  /// @param m_inv is the inverse to m
+  ALGEBRA_HOST
+  transform3(const matrix44 &m, const matrix44 &m_inv)
+      : _data{m}, _data_inv{m_inv} {}
 
   /// Constructor with arguments: matrix as Fastor::Tensor<scalar_t, 16> of
   /// scalars
   ///
   /// @param ma is the full 4x4 matrix as a 16-element array
   ALGEBRA_HOST
-  explicit transform3(const array_type<16> &ma) {
-    _data = ma;
-
+  explicit transform3(const array_type<16> &ma) : _data{ma} {
     _data_inv = Fastor::inverse(_data);
   }
 

--- a/math/generic/CMakeLists.txt
+++ b/math/generic/CMakeLists.txt
@@ -21,6 +21,6 @@ algebra_add_library(algebra_generic_math generic_math
    "include/algebra/math/algorithms/matrix/inverse/partial_pivot_lud.hpp"
    "include/algebra/math/algorithms/utils/algorithm_finder.hpp")
 target_link_libraries(algebra_generic_math
-   INTERFACE algebra::common algebra::common_math)
+   INTERFACE algebra::common algebra::utils algebra::common_math)
 algebra_test_public_headers( algebra_generic_math
    "algebra/math/generic.hpp" )

--- a/math/generic/include/algebra/math/impl/generic_transform3.hpp
+++ b/math/generic/include/algebra/math/impl/generic_transform3.hpp
@@ -13,6 +13,12 @@
 #include "algebra/math/impl/generic_vector.hpp"
 #include "algebra/qualifiers.hpp"
 #include "algebra/type_traits.hpp"
+#include "algebra/utils/approximately_equal.hpp"
+
+// System include(s)
+#include <cassert>
+#include <concepts>
+#include <limits>
 
 namespace algebra::generic::math {
 
@@ -153,7 +159,28 @@ struct transform3 {
   /// @param m_inv is the inverse to m
   ALGEBRA_HOST_DEVICE
   transform3(const matrix44 &m, const matrix44 &m_inv)
-      : _data{m}, _data_inv{m_inv} {}
+      : _data{m}, _data_inv{m_inv} {
+    // The assertion will not hold for (casts to) int
+    if constexpr (std::floating_point<scalar_type>) {
+      // The concrete type of matrix mult is not available at this point
+      auto prod = generic::math::zero<matrix44>();
+
+      constexpr element_getter elem{};
+
+      for (index_t i = 0; i < 4; ++i) {
+        for (index_t j = 0; j < 4; ++j) {
+          for (index_t k = 0; k < 4; ++k) {
+            elem(prod, k, j) += elem(m, k, i) * elem(m_inv, i, j);
+          }
+        }
+      }
+
+      [[maybe_unused]] constexpr auto epsilon{
+          std::numeric_limits<scalar_type>::epsilon()};
+      assert(algebra::approx_equal(prod, generic::math::identity<matrix44>(),
+                                   16.f * epsilon, 1e-6f));
+    }
+  }
 
   /// Constructor with arguments: matrix as array of scalar
   ///

--- a/math/generic/include/algebra/math/impl/generic_transform3.hpp
+++ b/math/generic/include/algebra/math/impl/generic_transform3.hpp
@@ -53,6 +53,10 @@ struct transform3 {
   using matrix_inversion =
       generic::matrix::inverse::hard_coded<matrix44, element_getter>;
 
+  /// Helper type to cast this to another floating point precision
+  template <concepts::scalar o_scalar_t>
+  using other_type = transform3<index_t, o_scalar_t, matrix_t, array_t>;
+
   /// @}
 
   /// @name Data objects
@@ -142,6 +146,14 @@ struct transform3 {
   explicit transform3(const matrix44 &m) : _data{m} {
     _data_inv = matrix_inversion{}(_data);
   }
+
+  /// Constructor with arguments: matrix and its inverse
+  ///
+  /// @param m is the full 4x4 matrix
+  /// @param m_inv is the inverse to m
+  ALGEBRA_HOST_DEVICE
+  transform3(const matrix44 &m, const matrix44 &m_inv)
+      : _data{m}, _data_inv{m_inv} {}
 
   /// Constructor with arguments: matrix as array of scalar
   ///

--- a/math/smatrix/CMakeLists.txt
+++ b/math/smatrix/CMakeLists.txt
@@ -15,7 +15,7 @@ algebra_add_library(algebra_smatrix_math smatrix_math
    "include/algebra/math/impl/smatrix_transform3.hpp"
    "include/algebra/math/impl/smatrix_vector.hpp")
 target_link_libraries(algebra_smatrix_math
-   INTERFACE algebra::common algebra::smatrix_storage ROOT::Core ROOT::MathCore
-             ROOT::Smatrix)
+   INTERFACE algebra::common algebra::utils algebra::smatrix_storage ROOT::Core
+             ROOT::MathCore ROOT::Smatrix)
 algebra_test_public_headers( algebra_smatrix_math
    "algebra/math/smatrix.hpp" )

--- a/math/smatrix/include/algebra/math/impl/smatrix_transform3.hpp
+++ b/math/smatrix/include/algebra/math/impl/smatrix_transform3.hpp
@@ -41,6 +41,10 @@ struct transform3 {
   /// 4x4 matrix type
   using matrix44 = ROOT::Math::SMatrix<scalar_type, 4, 4>;
 
+  /// Helper type to cast this to another floating point precision
+  template <concepts::scalar o_scalar_t>
+  using other_type = transform3<o_scalar_t>;
+
   /// @}
 
   /// @name Data objects
@@ -116,6 +120,14 @@ struct transform3 {
     _data_inv = _data.Inverse(ifail);
     SMATRIX_CHECK(ifail);
   }
+
+  /// Constructor with arguments: matrix and its inverse
+  ///
+  /// @param m is the full 4x4 matrix
+  /// @param m_inv is the inverse to m
+  ALGEBRA_HOST
+  transform3(const matrix44 &m, const matrix44 &m_inv)
+      : _data{m}, _data_inv{m_inv} {}
 
   /// Constructor with arguments: matrix as ROOT::Math::SVector<scalar_t, 16> of
   /// scalars

--- a/math/vc_aos/CMakeLists.txt
+++ b/math/vc_aos/CMakeLists.txt
@@ -11,6 +11,6 @@ algebra_add_library( algebra_vc_aos_math vc_aos_math
    "include/algebra/math/impl/vc_aos_transform3.hpp"
    "include/algebra/math/impl/vc_aos_vector.hpp" )
 target_link_libraries( algebra_vc_aos_math
-   INTERFACE Vc::Vc algebra::common algebra::common_math algebra::generic_math algebra::vc_aos_storage )
+   INTERFACE Vc::Vc algebra::common algebra::utils algebra::common_math algebra::generic_math algebra::vc_aos_storage )
 algebra_test_public_headers( algebra_vc_aos_math
    "algebra/math/vc_aos.hpp" )

--- a/math/vc_aos/include/algebra/math/impl/vc_aos_transform3.hpp
+++ b/math/vc_aos/include/algebra/math/impl/vc_aos_transform3.hpp
@@ -72,6 +72,10 @@ struct transform3 {
   /// Function (object) used for accessing a matrix element
   using element_getter = storage::element_getter;
 
+  /// Helper type to cast this to another floating point precision
+  template <concepts::scalar o_scalar_t>
+  using other_type = transform3<array_t, o_scalar_t>;
+
   /// @}
 
   /// @name Data objects
@@ -127,6 +131,14 @@ struct transform3 {
   /// @param m is the full 4x4 matrix with simd-vector elements
   ALGEBRA_HOST_DEVICE
   explicit transform3(const matrix44 &m) : _data{m}, _data_inv{invert(_data)} {}
+
+  /// Constructor with arguments: matrix and its inverse
+  ///
+  /// @param m is the full 4x4 matrix
+  /// @param m_inv is the inverse to m
+  ALGEBRA_HOST_DEVICE
+  transform3(const matrix44 &m, const matrix44 &m_inv)
+      : _data{m}, _data_inv{m_inv} {}
 
   /// Constructor with arguments: matrix as std::aray of scalar
   ///

--- a/storage/vc_aos/CMakeLists.txt
+++ b/storage/vc_aos/CMakeLists.txt
@@ -13,7 +13,4 @@ algebra_add_library( algebra_vc_aos_storage vc_aos_storage
 target_link_libraries( algebra_vc_aos_storage
    INTERFACE algebra::common algebra::common_storage Vc::Vc algebra::common_math )
 algebra_test_public_headers( algebra_vc_aos_storage
-   "algebra/storage/vc_aos.hpp"
-   "algebra/storage/impl/vc_aos_approximately_equal.hpp"
-   "algebra/storage/impl/vc_aos_concepts.hpp"
-   "algebra/storage/impl/vc_aos_getter.hpp" )
+   "algebra/storage/vc_aos.hpp" )

--- a/storage/vc_soa/CMakeLists.txt
+++ b/storage/vc_soa/CMakeLists.txt
@@ -13,7 +13,4 @@ algebra_add_library( algebra_vc_soa_storage vc_soa_storage
 target_link_libraries( algebra_vc_soa_storage
    INTERFACE algebra::common algebra::common_storage Vc::Vc algebra::vc_aos_storage )
 algebra_test_public_headers( algebra_vc_soa_storage
-   "algebra/storage/vc_soa.hpp"
-   "algebra/storage/impl/vc_soa_casts.hpp"
-   "algebra/storage/impl/vc_soa_concepts.hpp"
-   "algebra/storage/impl/vc_soa_getter.hpp" )
+   "algebra/storage/vc_soa.hpp" )

--- a/storage/vc_soa/CMakeLists.txt
+++ b/storage/vc_soa/CMakeLists.txt
@@ -7,9 +7,13 @@
 # Set up the library.
 algebra_add_library( algebra_vc_soa_storage vc_soa_storage
    "include/algebra/storage/vc_soa.hpp"
+   "include/algebra/storage/impl/vc_soa_casts.hpp"
    "include/algebra/storage/impl/vc_soa_concepts.hpp"
    "include/algebra/storage/impl/vc_soa_getter.hpp" )
 target_link_libraries( algebra_vc_soa_storage
    INTERFACE algebra::common algebra::common_storage Vc::Vc algebra::vc_aos_storage )
 algebra_test_public_headers( algebra_vc_soa_storage
-   "algebra/storage/vc_soa.hpp" )
+   "algebra/storage/vc_soa.hpp"
+   "algebra/storage/impl/vc_soa_casts.hpp"
+   "algebra/storage/impl/vc_soa_concepts.hpp"
+   "algebra/storage/impl/vc_soa_getter.hpp" )

--- a/storage/vc_soa/include/algebra/storage/impl/vc_soa_casts.hpp
+++ b/storage/vc_soa/include/algebra/storage/impl/vc_soa_casts.hpp
@@ -1,0 +1,49 @@
+/** Algebra plugins, part of the ACTS project
+ *
+ * (c) 2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s)
+#include "algebra/concepts.hpp"
+#include "algebra/qualifiers.hpp"
+
+// Vc include(s).
+#ifdef _MSC_VER
+#pragma warning(push, 0)
+#endif  // MSVC
+#include <Vc/Vc>
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif  // MSVC
+
+namespace algebra {
+
+// Forward declare the generic cast impl from matrices
+template <concepts::value value_t, concepts::matrix matrix_t>
+ALGEBRA_HOST_DEVICE constexpr auto cast_to(const matrix_t& m);
+
+/// Cast a Vc SoA salar @param s to the precision given by @tparam other_value_t
+template <concepts::value other_value_t, concepts::value value_t>
+ALGEBRA_HOST constexpr auto cast_to(const Vc::Vector<value_t>& s) {
+  using other_scalar_t = Vc::Vector<other_value_t>;
+
+  return Vc::simd_cast<other_scalar_t>(s);
+}
+
+/// Cast a Vc SoA transform @param trf to the precision given by @tparam value_t
+template <concepts::value value_t, concepts::transform3D transform_t>
+requires Vc::is_simd_vector<typename transform_t::scalar_type>::value
+    ALGEBRA_HOST_DEVICE constexpr auto
+    cast_to(const transform_t& trf) {
+  using scalar_t = Vc::Vector<value_t>;
+  using new_trf3_t = typename transform_t::template other_type<scalar_t>;
+
+  return new_trf3_t{cast_to<value_t>(trf.matrix()),
+                    cast_to<value_t>(trf.matrix_inverse())};
+}
+
+}  // namespace algebra

--- a/storage/vc_soa/include/algebra/storage/vc_soa.hpp
+++ b/storage/vc_soa/include/algebra/storage/vc_soa.hpp
@@ -10,6 +10,7 @@
 // Project include(s).
 #include "algebra/concepts.hpp"
 #include "algebra/storage/impl/vc_aos_approximately_equal.hpp"
+#include "algebra/storage/impl/vc_soa_casts.hpp"
 #include "algebra/storage/impl/vc_soa_getter.hpp"
 #include "algebra/storage/matrix.hpp"
 #include "algebra/storage/vector.hpp"

--- a/tests/common/test_host_basics.hpp
+++ b/tests/common/test_host_basics.hpp
@@ -9,6 +9,7 @@
 
 // Project include(s).
 #include "algebra/utils/approximately_equal.hpp"
+#include "algebra/utils/casts.hpp"
 #include "algebra/utils/print.hpp"
 
 // Local include(s).
@@ -301,6 +302,33 @@ TYPED_TEST_P(test_host_basics_vector, local_vectors) {
   vA_err = rel_err * vA;
   ASSERT_TRUE(algebra::approx_equal(vA, vA_err, 18.f * epsilon));
   ASSERT_FALSE(algebra::approx_equal(vA, vA_err, 16.f * epsilon));
+  // Cast to (different) precision
+  const auto vA_cast_f = algebra::cast_to<float>(vA);
+
+  for (typename TypeParam::size_type i = 0; i < 2; ++i) {
+    auto elem_i = vA_cast_f[i];
+
+    static_assert(std::same_as<decltype(elem_i), float>);
+    ASSERT_FLOAT_EQ(elem_i, static_cast<float>(vA[i]));
+  }
+
+  const auto vA_cast_d = algebra::cast_to<double>(vA);
+
+  for (typename TypeParam::size_type i = 0; i < 2; ++i) {
+    auto elem_i = vA_cast_d[i];
+
+    static_assert(std::same_as<decltype(elem_i), double>);
+    ASSERT_DOUBLE_EQ(elem_i, static_cast<double>(vA[i]));
+  }
+
+  const auto vA_cast_i = algebra::cast_to<int>(vA);
+
+  for (typename TypeParam::size_type i = 0; i < 2; ++i) {
+    auto elem_i = vA_cast_i[i];
+
+    static_assert(std::same_as<decltype(elem_i), int>);
+    ASSERT_EQ(elem_i, static_cast<int>(vA[i]));
+  }
 
   // Assignment
   typename TypeParam::point2 vB = vA;
@@ -380,6 +408,34 @@ TYPED_TEST_P(test_host_basics_vector, vector3) {
 
   // Test printing
   std::cout << vA << std::endl;
+
+  // Cast to (different) precision
+  const auto vA_cast_f = algebra::cast_to<float>(vA);
+
+  for (typename TypeParam::size_type i = 0; i < 3; ++i) {
+    auto elem_i = vA_cast_f[i];
+
+    static_assert(std::same_as<decltype(elem_i), float>);
+    ASSERT_FLOAT_EQ(elem_i, static_cast<float>(vA[i]));
+  }
+
+  const auto vA_cast_d = algebra::cast_to<double>(vA);
+
+  for (typename TypeParam::size_type i = 0; i < 3; ++i) {
+    auto elem_i = vA_cast_d[i];
+
+    static_assert(std::same_as<decltype(elem_i), double>);
+    ASSERT_DOUBLE_EQ(elem_i, static_cast<double>(vA[i]));
+  }
+
+  const auto vA_cast_i = algebra::cast_to<int>(vA);
+
+  for (typename TypeParam::size_type i = 0; i < 3; ++i) {
+    auto elem_i = vA_cast_i[i];
+
+    static_assert(std::same_as<decltype(elem_i), int>);
+    ASSERT_EQ(elem_i, static_cast<int>(vA[i]));
+  }
 
   // Assignment
   typename TypeParam::vector3 vB = vA;
@@ -495,6 +551,42 @@ TYPED_TEST_P(test_host_basics_matrix, matrix_2x3) {
   algebra::getter::element(m23, 1, 1) = 5.f;
   algebra::getter::element(m23, 1, 2) = 6.f;
 
+  // Cast to (different) precision
+  const auto m23_cast_f = algebra::cast_to<float>(m23);
+
+  for (typename TypeParam::size_type j = 0; j < 3; ++j) {
+    for (typename TypeParam::size_type i = 0; i < 2; ++i) {
+      auto elem_i = algebra::getter::element(m23_cast_f, i, j);
+
+      static_assert(std::same_as<decltype(elem_i), float>);
+      ASSERT_FLOAT_EQ(elem_i,
+                      static_cast<float>(algebra::getter::element(m23, i, j)));
+    }
+  }
+
+  const auto m23_cast_d = algebra::cast_to<double>(m23);
+
+  for (typename TypeParam::size_type j = 0; j < 3; ++j) {
+    for (typename TypeParam::size_type i = 0; i < 2; ++i) {
+      auto elem_i = algebra::getter::element(m23_cast_d, i, j);
+
+      static_assert(std::same_as<decltype(elem_i), double>);
+      ASSERT_DOUBLE_EQ(
+          elem_i, static_cast<double>(algebra::getter::element(m23, i, j)));
+    }
+  }
+
+  const auto m23_cast_i = algebra::cast_to<int>(m23);
+
+  for (typename TypeParam::size_type j = 0; j < 3; ++j) {
+    for (typename TypeParam::size_type i = 0; i < 2; ++i) {
+      auto elem_i = algebra::getter::element(m23_cast_i, i, j);
+
+      static_assert(std::same_as<decltype(elem_i), int>);
+      ASSERT_EQ(elem_i, static_cast<int>(algebra::getter::element(m23, i, j)));
+    }
+  }
+
   typename TypeParam::vector2 v2 = m23 * vE;
 
   ASSERT_NEAR(v2[0], 14, this->m_epsilon);
@@ -518,6 +610,36 @@ TYPED_TEST_P(test_host_basics_matrix, matrix_3x1) {
 
   // Test printing
   std::cout << vF << std::endl;
+
+  // Cast to (different) precision
+  const auto vF_cast_f = algebra::cast_to<float>(vF);
+
+  for (typename TypeParam::size_type i = 0; i < 3; ++i) {
+    auto elem_i = algebra::getter::element(vF_cast_f, i, 0);
+
+    static_assert(std::same_as<decltype(elem_i), float>);
+    ASSERT_FLOAT_EQ(elem_i,
+                    static_cast<float>(algebra::getter::element(vF, i, 0)));
+  }
+
+  const auto vF_cast_d = algebra::cast_to<double>(vF);
+
+  for (typename TypeParam::size_type i = 0; i < 3; ++i) {
+    auto elem_i = algebra::getter::element(vF_cast_d, i, 0);
+
+    static_assert(std::same_as<decltype(elem_i), double>);
+    ASSERT_DOUBLE_EQ(elem_i,
+                     static_cast<double>(algebra::getter::element(vF, i, 0)));
+  }
+
+  const auto vF_cast_i = algebra::cast_to<int>(vF);
+
+  for (typename TypeParam::size_type i = 0; i < 3; ++i) {
+    auto elem_i = algebra::getter::element(vF_cast_i, i, 0);
+
+    static_assert(std::same_as<decltype(elem_i), int>);
+    ASSERT_EQ(elem_i, static_cast<int>(algebra::getter::element(vF, i, 0)));
+  }
 
   typename TypeParam::vector3 vD{1.f, 1.f, 1.f};
   typename TypeParam::vector3 vG = algebra::vector::cross(vD, vF);
@@ -991,6 +1113,43 @@ TYPED_TEST_P(test_host_basics_matrix, matrix_6x6) {
   ASSERT_NEAR(algebra::getter::element(m66_big_inv, 5, 5), -36.f / 36.f,
               this->m_isclose);
 
+  // Cast to (different) precision
+  const auto m66_cast_f = algebra::cast_to<float>(m66_big_inv);
+
+  for (typename TypeParam::size_type j = 0; j < 6; ++j) {
+    for (typename TypeParam::size_type i = 0; i < 6; ++i) {
+      auto elem_i = algebra::getter::element(m66_cast_f, i, j);
+
+      static_assert(std::same_as<decltype(elem_i), float>);
+      ASSERT_FLOAT_EQ(elem_i, static_cast<float>(
+                                  algebra::getter::element(m66_big_inv, i, j)));
+    }
+  }
+
+  const auto m66_cast_d = algebra::cast_to<double>(m66_big_inv);
+
+  for (typename TypeParam::size_type j = 0; j < 6; ++j) {
+    for (typename TypeParam::size_type i = 0; i < 6; ++i) {
+      auto elem_i = algebra::getter::element(m66_cast_d, i, j);
+
+      static_assert(std::same_as<decltype(elem_i), double>);
+      ASSERT_DOUBLE_EQ(elem_i, static_cast<double>(algebra::getter::element(
+                                   m66_big_inv, i, j)));
+    }
+  }
+
+  const auto m66_cast_i = algebra::cast_to<int>(m66_big_inv);
+
+  for (typename TypeParam::size_type j = 0; j < 6; ++j) {
+    for (typename TypeParam::size_type i = 0; i < 6; ++i) {
+      auto elem_i = algebra::getter::element(m66_cast_i, i, j);
+
+      static_assert(std::same_as<decltype(elem_i), int>);
+      ASSERT_EQ(elem_i,
+                static_cast<int>(algebra::getter::element(m66_big_inv, i, j)));
+    }
+  }
+
   // Test 6 X 6 small matrix determinant
   typename TypeParam::template matrix<6, 6> m66_small;
 
@@ -1205,6 +1364,63 @@ TYPED_TEST_P(test_host_basics_transform, transform3) {
                                           rel_err * x);
   ASSERT_TRUE(algebra::approx_equal(trf1, trf1_err, 200.f * epsilon));
   ASSERT_FALSE(algebra::approx_equal(trf1, trf1_err, 10.f * epsilon));
+  // Cast to (different) precision
+  const auto trf1_cast_f = algebra::cast_to<float>(trf1);
+  const auto& mat_f = trf1_cast_f.matrix();
+  const auto& mat_inv_f = trf1_cast_f.matrix_inverse();
+
+  for (typename TypeParam::size_type j = 0; j < 3; ++j) {
+    for (typename TypeParam::size_type i = 0; i < 2; ++i) {
+
+      auto elem_i = algebra::getter::element(mat_f, i, j);
+      auto elem_inv_i = algebra::getter::element(mat_inv_f, i, j);
+
+      static_assert(std::same_as<decltype(elem_i), float>);
+      static_assert(std::same_as<decltype(elem_inv_i), float>);
+      ASSERT_FLOAT_EQ(
+          elem_i, static_cast<float>(algebra::getter::element(mat_f, i, j)));
+      ASSERT_FLOAT_EQ(elem_inv_i, static_cast<float>(algebra::getter::element(
+                                      mat_inv_f, i, j)));
+    }
+  }
+
+  const auto trf1_cast_d = algebra::cast_to<double>(trf1);
+  const auto& mat_d = trf1_cast_d.matrix();
+  const auto& mat_inv_d = trf1_cast_d.matrix_inverse();
+
+  for (typename TypeParam::size_type j = 0; j < 3; ++j) {
+    for (typename TypeParam::size_type i = 0; i < 2; ++i) {
+
+      auto elem_i = algebra::getter::element(mat_d, i, j);
+      auto elem_inv_i = algebra::getter::element(mat_inv_d, i, j);
+
+      static_assert(std::same_as<decltype(elem_i), double>);
+      static_assert(std::same_as<decltype(elem_inv_i), double>);
+      ASSERT_DOUBLE_EQ(
+          elem_i, static_cast<double>(algebra::getter::element(mat_d, i, j)));
+      ASSERT_DOUBLE_EQ(elem_inv_i, static_cast<double>(algebra::getter::element(
+                                       mat_inv_d, i, j)));
+    }
+  }
+
+  const auto trf1_cast_i = algebra::cast_to<int>(trf1);
+  const auto& mat_i = trf1_cast_i.matrix();
+  const auto& mat_inv_i = trf1_cast_i.matrix_inverse();
+
+  for (typename TypeParam::size_type j = 0; j < 3; ++j) {
+    for (typename TypeParam::size_type i = 0; i < 2; ++i) {
+
+      auto elem_i = algebra::getter::element(mat_i, i, j);
+      auto elem_inv_i = algebra::getter::element(mat_inv_i, i, j);
+
+      static_assert(std::same_as<decltype(elem_i), int>);
+      static_assert(std::same_as<decltype(elem_inv_i), int>);
+      ASSERT_EQ(elem_i,
+                static_cast<int>(algebra::getter::element(mat_i, i, j)));
+      ASSERT_EQ(elem_inv_i,
+                static_cast<int>(algebra::getter::element(mat_inv_i, i, j)));
+    }
+  }
 
   const auto rot = trf2.rotation();
   ASSERT_NEAR(algebra::getter::element(rot, 0, 0), x[0], this->m_epsilon);

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -7,8 +7,10 @@
 # Set up the library.
 algebra_add_library( algebra_utils utils
    "include/algebra/utils/approximately_equal.hpp"
+   "include/algebra/utils/casts.hpp"
    "include/algebra/utils/print.hpp" )
 target_link_libraries( algebra_utils INTERFACE algebra::common algebra_common_math )
 algebra_test_public_headers( algebra_utils
    "algebra/utils/approximately_equal.hpp"
+   "algebra/utils/casts.hpp"
    "algebra/utils/print.hpp" )

--- a/utils/include/algebra/utils/casts.hpp
+++ b/utils/include/algebra/utils/casts.hpp
@@ -1,0 +1,110 @@
+/** Algebra plugins, part of the ACTS project
+ *
+ * (c) 2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s)
+#include "algebra/concepts.hpp"
+#include "algebra/qualifiers.hpp"
+
+// System include(s)
+#include <concepts>
+
+namespace algebra {
+
+/// Cast a salar (might be simd) @param s to the precision given by
+/// @tparam value_t
+template <concepts::value value_t, concepts::scalar scalar_t>
+requires std::convertible_to<scalar_t, value_t>
+    ALGEBRA_HOST_DEVICE constexpr auto cast_to(const scalar_t& s) {
+  return static_cast<value_t>(s);
+}
+
+/// Cast a generic vector or point @param v to the precision given by
+/// @tparam value_t
+template <concepts::value value_t, typename vector_t>
+requires(concepts::vector<vector_t> ||
+         concepts::point<vector_t>) ALGEBRA_HOST_DEVICE
+    constexpr auto cast_to(const vector_t& v) {
+
+  using index_t = algebra::traits::index_t<vector_t>;
+
+  constexpr index_t size{algebra::traits::size<vector_t>};
+
+  using new_vector_t = algebra::traits::get_vector_t<vector_t, size, value_t>;
+  new_vector_t ret;
+
+  static_assert(std::same_as<value_t, algebra::traits::value_t<new_vector_t>>);
+
+  for (index_t i = 0; i < size; ++i) {
+    ret[i] = ::algebra::cast_to<value_t>(v[i]);
+  }
+
+  return ret;
+}
+
+/// Cast a column matrix @param v to the precision given by @tparam value_t
+template <concepts::value value_t, concepts::column_matrix vector_t>
+ALGEBRA_HOST_DEVICE constexpr auto cast_to(const vector_t& v) {
+
+  using index_t = algebra::traits::index_t<vector_t>;
+  using element_getter_t = algebra::traits::element_getter_t<vector_t>;
+
+  constexpr index_t rows{algebra::traits::rows<vector_t>};
+
+  using new_vector_t =
+      algebra::traits::get_matrix_t<vector_t, rows, 1, value_t>;
+  new_vector_t ret;
+
+  static_assert(std::same_as<value_t, algebra::traits::value_t<new_vector_t>>);
+
+  for (index_t i = 0; i < rows; ++i) {
+    element_getter_t{}(ret, i, 0) =
+        ::algebra::cast_to<value_t>(element_getter_t{}(v, i, 0));
+  }
+
+  return ret;
+}
+
+/// Cast a generic matrix @param v to the precision given by @tparam value_t
+template <concepts::value value_t, concepts::matrix matrix_t>
+ALGEBRA_HOST_DEVICE constexpr auto cast_to(const matrix_t& m) {
+
+  using index_t = algebra::traits::index_t<matrix_t>;
+  using element_getter_t = algebra::traits::element_getter_t<matrix_t>;
+
+  constexpr index_t rows{algebra::traits::rows<matrix_t>};
+  constexpr index_t columns{algebra::traits::columns<matrix_t>};
+
+  using new_matrix_t =
+      algebra::traits::get_matrix_t<matrix_t, rows, columns, value_t>;
+  new_matrix_t ret;
+
+  static_assert(std::same_as<value_t, algebra::traits::value_t<new_matrix_t>>);
+
+  for (index_t j = 0; j < columns; ++j) {
+    for (index_t i = 0; i < rows; ++i) {
+      element_getter_t{}(ret, i, j) =
+          ::algebra::cast_to<value_t>(element_getter_t{}(m, i, j));
+    }
+  }
+
+  return ret;
+}
+
+/// Cast a 3D transform @param trf to the precision given by @tparam scalar_t
+template <concepts::scalar scalar_t, concepts::transform3D transform_t>
+requires(!concepts::simd_scalar<scalar_t> &&
+         !concepts::simd_scalar<typename transform_t::scalar_type>)
+    ALGEBRA_HOST_DEVICE constexpr auto cast_to(const transform_t& trf) {
+  using new_trf3_t = typename transform_t::template other_type<scalar_t>;
+
+  return new_trf3_t{::algebra::cast_to<scalar_t>(trf.matrix()),
+                    ::algebra::cast_to<scalar_t>(trf.matrix_inverse())};
+}
+
+}  // namespace algebra


### PR DESCRIPTION
Implement functionality to cast algebra types to different floating point precision. This will be helpful in testing where floating point errors come from in downstream projects.

Edit: Also applied a sonar cloud suggestion on member initialization in the fastor transform type