### PR TITLE
ref: Move hip runtime for assertion into dedicated header

### DIFF
--- a/common/include/algebra/assert.hpp
+++ b/common/include/algebra/assert.hpp
@@ -1,0 +1,15 @@
+/**
+ * ALGEBRA PLUGIN library, part of the ACTS project (R&D line)
+ *
+ * (c) 2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include <cassert>
+
+#if defined(__HIP__)
+#include <hip/hip_runtime.h>
+#endif

--- a/storage/cmath/include/algebra/storage/impl/cmath_getter.hpp
+++ b/storage/cmath/include/algebra/storage/impl/cmath_getter.hpp
@@ -8,18 +8,14 @@
 #pragma once
 
 // Project include(s).
+#include "algebra/assert.hpp"
 #include "algebra/concepts.hpp"
 #include "algebra/math/common.hpp"
 #include "algebra/qualifiers.hpp"
 
 // System include(s).
-#include <cassert>
 #include <cstddef>
 #include <type_traits>
-
-#if defined(__HIP__)
-#include <hip/hip_runtime.h>
-#endif
 
 namespace algebra::cmath::storage {
 


### PR DESCRIPTION
Move the HIP runtime  that is needed in one place for the assertion into a dedicated header to make it reusable