### PR TITLE
feat: approximately equal for algebra types

### DIFF
--- a/common/include/algebra/type_traits.hpp
+++ b/common/include/algebra/type_traits.hpp
@@ -35,6 +35,11 @@ struct value {};
 
 template <class M>
 using value_t = typename value<M>::type;
+
+template <typename T>
+requires(std::is_arithmetic_v<T>&& std::is_scalar_v<T>) struct value<T> {
+  using type = T;
+};
 /// @}
 
 /// Scalar type that is used with the matrix (can be multiple values in SoA)

--- a/math/fastor/include/algebra/math/impl/fastor_transform3.hpp
+++ b/math/fastor/include/algebra/math/impl/fastor_transform3.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 // Project include(s).
+#include "algebra/math/impl/fastor_matrix.hpp"
 #include "algebra/qualifiers.hpp"
 
 // Fastor include(s).
@@ -45,7 +46,7 @@ struct transform3 {
   using point2 = array_type<2>;
 
   /// 4x4 matrix type
-  using matrix44 = Fastor::Tensor<scalar_type, 4UL, 4UL>;
+  using matrix44 = fastor::Matrix<scalar_type, 4UL, 4UL>;
 
   /// @}
 

--- a/storage/array/include/algebra/storage/array.hpp
+++ b/storage/array/include/algebra/storage/array.hpp
@@ -22,6 +22,12 @@ namespace array {
 
 /// size type for Array storage model
 using size_type = std::size_t;
+/// Value type for Array storage model
+template <concepts::value T>
+using value_type = T;
+/// Scalar type for Array storage model
+template <concepts::value T>
+using scalar_type = T;
 /// Array type used in the Array storage model
 template <typename T, size_type N>
 using storage_type = std::array<T, N>;

--- a/storage/common/include/algebra/storage/matrix.hpp
+++ b/storage/common/include/algebra/storage/matrix.hpp
@@ -214,7 +214,7 @@ template <concepts::matrix matrix_t, concepts::scalar scalar_t,
           std::size_t... J>
 ALGEBRA_HOST_DEVICE constexpr matrix_t matrix_scalar_mul(
     scalar_t a, const matrix_t &rhs, std::index_sequence<J...>) noexcept {
-  using mat_scalar_t = algebra::traits::value_t<matrix_t>;
+  using mat_scalar_t = algebra::traits::scalar_t<matrix_t>;
 
   return matrix_t{(static_cast<mat_scalar_t>(a) * rhs[J])...};
 }

--- a/storage/common/include/algebra/storage/vector.hpp
+++ b/storage/common/include/algebra/storage/vector.hpp
@@ -164,10 +164,11 @@ class ALGEBRA_ALIGN(
   operator==(const vector &lhs, const vector &rhs) noexcept {
 
     const auto comp = lhs.compare(rhs);
-    bool is_full = false;
+    bool is_full = true;
 
+    ALGEBRA_UNROLL_N(N)
     for (unsigned int i{0u}; i < N; ++i) {
-      is_full |= comp[i];
+      is_full &= comp[i];
     }
 
     return is_full;
@@ -179,12 +180,12 @@ class ALGEBRA_ALIGN(
   operator==(const vector &lhs, const vector &rhs) noexcept {
 
     const auto comp = lhs.compare(rhs);
-    bool is_full = false;
+    bool is_full = true;
 
     ALGEBRA_UNROLL_N(N)
     for (unsigned int i{0u}; i < N; ++i) {
       // Ducktyping the Vc::Vector::MaskType
-      is_full |= comp[i].isFull();
+      is_full &= comp[i].isFull();
     }
 
     return is_full;

--- a/storage/eigen/include/algebra/storage/eigen.hpp
+++ b/storage/eigen/include/algebra/storage/eigen.hpp
@@ -22,6 +22,12 @@ namespace eigen {
 
 /// size type for Eigen storage model
 using size_type = int;
+/// Value type for Eigen storage model
+template <concepts::value T>
+using value_type = T;
+/// Scalar type for Eigen storage model
+template <concepts::value T>
+using scalar_type = T;
 /// Array type used in the Eigen storage model
 template <concepts::scalar T, size_type N>
 using storage_type = array<T, N>;

--- a/storage/fastor/include/algebra/storage/fastor.hpp
+++ b/storage/fastor/include/algebra/storage/fastor.hpp
@@ -22,6 +22,12 @@ namespace fastor {
 
 /// size type for Fastor storage model
 using size_type = std::size_t;
+/// Value type for Fastor storage model
+template <concepts::value T>
+using value_type = T;
+/// Scalar type for Fastor storage model
+template <concepts::value T>
+using scalar_type = T;
 /// Array type used in the Fastor storage model
 template <concepts::scalar T, size_type N>
 using storage_type = Fastor::Tensor<T, N>;

--- a/storage/smatrix/include/algebra/storage/smatrix.hpp
+++ b/storage/smatrix/include/algebra/storage/smatrix.hpp
@@ -25,6 +25,12 @@ namespace smatrix {
 
 /// size type for SMatrix storage model
 using size_type = unsigned int;
+/// Value type for SMatrix storage model
+template <concepts::value T>
+using value_type = T;
+/// Scalar type for SMatrix storage model
+template <concepts::value T>
+using scalar_type = T;
 /// Array type used in the SMatrix storage model
 template <concepts::scalar T, size_type N>
 using storage_type = ROOT::Math::SVector<T, N>;

--- a/storage/vc_aos/CMakeLists.txt
+++ b/storage/vc_aos/CMakeLists.txt
@@ -7,9 +7,13 @@
 # Set up the library.
 algebra_add_library( algebra_vc_aos_storage vc_aos_storage
    "include/algebra/storage/vc_aos.hpp"
+   "include/algebra/storage/impl/vc_aos_approximately_equal.hpp"
    "include/algebra/storage/impl/vc_aos_concepts.hpp"
    "include/algebra/storage/impl/vc_aos_getter.hpp" )
 target_link_libraries( algebra_vc_aos_storage
    INTERFACE algebra::common algebra::common_storage Vc::Vc algebra::common_math )
 algebra_test_public_headers( algebra_vc_aos_storage
-   "algebra/storage/vc_aos.hpp" )
+   "algebra/storage/vc_aos.hpp"
+   "algebra/storage/impl/vc_aos_approximately_equal.hpp"
+   "algebra/storage/impl/vc_aos_concepts.hpp"
+   "algebra/storage/impl/vc_aos_getter.hpp" )

--- a/storage/vc_aos/include/algebra/storage/impl/vc_aos_approximately_equal.hpp
+++ b/storage/vc_aos/include/algebra/storage/impl/vc_aos_approximately_equal.hpp
@@ -1,0 +1,73 @@
+/** Algebra plugins, part of the ACTS project
+ *
+ * (c) 2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s)
+#include "algebra/concepts.hpp"
+#include "algebra/qualifiers.hpp"
+
+// Vc include(s).
+#ifdef _MSC_VER
+#pragma warning(push, 0)
+#endif  // MSVC
+#include <Vc/Vc>
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif  // MSVC
+
+// System include(s)
+#include <concepts>
+#include <limits>
+
+namespace algebra {
+
+/// Elementwise compare two simd types according to a max relative error
+/// tolerance
+/// @see
+/// https://randomascii.wordpress.com/2012/02/25/comparing-floating-point-numbers-2012-edition/
+///
+/// @note This is by no means safe for all comparisons. Use with caution!
+///
+/// @param a first simd type
+/// @param b second simd type
+/// @param rel_error maximal relative error
+///
+/// @returns true if the two simd types are elementwise approximately equal
+template <typename simd1_t, typename simd2_t>
+requires((Vc::is_simd_vector<simd1_t>::value &&
+          std::convertible_to<simd2_t, simd1_t>) ||
+         (Vc::is_simd_vector<simd2_t>::value &&
+          std::convertible_to<simd1_t, simd2_t>)) ALGEBRA_HOST_DEVICE
+    constexpr auto approx_equal(
+        const simd1_t a, const simd2_t b,
+        const typename simd1_t::value_type rel_error =
+            16.f * std::numeric_limits<typename simd1_t::value_type>::epsilon(),
+        const typename simd1_t::value_type max_error =
+            std::numeric_limits<typename simd1_t::value_type>::epsilon()) {
+  static_assert(
+      std::same_as<typename simd1_t::value_type, typename simd2_t::value_type>);
+
+  if constexpr (std::integral<typename simd1_t::value_type>) {
+    return (a == b).isFull();
+  } else {
+    // Calculate the difference.
+    const simd1_t diff{Vc::abs(a - b)};
+
+    // If the numbers are is close to zero
+    if ((diff <= simd1_t(max_error)).isFull()) {
+      return true;
+    }
+
+    // Find the largest entries and scale the epsilon
+    const simd1_t largest = Vc::max(Vc::abs(a), Vc::abs(b));
+
+    return (diff <= (largest * rel_error)).isFull();
+  }
+}
+
+}  // namespace algebra

--- a/storage/vc_aos/include/algebra/storage/vc_aos.hpp
+++ b/storage/vc_aos/include/algebra/storage/vc_aos.hpp
@@ -9,6 +9,7 @@
 
 // Project include(s).
 #include "algebra/concepts.hpp"
+#include "algebra/storage/impl/vc_aos_approximately_equal.hpp"
 #include "algebra/storage/impl/vc_aos_concepts.hpp"
 #include "algebra/storage/impl/vc_aos_getter.hpp"
 #include "algebra/storage/matrix.hpp"
@@ -34,6 +35,12 @@ namespace vc_aos {
 
 /// Size type for Vc storage model
 using size_type = std::size_t;
+/// Value type for Vc storage model
+template <concepts::value T>
+using value_type = T;
+/// Scalar type for Vc storage model
+template <concepts::value T>
+using scalar_type = T;
 /// Array type used to store Vc::Vectors
 template <concepts::value T, size_type N>
 using storage_type = Vc::SimdArray<T, N>;

--- a/storage/vc_soa/include/algebra/storage/vc_soa.hpp
+++ b/storage/vc_soa/include/algebra/storage/vc_soa.hpp
@@ -9,6 +9,7 @@
 
 // Project include(s).
 #include "algebra/concepts.hpp"
+#include "algebra/storage/impl/vc_aos_approximately_equal.hpp"
 #include "algebra/storage/impl/vc_soa_getter.hpp"
 #include "algebra/storage/matrix.hpp"
 #include "algebra/storage/vector.hpp"
@@ -33,15 +34,15 @@ namespace vc_soa {
 
 /// Size type for Vc storage model
 using size_type = std::size_t;
-/// Array type used to store Vc::Vectors or matrix columns
-template <concepts::simd_scalar T, size_type N>
-using storage_type = std::array<T, N>;
 /// Value type in a linear algebra vector: SoA layout
 template <concepts::value T>
 using value_type = T;
 /// Scalar type in a linear algebra vector: SoA layout
 template <concepts::value T>
 using scalar_type = Vc::Vector<T>;
+/// Array type used to store Vc::Vectors or matrix columns
+template <concepts::simd_scalar T, size_type N>
+using storage_type = std::array<T, N>;
 /// Vector type used in the Vc SoA storage model
 template <concepts::value T, std::size_t N>
 using vector_type = algebra::storage::vector<N, Vc::Vector<T>, storage_type>;
@@ -92,6 +93,14 @@ template <concepts::value T, std::size_t N>
 struct scalar<
     algebra::storage::vector<N, Vc::Vector<T>, vc_soa::storage_type>> {
   using type = Vc::Vector<T>;
+};
+/// @}
+
+/// Get the single value type from the simd scalar type
+/// @{
+template <concepts::value T>
+struct value<Vc::Vector<T>> {
+  using type = T;
 };
 /// @}
 

--- a/storage/vecmem/include/algebra/storage/vecmem.hpp
+++ b/storage/vecmem/include/algebra/storage/vecmem.hpp
@@ -24,6 +24,12 @@ namespace vecmem {
 
 /// size type for VecMem storage model
 using size_type = std::size_t;
+/// Value type for VecMem storage model
+template <concepts::value T>
+using value_type = T;
+/// Scalar type for VecMem storage model
+template <concepts::value T>
+using scalar_type = T;
 /// Array type used in the VecMem storage model
 template <typename T, std::size_t N>
 using storage_type = ::vecmem::static_array<T, N>;

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -6,7 +6,9 @@
 
 # Set up the library.
 algebra_add_library( algebra_utils utils
+   "include/algebra/utils/approximately_equal.hpp"
    "include/algebra/utils/print.hpp" )
-target_link_libraries( algebra_utils INTERFACE algebra::common )
+target_link_libraries( algebra_utils INTERFACE algebra::common algebra_common_math )
 algebra_test_public_headers( algebra_utils
+   "algebra/utils/approximately_equal.hpp"
    "algebra/utils/print.hpp" )

--- a/utils/include/algebra/utils/approximately_equal.hpp
+++ b/utils/include/algebra/utils/approximately_equal.hpp
@@ -1,0 +1,197 @@
+/** Algebra plugins, part of the ACTS project
+ *
+ * (c) 2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s)
+#include "algebra/concepts.hpp"
+#include "algebra/math/common.hpp"
+#include "algebra/qualifiers.hpp"
+
+// System include(s)
+#include <concepts>
+#include <limits>
+
+namespace algebra {
+
+/// Compare two scalars according to a max relative error tolerance
+/// @see
+/// https://randomascii.wordpress.com/2012/02/25/comparing-floating-point-numbers-2012-edition/
+///
+/// @note This is by no means safe for all comparisons. Use with caution!
+///
+/// @param a first value
+/// @param b second value
+/// @param rel_error maximal relative error
+///
+/// @returns true if the two values are approximaterly equal
+template <concepts::scalar scalar_t, concepts::value value_t>
+requires std::convertible_to<scalar_t, value_t>
+    ALGEBRA_HOST_DEVICE constexpr auto approx_equal(
+        const scalar_t a, const scalar_t b,
+        const value_t rel_error = 16.f *
+                                  std::numeric_limits<value_t>::epsilon(),
+        const value_t max_error = std::numeric_limits<value_t>::epsilon()) {
+
+  if constexpr (std::integral<scalar_t>) {
+    return a == b;
+  } else {
+    // Calculate the difference.
+    const scalar_t diff{math::fabs(a - b)};
+
+    // If the numbers are is close to zero
+    if (diff <= max_error) {
+      return true;
+    }
+
+    // Find the largest value to scale the epsilon
+    const scalar_t largest = math::max(math::fabs(a), math::fabs(b));
+
+    return (diff <= largest * rel_error);
+  }
+}
+
+/// Elementwise compare two vectors according to a max relative error tolerance
+///
+/// @note This is by no means safe for all comparisons. Use with caution!
+///
+/// @param v1 first vector
+/// @param v2 second vector
+/// @param rel_error maximal relative error
+///
+/// @returns true if the two vectors are approximaterly equal
+template <typename vector1_t, typename vector2_t>
+requires((concepts::vector<vector1_t> || concepts::point<vector1_t>)&&(
+             concepts::vector<vector2_t> ||
+             concepts::point<vector2_t>)&&!concepts::simd_scalar<vector1_t> &&
+         !concepts::simd_scalar<vector2_t>) ALGEBRA_HOST_DEVICE
+    constexpr auto approx_equal(
+        const vector1_t& v1, const vector2_t& v2,
+        const algebra::traits::value_t<vector1_t> rel_error =
+            16.f *
+            std::numeric_limits<algebra::traits::value_t<vector1_t>>::epsilon(),
+        const algebra::traits::value_t<vector1_t> max_error = std::
+            numeric_limits<algebra::traits::value_t<vector1_t>>::epsilon()) {
+
+  static_assert(std::same_as<algebra::traits::value_t<vector1_t>,
+                             algebra::traits::value_t<vector2_t>>);
+
+  using index_t = algebra::traits::index_t<vector1_t>;
+
+  constexpr index_t size{algebra::traits::size<vector1_t>};
+
+  bool ret{true};
+  for (index_t i = 0; i < size; ++i) {
+    ret &= ::algebra::approx_equal(v1[i], v2[i], rel_error, max_error);
+  }
+
+  return ret;
+}
+
+/// Elementwise compare two column matrices according to a max relative error
+/// tolerance
+///
+/// @note This is by no means safe for all comparisons. Use with caution!
+///
+/// @param v1 first column matrix
+/// @param v2 second column matrix
+/// @param rel_error maximal relative error
+///
+/// @returns true if the two column matrices are approximaterly equal
+template <concepts::column_matrix vector1_t, concepts::column_matrix vector2_t>
+ALGEBRA_HOST_DEVICE constexpr auto approx_equal(
+    const vector1_t& v1, const vector2_t& v2,
+    const algebra::traits::value_t<vector1_t> rel_error =
+        16.f *
+        std::numeric_limits<algebra::traits::value_t<vector1_t>>::epsilon(),
+    const algebra::traits::value_t<vector1_t> max_error =
+        std::numeric_limits<algebra::traits::value_t<vector1_t>>::epsilon()) {
+
+  static_assert(std::same_as<algebra::traits::value_t<vector1_t>,
+                             algebra::traits::value_t<vector2_t>>);
+
+  using index_t = algebra::traits::index_t<vector1_t>;
+  using element_getter_t = algebra::traits::element_getter_t<vector1_t>;
+
+  constexpr index_t rows{algebra::traits::rows<vector1_t>};
+
+  bool ret{true};
+  for (index_t i = 0; i < rows; ++i) {
+    ret &= ::algebra::approx_equal(element_getter_t{}(v1, i, 0),
+                                   element_getter_t{}(v2, i, 0), rel_error,
+                                   max_error);
+  }
+
+  return ret;
+}
+
+/// Elementwise compare two matrices according to a max relative error tolerance
+///
+/// @note This is by no means safe for all comparisons. Use with caution!
+///
+/// @param m1 first matrix
+/// @param m2 second matrix
+/// @param rel_error maximal relative error
+///
+/// @returns true if the two matrices are approximaterly equal
+template <concepts::matrix matrix1_t, concepts::matrix matrix2_t>
+ALGEBRA_HOST_DEVICE constexpr auto approx_equal(
+    const matrix1_t& m1, const matrix2_t& m2,
+    const algebra::traits::value_t<matrix1_t> rel_error =
+        16.f *
+        std::numeric_limits<algebra::traits::value_t<matrix1_t>>::epsilon(),
+    const algebra::traits::value_t<matrix1_t> max_error =
+        std::numeric_limits<algebra::traits::value_t<matrix1_t>>::epsilon()) {
+
+  static_assert(std::same_as<algebra::traits::value_t<matrix1_t>,
+                             algebra::traits::value_t<matrix2_t>>);
+
+  using index_t = algebra::traits::index_t<matrix1_t>;
+  using element_getter_t = algebra::traits::element_getter_t<matrix1_t>;
+
+  constexpr index_t rows{algebra::traits::rows<matrix1_t>};
+  constexpr index_t columns{algebra::traits::columns<matrix1_t>};
+
+  bool ret{true};
+  for (index_t j = 0; j < columns; ++j) {
+    for (index_t i = 0; i < rows; ++i) {
+      ret &= ::algebra::approx_equal(element_getter_t{}(m1, i, j),
+                                     element_getter_t{}(m2, i, j), rel_error,
+                                     max_error);
+    }
+  }
+
+  return ret;
+}
+
+/// Elementwise compare two transforms according to a max relative error
+/// tolerance
+///
+/// @note This is by no means safe for all comparisons. Use with caution!
+///
+/// @param trf1 first transform
+/// @param trf2 second transform
+/// @param rel_error maximal relative error
+///
+/// @returns true if the two transforms are approximaterly equal
+template <concepts::transform3D transform_t>
+ALGEBRA_HOST_DEVICE constexpr auto approx_equal(
+    const transform_t& trf1, const transform_t& trf2,
+    const algebra::traits::value_t<typename transform_t::scalar_type>
+        rel_error = 16.f * std::numeric_limits<algebra::traits::value_t<
+                               typename transform_t::scalar_type>>::epsilon(),
+    const algebra::traits::value_t<typename transform_t::scalar_type>
+        max_error = std::numeric_limits<algebra::traits::value_t<
+            typename transform_t::scalar_type>>::epsilon()) {
+
+  return (::algebra::approx_equal(trf1.matrix(), trf2.matrix(), rel_error,
+                                  max_error) &&
+          ::algebra::approx_equal(trf1.matrix_inverse(), trf2.matrix_inverse(),
+                                  rel_error, max_error));
+}
+
+}  // namespace algebra


### PR DESCRIPTION
 Implements an approximate equals function that works on algebra types. It is not foolproof for the comparison of any floating point numbers, so the google test version should be used in any actual tests.

Also adds a few missing typedefs to the algebras and fixes the `mat_scalar_t` type in the storage matrix and the comparison of the storage vector types, which came up during writing the tests for this PR